### PR TITLE
feat: optimize memory search retrieval caches

### DIFF
--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -1,10 +1,11 @@
 import argparse
 import asyncio
 import json
+import re
 import sys
 import time
 import uuid
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 
 CHAT_COMMAND_HELP = (
@@ -14,6 +15,8 @@ CHAT_COMMAND_HELP = (
     "  /exit     leave the session\n"
     "  /quit     leave the session"
 )
+
+TOOL_NAME_TAG_PATTERN = re.compile(r"<tool_name>\s*([A-Za-z0-9_.-]+)\s*</tool_name>")
 
 
 def _truncate(value: Optional[str], max_len: int) -> str:
@@ -150,15 +153,9 @@ def _print_plain_event(event: Dict[str, Any]) -> None:
         sys.stdout.flush()
         return
 
-    tool_calls = event.get("tool_calls") or []
-    if tool_calls:
-        names = []
-        for tool_call in tool_calls:
-            function = tool_call.get("function", {}) if isinstance(tool_call, dict) else {}
-            name = function.get("name")
-            if name:
-                names.append(name)
-        if names:
+    names = _collect_event_tool_names(event)
+    if names:
+        if event.get("tool_calls"):
             sys.stderr.write(f"\n[tool] {', '.join(names)}\n")
             sys.stderr.flush()
 
@@ -190,7 +187,39 @@ def _empty_stats(*, request, workspace: Optional[str]) -> Dict[str, Any]:
         "completion_tokens": None,
         "total_tokens": None,
         "per_step_info": [],
+        "_tool_tag_buffer": "",
     }
+
+
+def _collect_event_tool_names(event: Dict[str, Any], *, content_buffer: str = "") -> List[str]:
+    tool_names: List[str] = []
+
+    tool_calls = event.get("tool_calls") or []
+    for tool_call in tool_calls:
+        function = tool_call.get("function", {}) if isinstance(tool_call, dict) else {}
+        name = function.get("name")
+        if name:
+            tool_names.append(name)
+
+    metadata = event.get("metadata") or {}
+    metadata_tool_name = metadata.get("tool_name")
+    if isinstance(metadata_tool_name, str) and metadata_tool_name:
+        tool_names.append(metadata_tool_name)
+
+    event_tool_name = event.get("tool_name")
+    if isinstance(event_tool_name, str) and event_tool_name:
+        tool_names.append(event_tool_name)
+
+    combined_content = content_buffer
+    content = event.get("content")
+    if isinstance(content, str) and content:
+        combined_content += content
+    if combined_content:
+        for match in TOOL_NAME_TAG_PATTERN.findall(combined_content):
+            if match:
+                tool_names.append(match.strip())
+
+    return sorted(set(tool_names))
 
 
 def _record_stats_event(stats: Dict[str, Any], event: Dict[str, Any], start_time: float) -> None:
@@ -202,17 +231,15 @@ def _record_stats_event(stats: Dict[str, Any], event: Dict[str, Any], start_time
     content = event.get("content")
     if isinstance(content, str) and content:
         has_visible_output = True
+        buffer = (stats.get("_tool_tag_buffer") or "") + content
+        stats["_tool_tag_buffer"] = buffer[-2048:]
 
-    tool_calls = event.get("tool_calls") or []
-    if tool_calls:
+    tool_names = _collect_event_tool_names(event, content_buffer=stats.get("_tool_tag_buffer") or "")
+    if tool_names:
         has_visible_output = True
-        tool_names = set(stats["tools"])
-        for tool_call in tool_calls:
-            function = tool_call.get("function", {}) if isinstance(tool_call, dict) else {}
-            name = function.get("name")
-            if name:
-                tool_names.add(name)
-        stats["tools"] = sorted(tool_names)
+        existing_tool_names = set(stats["tools"])
+        existing_tool_names.update(tool_names)
+        stats["tools"] = sorted(existing_tool_names)
 
     if event.get("type") == "error":
         has_visible_output = True

--- a/sagents/context/session_memory/session_memory_manager.py
+++ b/sagents/context/session_memory/session_memory_manager.py
@@ -3,8 +3,10 @@
 
 负责使用 BM25 算法对历史消息进行检索和召回
 """
+import hashlib
+import json
 import re
-from typing import List
+from typing import List, Optional, Tuple
 
 from sagents.context.messages.message import MessageChunk
 from sagents.context.messages.context_budget import ContextBudgetManager
@@ -17,7 +19,10 @@ class SessionMemoryManager:
     """历史消息检索器"""
     
     def __init__(self):
-        pass
+        self._message_bm25_cache_key: Optional[str] = None
+        self._message_bm25_cache: Optional[Tuple[BM25Okapi, List[List[str]]]] = None
+        self._chat_bm25_cache_key: Optional[str] = None
+        self._chat_bm25_cache: Optional[Tuple[BM25Okapi, List[List[str]], List[List[MessageChunk]]]] = None
     
     def _tokenize_text(self, text: str) -> List[str]:
         """文本分词（用于BM25，私有辅助方法）"""
@@ -48,6 +53,63 @@ class SessionMemoryManager:
     def _calculate_messages_tokens(self, messages: List[MessageChunk]) -> int:
         """计算多条消息的总token数（私有辅助方法）"""
         return sum(self._calculate_message_tokens(msg) for msg in messages)
+
+    @staticmethod
+    def _serialize_content(content) -> str:
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        return json.dumps(content, ensure_ascii=False, sort_keys=True, default=str)
+
+    def _fingerprint_messages(self, messages: List[MessageChunk]) -> str:
+        digests: List[str] = []
+        for msg in messages:
+            content = self._serialize_content(msg.get_content())
+            content_hash = hashlib.md5(content.encode("utf-8")).hexdigest()
+            normalized_type = msg.normalized_message_type() if hasattr(msg, "normalized_message_type") else None
+            digests.append(
+                f"{msg.message_id}|{msg.role}|{normalized_type or ''}|{content_hash}"
+            )
+        return hashlib.md5("\n".join(digests).encode("utf-8")).hexdigest()
+
+    def _get_or_build_message_bm25(self, messages: List[MessageChunk]) -> Optional[BM25Okapi]:
+        cache_key = self._fingerprint_messages(messages)
+        if self._message_bm25_cache_key == cache_key and self._message_bm25_cache:
+            return self._message_bm25_cache[0]
+
+        corpus = [self._tokenize_text(msg.get_content()) for msg in messages]
+        if not corpus:
+            return None
+
+        bm25 = BM25Okapi(corpus)
+        self._message_bm25_cache_key = cache_key
+        self._message_bm25_cache = (bm25, corpus)
+        return bm25
+
+    def _get_or_build_chat_bm25(self, messages: List[MessageChunk]) -> Tuple[Optional[BM25Okapi], List[List[MessageChunk]]]:
+        cache_key = self._fingerprint_messages(messages)
+        if self._chat_bm25_cache_key == cache_key and self._chat_bm25_cache:
+            return self._chat_bm25_cache[0], self._chat_bm25_cache[2]
+
+        chat_list = self._group_messages_by_chat(messages)
+        if not chat_list:
+            return None, []
+
+        corpus = []
+        for chat in chat_list:
+            combined_content = ""
+            for msg in chat:
+                combined_content += f" {msg.get_content()}"
+            corpus.append(self._tokenize_text(combined_content.strip()))
+
+        if not corpus:
+            return None, chat_list
+
+        bm25 = BM25Okapi(corpus)
+        self._chat_bm25_cache_key = cache_key
+        self._chat_bm25_cache = (bm25, corpus, chat_list)
+        return bm25, chat_list
 
     def _group_messages_by_chat(self, messages: List[MessageChunk]) -> List[List[MessageChunk]]:
         """按对话轮次分组消息"""
@@ -83,26 +145,10 @@ class SessionMemoryManager:
          
         try:
             # 按对话轮次分组
-            chat_list = self._group_messages_by_chat(messages)
-             
-            if not chat_list:
+            bm25, chat_list = self._get_or_build_chat_bm25(messages)
+            if not bm25 or not chat_list:
                 return messages
-             
-            # 构建BM25语料库（每轮对话作为一个文档）
-            corpus = []
-            for chat in chat_list:
-                # 合并一轮对话中所有消息的内容
-                combined_content = ""
-                for msg in chat:
-                    content = msg.get_content()
-                    combined_content += f" {content}"
-                corpus.append(self._tokenize_text(combined_content.strip()))
-             
-            if not corpus:
-                return messages
-             
-            # BM25重排序
-            bm25 = BM25Okapi(corpus)
+
             query_tokens = self._tokenize_text(query)
             scores = bm25.get_scores(query_tokens)
              
@@ -154,17 +200,10 @@ class SessionMemoryManager:
             return messages
         
         try:
-            # 构建BM25语料库
-            corpus = []
-            for msg in messages:
-                content = msg.get_content()
-                corpus.append(self._tokenize_text(content))
-            
-            if not corpus:
+            bm25 = self._get_or_build_message_bm25(messages)
+            if not bm25:
                 return messages
-            
-            # BM25重排序
-            bm25 = BM25Okapi(corpus)
+
             query_tokens = self._tokenize_text(query)
             scores = bm25.get_scores(query_tokens)
             
@@ -203,4 +242,3 @@ class SessionMemoryManager:
         except Exception as e:
             logger.error(f"HistoryMessageRetriever: 历史消息召回失败: {e}")
             return messages
-

--- a/sagents/tool/impl/memory_tool.py
+++ b/sagents/tool/impl/memory_tool.py
@@ -3,12 +3,214 @@
 Memory tool based on BM25 file system - Sandbox version
 Get workspace through session_id, build file index and support search
 """
+import hashlib
+import json
 import os
 import re
+import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Any, Optional, List
 from ..tool_base import tool
 from sagents.utils.logger import logger
+
+
+@dataclass
+class _FileIndexCacheEntry:
+    index: Any
+    last_refresh_at: float = 0.0
+
+
+@dataclass
+class _SessionHistoryCacheEntry:
+    messages_fingerprint: str
+    agent_config_fingerprint: str
+    history_messages: List[Any]
+
+
+class FileMemoryRetriever:
+    """文件级长期记忆检索。
+
+    作用域按 user + agent + workspace 区分，避免不同工作区/Agent 串用索引。
+    """
+
+    INDEX_REFRESH_INTERVAL_SECONDS = 10.0
+    _index_cache: Dict[str, _FileIndexCacheEntry] = {}
+
+    def __init__(self, memory_tool: "MemoryTool"):
+        self.memory_tool = memory_tool
+
+    @staticmethod
+    def _build_scope_key(user_id: str, agent_id: str, workspace_path: str) -> str:
+        scope = f"{user_id}|{agent_id}|{workspace_path}"
+        return hashlib.md5(scope.encode("utf-8")).hexdigest()
+
+    async def search(self, query: str, top_k: int, session_context) -> List[Dict[str, Any]]:
+        try:
+            sandbox = session_context.sandbox
+            if not sandbox:
+                logger.warning("MemoryTool: No sandbox available for file memory search")
+                return []
+
+            workspace_path = getattr(session_context, "sandbox_agent_workspace", None) or "/sage-workspace"
+            agent_id = getattr(session_context, "agent_id", None)
+            user_id = getattr(session_context, "user_id", None) or "default_user"
+
+            if not agent_id:
+                logger.warning("MemoryTool: Cannot get agent_id for file memory search")
+                return []
+
+            from .memory_index import MemoryIndex
+
+            scope_key = self._build_scope_key(user_id, agent_id, workspace_path)
+            index_path = self.memory_tool._get_index_path(
+                user_id=user_id,
+                agent_id=agent_id,
+                workspace_path=workspace_path,
+            )
+            cache_entry = self._index_cache.get(scope_key)
+
+            if not cache_entry:
+                cache_entry = _FileIndexCacheEntry(
+                    index=MemoryIndex(sandbox, workspace_path, index_path)
+                )
+                self._index_cache[scope_key] = cache_entry
+            else:
+                # 同作用域下复用 MemoryIndex，但每次绑定当前 session 的 sandbox 引用。
+                cache_entry.index.sandbox = sandbox
+                cache_entry.index.workspace_path = workspace_path.rstrip("/")
+
+            now = time.time()
+            should_refresh = (
+                cache_entry.index.bm25 is None
+                or (now - cache_entry.last_refresh_at) >= self.INDEX_REFRESH_INTERVAL_SECONDS
+            )
+            if should_refresh:
+                stats = await cache_entry.index.update_index()
+                cache_entry.last_refresh_at = now
+                logger.info(f"MemoryTool: File memory index update stats: {stats}")
+
+            results = cache_entry.index.search(query, top_k)
+
+            formatted_results = []
+            for result in results:
+                snippets = []
+                if result.content:
+                    snippet_matches = re.findall(r'\[Line (\d+)\] (.*?)(?=\n\n|\Z)', result.content, re.DOTALL)
+                    for line_num, snippet_text in snippet_matches:
+                        snippets.append({
+                            "line_number": int(line_num),
+                            "text": snippet_text.strip()
+                        })
+
+                formatted_results.append({
+                    "path": result.path,
+                    "snippets": snippets,
+                })
+
+            return formatted_results
+
+        except Exception as e:
+            logger.error(f"MemoryTool: File memory search failed: {e}")
+            return []
+
+
+class SessionHistoryRetriever:
+    """会话级历史记忆检索。
+
+    保持当前 history_messages 的语义边界不变，只优化 prepare/BM25 的重复开销。
+    """
+
+    _history_cache: Dict[str, _SessionHistoryCacheEntry] = {}
+
+    def __init__(self, memory_tool: "MemoryTool"):
+        self.memory_tool = memory_tool
+
+    @staticmethod
+    def _serialize_message_content(content: Any) -> str:
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        return json.dumps(content, ensure_ascii=False, sort_keys=True, default=str)
+
+    def _fingerprint_messages(self, messages: List[Any]) -> str:
+        digests: List[str] = []
+        for msg in messages:
+            content = self._serialize_message_content(msg.get_content())
+            content_hash = hashlib.md5(content.encode("utf-8")).hexdigest()
+            normalized_type = msg.normalized_message_type() if hasattr(msg, "normalized_message_type") else None
+            digests.append(
+                f"{msg.message_id}|{msg.role}|{normalized_type or ''}|{content_hash}"
+            )
+        return hashlib.md5("\n".join(digests).encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _fingerprint_agent_config(agent_config: Dict[str, Any]) -> str:
+        try:
+            serialized = json.dumps(agent_config or {}, ensure_ascii=False, sort_keys=True, default=str)
+        except Exception:
+            serialized = str(agent_config or {})
+        return hashlib.md5(serialized.encode("utf-8")).hexdigest()
+
+    def _get_history_messages(self, session_id: str, session_context) -> List[Any]:
+        message_manager = session_context.message_manager
+        agent_config = getattr(session_context, "agent_config", {}) or {}
+
+        messages_fingerprint = self._fingerprint_messages(message_manager.messages)
+        agent_config_fingerprint = self._fingerprint_agent_config(agent_config)
+
+        cache_entry = self._history_cache.get(session_id)
+        if (
+            cache_entry
+            and cache_entry.messages_fingerprint == messages_fingerprint
+            and cache_entry.agent_config_fingerprint == agent_config_fingerprint
+        ):
+            return cache_entry.history_messages
+
+        prepare_result = message_manager.prepare_history_split(agent_config)
+        history_messages = prepare_result["split_result"]["history_messages"]
+        self._history_cache[session_id] = _SessionHistoryCacheEntry(
+            messages_fingerprint=messages_fingerprint,
+            agent_config_fingerprint=agent_config_fingerprint,
+            history_messages=history_messages,
+        )
+        return history_messages
+
+    def search(self, query: str, top_k: int, session_id: str, session_context) -> List[Dict[str, Any]]:
+        try:
+            history_messages = self._get_history_messages(session_id, session_context)
+            if not history_messages:
+                logger.debug("MemoryTool: No history messages to search")
+                return []
+
+            session_memory_manager = session_context.session_memory_manager
+            retrieved_messages = session_memory_manager.retrieve_history_messages(
+                messages=history_messages,
+                query=query,
+                history_budget=top_k * 200
+            )
+            retrieved_messages = retrieved_messages[:top_k]
+
+            logger.info(f"MemoryTool: Retrieved {len(retrieved_messages)} history messages for query '{query}'")
+
+            formatted_results = []
+            for msg in retrieved_messages:
+                content = msg.content or ""
+                snippet = self.memory_tool._extract_history_snippet(content, query.lower().split())
+                formatted_results.append({
+                    "role": msg.role,
+                    "content_preview": snippet,
+                    "timestamp": getattr(msg, 'timestamp', None)
+                })
+
+            return formatted_results
+
+        except Exception as e:
+            logger.error(f"MemoryTool: Session history search failed: {e}")
+            import traceback
+            logger.error(traceback.format_exc())
+            return []
 
 
 class MemoryTool:
@@ -21,6 +223,10 @@ class MemoryTool:
     3. Search session history messages
     4. Use file extension whitelist and directory blacklist managed by MemoryIndex
     """
+
+    def __init__(self):
+        self.file_memory_retriever = FileMemoryRetriever(self)
+        self.session_history_retriever = SessionHistoryRetriever(self)
 
     def _get_sandbox(self, session_id: str):
         """通过 session_id 获取沙箱"""
@@ -84,11 +290,10 @@ class MemoryTool:
             logger.error(f"MemoryTool: Get agent_id failed: {e}")
             return None
 
-    def _get_index_path(self, agent_id: str) -> str:
-        """Get index file path for agent (stored on host)
-        
-        Args:
-            agent_id: Agent ID (not session_id)
+    def _get_index_path(self, user_id: str, agent_id: str, workspace_path: str) -> str:
+        """Get scoped index file path (stored on host).
+
+        文件长期记忆按 user + agent + workspace 隔离，避免不同作用域复用同一个磁盘索引。
         """
         # Get MEMORY_ROOT_PATH from environment variable
         memory_root = os.environ.get('MEMORY_ROOT_PATH')
@@ -100,8 +305,11 @@ class MemoryTool:
         # Create memory directory
         memory_dir = Path(memory_root)
         memory_dir.mkdir(parents=True, exist_ok=True)
-        
-        index_path = memory_dir / f"{agent_id}.pkl"
+
+        workspace_hash = hashlib.md5(workspace_path.encode("utf-8")).hexdigest()[:12]
+        safe_user_id = re.sub(r"[^A-Za-z0-9._-]+", "_", user_id or "default_user")
+        safe_agent_id = re.sub(r"[^A-Za-z0-9._-]+", "_", agent_id or "default_agent")
+        index_path = memory_dir / f"{safe_user_id}__{safe_agent_id}__{workspace_hash}.pkl"
         logger.debug(f"MemoryTool: Index path: {index_path}")
         
         return str(index_path)
@@ -184,55 +392,18 @@ class MemoryTool:
             }
 
     async def _search_file_memory(self, query: str, top_k: int, session_id: str) -> List[Dict[str, Any]]:
-        """Search file memory using BM25 index through sandbox"""
+        """Search file memory using cached BM25 index through sandbox"""
         try:
-            # Get sandbox and workspace path
-            sandbox = self._get_sandbox(session_id)
-            workspace_path = self._get_workspace_path(session_id)
-            if not workspace_path:
-                logger.warning(f"MemoryTool: Cannot get workspace path for session {session_id}")
+            from sagents.session_runtime import get_global_session_manager
+
+            session_manager = get_global_session_manager()
+            session = session_manager.get(session_id)
+            if not session or not session.session_context:
+                logger.warning(f"MemoryTool: Session not found for file memory search: {session_id}")
                 return []
-            
-            # Get agent_id and index path (stored on host, keyed by agent_id)
-            agent_id = self._get_agent_id(session_id)
-            if not agent_id:
-                logger.warning(f"MemoryTool: Cannot get agent_id for session {session_id}")
-                return []
-            
-            index_path = self._get_index_path(agent_id)
-            
-            # Load/build index
-            from .memory_index import MemoryIndex
-            index = MemoryIndex(sandbox, workspace_path, index_path)
-            
-            # Auto update index (fast check if no changes)
-            stats = await index.update_index()
-            logger.info(f"MemoryTool: Index update stats: {stats}")
-            
-            # Search
-            results = index.search(query, top_k)
-            
-            # Format results with snippets
-            formatted_results = []
-            for r in results:
-                # Extract snippets from the content preview
-                snippets = []
-                if r.content:
-                    # Split by line number markers
-                    snippet_matches = re.findall(r'\[Line (\d+)\] (.*?)(?=\n\n|\Z)', r.content, re.DOTALL)
-                    for line_num, snippet_text in snippet_matches:
-                        snippets.append({
-                            "line_number": int(line_num),
-                            "text": snippet_text.strip()
-                        })
-                
-                formatted_results.append({
-                    "path": r.path,
-                    "snippets": snippets,
-                })
-            
-            return formatted_results
-            
+
+            return await self.file_memory_retriever.search(query, top_k, session.session_context)
+
         except Exception as e:
             logger.error(f"MemoryTool: File memory search failed: {e}")
             return []
@@ -254,48 +425,8 @@ class MemoryTool:
                 return []
             
             session_context = session.session_context
-            message_manager = session_context.message_manager
-            session_memory_manager = session_context.session_memory_manager
-            
-            # 1. 准备历史上下文（计算预算、切分消息）
-            agent_config = getattr(session_context, 'agent_config', {})
-            prepare_result = message_manager.prepare_history_split(agent_config)
-            
-            # 2. 获取历史消息（排除最近的消息）
-            history_messages = prepare_result['split_result']['history_messages']
-            
-            if not history_messages:
-                logger.debug("MemoryTool: No history messages to search")
-                return []
-            
-            # 3. 使用 session_memory_manager 进行 BM25 检索
-            retrieved_messages = session_memory_manager.retrieve_history_messages(
-                messages=history_messages,
-                query=query,
-                history_budget=top_k * 200  # 估算每个消息约500字符
-            )
-            
-            # 4. 限制返回数量
-            retrieved_messages = retrieved_messages[:top_k]
-            
-            logger.info(f"MemoryTool: Retrieved {len(retrieved_messages)} history messages for query '{query}'")
-            
-            # 5. 格式化结果
-            formatted_results = []
-            for msg in retrieved_messages:
-                content = msg.content or ""
-                
-                # 提取包含查询词的片段
-                snippet = self._extract_history_snippet(content, query.lower().split())
-                
-                formatted_results.append({
-                    "role": msg.role,
-                    "content_preview": snippet,
-                    "timestamp": getattr(msg, 'timestamp', None)
-                })
-            
-            return formatted_results
-            
+            return self.session_history_retriever.search(query, top_k, session_id, session_context)
+
         except Exception as e:
             logger.error(f"MemoryTool: Session history search failed: {e}")
             import traceback


### PR DESCRIPTION
## Summary
  - separate file memory and session history retrieval responsibilities under the shared `search_memory` entrypoint
  - cache file memory indexes by `user + agent + workspace`
  - scope file index paths by `user + agent + workspace` to avoid cross-scope reuse
  - cache session-history BM25 structures by message fingerprint instead of rebuilding on every query
  - keep session history retrieval semantics unchanged
  - improve CLI stats so tool usage from memory retrieval is visible during validation

  ## Background
  Memory search was slow mainly because both file memory and session history were still doing repeated heavy work on the query path.

  The key issue was not that file memory and session history were one merged index. The issue was that the shared `search_memory` flow was driving
  two different retrieval paths, and both paths were doing too much work at query time.

  This PR handles the first phase only:
  - do not change retrieval semantics
  - do not change session history scope
  - reduce repeated rebuild/update work
  - make the two retrieval paths more explicit

  ## Design
  The public `search_memory` interface remains unified.

  Internally, retrieval is now split into:
  - `FileMemoryRetriever`
  - `SessionHistoryRetriever`

  This keeps file memory and session history on separate implementation tracks while preserving the current external behavior.

  ### File memory
  File memory now:
  - builds cache keys using `user + agent + workspace`
  - reuses `MemoryIndex` instances in memory
  - avoids refreshing the index on every query
  - scopes on-disk index paths by the same effective retrieval scope

  ### Session history
  Session history now:
  - keeps using the current `history_messages` range
  - does not change recall semantics
  - reuses BM25 indexes based on message fingerprints
  - avoids rebuilding BM25 structures on every query

  ## What Changed

  ### 1. Explicit retriever split
  In `sagents/tool/impl/memory_tool.py`, the shared memory tool flow now explicitly separates:
  - file memory retrieval
  - session history retrieval

  This is an implementation split only. It does not change the external tool interface.

  ### 2. File memory caching and scope isolation
  File memory now caches retrieval indexes by:
  - user id
  - agent id
  - workspace path

  This reduces repeated refresh/build work across repeated queries in the same scope.

  The disk-backed index path is also now derived from the same scope so indexes do not get reused across different users or workspaces by accident.

  ### 3. Session history BM25 caching
  In `sagents/context/session_memory/session_memory_manager.py`:
  - message-level BM25 structures are cached
  - grouped-chat BM25 structures are cached
  - cache keys are based on fingerprints of the current message set

  This keeps the current retrieval range intact while removing repeated rebuild overhead.

  ### 4. CLI stats visibility for validation
  During validation, memory tool usage was not always visible in `--stats` because some tool executions were surfaced through streamed content
  instead of standard `tool_calls` fields.

  The CLI stats collector was improved so memory validation runs can now correctly show:
  - `tools: search_memory`

  This makes it easier to validate memory behavior from the CLI.

  ## Scope Guarantees
  This PR intentionally does **not** do the following:
  - no file chunking yet
  - no SQLite FTS5 or hybrid file index yet
  - no session-history scope change
  - no runtime/bootstrap refactor

  This is the P0 phase only.

  ## Validation

  ### Code-level checks
  - `python -m py_compile sagents/tool/impl/memory_tool.py sagents/context/session_memory/session_memory_manager.py`
  - `python -m py_compile app/cli/main.py`

  ### Session history validation
  Using CLI chat/resume:
  - asked the agent to remember a unique phrase
  - verified recall in the same chat session
  - verified recall again after `sage resume`

  ### File memory validation
  Using CLI run with explicit `search_memory` constraint:
  - verified retrieval against a unique workspace test keyword
  - verified `tools: search_memory` appears in CLI stats
  - confirmed file memory results are returned through the tool path rather than falling back to shell-style reasoning

  ## Notes
  This PR is intentionally scoped to memory-search P0:
  - split responsibilities
  - add cache reuse
  - preserve semantics
  - improve observability for validation

  Chunked file retrieval and later file-index upgrades should land in follow-up work.