### PR TITLE
feat: chunk file memory retrieval results

### DIFF
--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -17,6 +17,8 @@ CHAT_COMMAND_HELP = (
 )
 
 TOOL_NAME_TAG_PATTERN = re.compile(r"<tool_name>\s*([A-Za-z0-9_.-]+)\s*</tool_name>")
+TOOL_CALL_FUNCTION_PATTERN = re.compile(r"<call\s+function=\"([A-Za-z0-9_.-]+)\"")
+TOOL_RESULT_NAME_PATTERN = re.compile(r"<function_result\s+name=\"([A-Za-z0-9_.-]+)\"")
 
 
 def _truncate(value: Optional[str], max_len: int) -> str:
@@ -220,6 +222,12 @@ def _collect_event_tool_names(event: Dict[str, Any], *, content_buffer: str = ""
         combined_content += content
     if combined_content:
         for match in TOOL_NAME_TAG_PATTERN.findall(combined_content):
+            if match:
+                tool_names.append(match.strip())
+        for match in TOOL_CALL_FUNCTION_PATTERN.findall(combined_content):
+            if match:
+                tool_names.append(match.strip())
+        for match in TOOL_RESULT_NAME_PATTERN.findall(combined_content):
             if match:
                 tool_names.append(match.strip())
 

--- a/sagents/tool/impl/memory_index.py
+++ b/sagents/tool/impl/memory_index.py
@@ -23,6 +23,9 @@ class FileDocument:
     size: int           # File size
     hash: str           # Content hash
     doc_id: int         # Document ID (index in BM25)
+    chunk_index: int = 0
+    line_start: int = 1
+    line_end: int = 1
 
 
 @dataclass
@@ -75,6 +78,9 @@ class MemoryIndex:
         '.rb', '.php', '.pl',
     ]
     DEFAULT_FILE_PROCESS_CONCURRENCY = 8
+    INDEX_SCHEMA_VERSION = 2
+    DEFAULT_CHUNK_SIZE = 1200
+    DEFAULT_CHUNK_OVERLAP = 200
 
     def __init__(self, sandbox, workspace_path: str, index_path: str, blacklist: Optional[Set[str]] = None):
         """
@@ -96,7 +102,7 @@ class MemoryIndex:
         # In-memory data
         self.bm25 = None
         self.documents: Dict[int, FileDocument] = {}
-        self.path_to_id: Dict[str, int] = {}
+        self.path_to_doc_ids: Dict[str, List[int]] = {}
         self._next_doc_id = 0
 
         # Directory mtime cache for incremental updates
@@ -126,9 +132,19 @@ class MemoryIndex:
                 self.bm25 = data.get('bm25')
                 self.documents = data.get('documents', {})
                 self._dir_mtime_cache = data.get('dir_mtime_cache', {})
+                schema_version = data.get('schema_version', 1)
+                if schema_version != self.INDEX_SCHEMA_VERSION:
+                    logger.info(
+                        f"MemoryIndex: Index schema {schema_version} != {self.INDEX_SCHEMA_VERSION}, clearing cached index for rebuild"
+                    )
+                    self.bm25 = None
+                    self.documents = {}
+                    self.path_to_doc_ids = {}
+                    self._next_doc_id = 0
+                    self._dir_mtime_cache = {}
+                    return False
 
-                # Rebuild path -> id mapping
-                self.path_to_id = {doc.path: doc.doc_id for doc in self.documents.values()}
+                self.path_to_doc_ids = data.get('path_to_doc_ids') or self._rebuild_path_to_doc_ids()
 
                 # Calculate next doc_id
                 if self.documents:
@@ -147,11 +163,18 @@ class MemoryIndex:
             logger.warning(f"MemoryIndex: Failed to load index: {e}")
             self.bm25 = None
             self.documents = {}
-            self.path_to_id = {}
+            self.path_to_doc_ids = {}
             self._next_doc_id = 0
             self._dir_mtime_cache = {}
 
         return False
+
+    def _rebuild_path_to_doc_ids(self) -> Dict[str, List[int]]:
+        path_to_doc_ids: Dict[str, List[int]] = {}
+        for doc_id in sorted(self.documents.keys()):
+            doc = self.documents[doc_id]
+            path_to_doc_ids.setdefault(doc.path, []).append(doc_id)
+        return path_to_doc_ids
 
     def _save_index(self) -> bool:
         """Save index to single pkl file"""
@@ -159,8 +182,10 @@ class MemoryIndex:
 
         try:
             data = {
+                'schema_version': self.INDEX_SCHEMA_VERSION,
                 'bm25': self.bm25,
                 'documents': self.documents,
+                'path_to_doc_ids': self.path_to_doc_ids,
                 'dir_mtime_cache': self._dir_mtime_cache,
                 'document_count': len(self.documents)
             }
@@ -235,6 +260,59 @@ class MemoryIndex:
         text = text.lower()
         tokens = re.findall(r'[a-z0-9_]+|[\u4e00-\u9fff]', text)
         return tokens
+
+    def _split_into_chunks(self, content: str) -> List[Dict[str, Any]]:
+        if not content:
+            return []
+
+        lines = content.splitlines()
+        if not lines:
+            return [{
+                "content": content,
+                "line_start": 1,
+                "line_end": 1,
+            }]
+
+        chunks: List[Dict[str, Any]] = []
+        current_lines: List[str] = []
+        current_line_start = 1
+        current_chars = 0
+
+        for index, line in enumerate(lines, start=1):
+            line_len = len(line) + 1
+            if current_lines and current_chars + line_len > self.DEFAULT_CHUNK_SIZE:
+                chunks.append({
+                    "content": "\n".join(current_lines),
+                    "line_start": current_line_start,
+                    "line_end": current_line_start + len(current_lines) - 1,
+                })
+
+                overlap_lines: List[str] = []
+                overlap_chars = 0
+                for existing_line in reversed(current_lines):
+                    existing_len = len(existing_line) + 1
+                    if overlap_lines and overlap_chars + existing_len > self.DEFAULT_CHUNK_OVERLAP:
+                        break
+                    overlap_lines.insert(0, existing_line)
+                    overlap_chars += existing_len
+
+                current_lines = overlap_lines[:]
+                current_chars = sum(len(existing_line) + 1 for existing_line in current_lines)
+                current_line_start = index - len(current_lines)
+
+            if not current_lines:
+                current_line_start = index
+            current_lines.append(line)
+            current_chars += line_len
+
+        if current_lines:
+            chunks.append({
+                "content": "\n".join(current_lines),
+                "line_start": current_line_start,
+                "line_end": current_line_start + len(current_lines) - 1,
+            })
+
+        return chunks
 
     def _build_bm25(self) -> None:
         """Build BM25 index"""
@@ -321,7 +399,7 @@ class MemoryIndex:
             # But we still need to collect files from this directory from existing index
             # logger.debug(f"MemoryIndex: Skipping unchanged directory: {dir_path}")
             # Collect files from existing index that belong to this directory
-            for filepath in self.path_to_id.keys():
+            for filepath in self.path_to_doc_ids.keys():
                 if filepath.startswith(dir_path + '/') or filepath == dir_path:
                     current_files.add(filepath)
             return
@@ -371,10 +449,10 @@ class MemoryIndex:
             size = entry.size or 0
 
             try:
-                if filepath in self.path_to_id:
+                if filepath in self.path_to_doc_ids:
                     # File exists in index, check if modified
-                    doc_id = self.path_to_id[filepath]
-                    old_doc = self.documents[doc_id]
+                    existing_doc_ids = self.path_to_doc_ids[filepath]
+                    old_doc = self.documents[existing_doc_ids[0]]
 
                     # Quick check: compare mtime and size
                     if old_doc.mtime == mtime and old_doc.size == size:
@@ -383,37 +461,51 @@ class MemoryIndex:
 
                     # mtime or size changed, treat as content changed and refresh directly.
                     content = await self._read_file_content(filepath)
-                    self.documents[doc_id] = FileDocument(
-                        path=filepath,
-                        content=content,
-                        mtime=mtime,
-                        size=size,
-                        hash="",
-                        doc_id=doc_id
-                    )
+                    self._replace_file_documents(filepath, content, mtime, size)
                     stats["updated"] += 1
                     logger.debug(f"MemoryIndex: Updated file {filepath}")
                 else:
                     # New file, add to index
                     content = await self._read_file_content(filepath)
-                    doc_id = self._next_doc_id
-                    self._next_doc_id += 1
-
-                    self.documents[doc_id] = FileDocument(
-                        path=filepath,
-                        content=content,
-                        mtime=mtime,
-                        size=size,
-                        hash="",
-                        doc_id=doc_id
-                    )
-                    self.path_to_id[filepath] = doc_id
+                    self._replace_file_documents(filepath, content, mtime, size)
                     stats["added"] += 1
                     logger.debug(f"MemoryIndex: Added file {filepath}")
 
             except Exception as e:
                 logger.warning(f"MemoryIndex: Failed to process file {filepath}: {e}")
                 stats["errors"] += 1
+
+    def _replace_file_documents(self, filepath: str, content: str, mtime: float, size: int) -> None:
+        existing_doc_ids = self.path_to_doc_ids.pop(filepath, [])
+        for doc_id in existing_doc_ids:
+            self.documents.pop(doc_id, None)
+
+        chunks = self._split_into_chunks(content)
+        if not chunks:
+            chunks = [{
+                "content": "",
+                "line_start": 1,
+                "line_end": 1,
+            }]
+
+        new_doc_ids: List[int] = []
+        for chunk_index, chunk in enumerate(chunks):
+            doc_id = self._next_doc_id
+            self._next_doc_id += 1
+            self.documents[doc_id] = FileDocument(
+                path=filepath,
+                content=chunk["content"],
+                mtime=mtime,
+                size=size,
+                hash="",
+                doc_id=doc_id,
+                chunk_index=chunk_index,
+                line_start=chunk["line_start"],
+                line_end=chunk["line_end"],
+            )
+            new_doc_ids.append(doc_id)
+
+        self.path_to_doc_ids[filepath] = new_doc_ids
 
     async def update_index(self, file_extensions: Optional[List[str]] = None, force: bool = False) -> Dict[str, Any]:
         """
@@ -462,17 +554,16 @@ class MemoryIndex:
             current_files
         )
         
-        # logger.debug(f"MemoryIndex: Scan complete. Found {len(current_files)} current files, {len(self.path_to_id)} indexed files")
+        # logger.debug(f"MemoryIndex: Scan complete. Found {len(current_files)} current files, {len(self.path_to_doc_ids)} indexed files")
 
         # Check for deleted files
-        indexed_paths = set(self.path_to_id.keys())
+        indexed_paths = set(self.path_to_doc_ids.keys())
         deleted_paths = indexed_paths - current_files
 
         for filepath in deleted_paths:
             try:
-                doc_id = self.path_to_id[filepath]
-                del self.documents[doc_id]
-                del self.path_to_id[filepath]
+                for doc_id in self.path_to_doc_ids.pop(filepath, []):
+                    self.documents.pop(doc_id, None)
                 stats["removed"] += 1
                 logger.debug(f"MemoryIndex: Removed file {filepath}")
             except Exception as e:
@@ -597,8 +688,9 @@ class MemoryIndex:
 
                 # Build preview from snippets or fallback to first 500 chars
                 if snippets:
+                    line_base = getattr(doc, "line_start", 1) - 1
                     preview = "\n\n".join([
-                        f"[Line {s['line_number']}] {s['snippet']}"
+                        f"[Line {line_base + s['line_number']}] {s['snippet']}"
                         for s in snippets
                     ])
                 else:
@@ -610,7 +702,10 @@ class MemoryIndex:
                     path=doc.path,
                     score=float(score),
                     content=preview,
-                    line_number=snippets[0]["line_number"] if snippets else 0
+                    line_number=(
+                        getattr(doc, "line_start", 1) + snippets[0]["line_number"] - 1
+                        if snippets else getattr(doc, "line_start", 1)
+                    )
                 ))
 
             elapsed = time.time() - start_time
@@ -631,7 +726,7 @@ class MemoryIndex:
 
         self.bm25 = None
         self.documents = {}
-        self.path_to_id = {}
+        self.path_to_doc_ids = {}
         self._next_doc_id = 0
         self._dir_mtime_cache = {}
 


### PR DESCRIPTION
## Summary
  - switch file memory retrieval from whole-file BM25 documents to chunk-based BM25 documents
  - keep session history retrieval unchanged in this phase
  - invalidate old file-memory indexes with a schema version bump so chunk indexes rebuild cleanly
  - preserve the existing search result shape while making file-memory hits more focused
  - update CLI tool stats parsing so memory validation runs recognize additional streamed tool-call formats

  ## Background
  Memory search P0 reduced repeated rebuild work and split file memory and session history responsibilities more clearly.

  This PR is the next step for file memory only:
  - keep BM25 for now
  - improve retrieval granularity
  - make results more focused
  - avoid returning large whole-file matches when a smaller local chunk is enough

  This work does **not** change session history semantics and does **not** replace BM25 yet.

  ## Scope
  This PR is intentionally limited to:
  - file memory chunk retrieval in `sagents/tool/impl/memory_index.py`
  - CLI tool-usage observability improvements in `app/cli/main.py`

  It does not modify:
  - session-history retrieval scope
  - runtime/bootstrap structure
  - file-memory storage backend beyond the existing BM25 index format

  ## What Changed

  ### 1. Chunk-based file indexing
  File memory indexing now stores multiple BM25 documents per file instead of one document per file.

  Each indexed file is split into overlapping chunks, and each chunk records:
  - file path
  - chunk content
  - chunk index
  - line start
  - line end

  This allows search results to target a smaller relevant region of a file instead of ranking and returning the entire file as one large document.

  ### 2. File-level incremental updates are preserved
  The update path is still file-oriented:
  - unchanged files are skipped
  - changed files rebuild only that file's chunk documents
  - deleted files remove all chunk documents for that file

  This keeps P1 compatible with the P0 caching/incremental update direction.

  ### 3. Old indexes rebuild automatically
  A schema version was added to the file-memory index format.

  If an older whole-file index is found, it is treated as stale and rebuilt as a chunk-based index automatically. This avoids mixing old and new
  document layouts.

  ### 4. Absolute line numbers are preserved
  Search results still expose line numbers, and the reported line number now stays aligned with the original file rather than only the local chunk
  offset.

  Preview content also uses the absolute line number format so downstream parsing remains coherent.

  ### 5. CLI stats recognize more tool-call output formats
  During validation, some tool executions were visible in streamed output but not reflected in CLI stats because the output format varied.

  CLI stats parsing now also recognizes additional streamed tool-call formats such as:
  - `<tool_name>...</tool_name>`
  - `<call function="...">`
  - `<function_result name="...">`

  This makes `tools: search_memory` show up more reliably during memory validation runs.

  ## Why This Is Separate From BM25 Replacement
  This PR intentionally stops at chunk-based BM25 retrieval.

  The goal here is to improve retrieval granularity first, while keeping the search backend stable enough to isolate the effect of chunking. Replacing
  BM25 with SQLite FTS5 or a hybrid approach should happen in a separate follow-up so:
  - behavior changes remain attributable
  - regressions are easier to isolate
  - rollback scope stays smaller

  ## Validation

  ### Code-level checks
  - `python -m py_compile sagents/tool/impl/memory_index.py sagents/tool/impl/memory_tool.py`
  - `python -m py_compile app/cli/main.py`
  - function-level sanity checks for:
    - chunk splitting
    - absolute line-number preservation

  ### Manual validation
  Using a workspace file containing a unique marker:
  - verified `search_memory` hits the correct file
  - verified results are highly focused instead of returning large whole-file blocks
  - verified CLI stats now show:
    - `tools: search_memory`

  Example validation command:
  ```bash
  sage run --workspace /path/to/workspace --stats "你必须先调用 search_memory 工具检索当前工作区里和 P1ChunkUniqueGamma 相关的内容。不要使用 grep、
  find、cat 或其他 shell 命令。最终只输出 file_path 和一句话摘要。"
  ```

  Observed behavior:
  - correct file hit
  - concise result
  - `tools: search_memory` shown in stats

  ## Notes
  This PR is memory-search P1 only:
  - file retrieval granularity improvement
  - no session-history semantic changes
  - no BM25 replacement yet

  The next follow-up can focus on the file-memory backend upgrade itself if needed.