### PR TITLE
feat: switch file memory search to sqlite fts

### DIFF
--- a/sagents/tool/impl/memory_index.py
+++ b/sagents/tool/impl/memory_index.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 """
-File-based memory index using BM25 algorithm - Sandbox version
-Supports incremental updates and fast search through sandbox interface
+File-based memory index for sandbox workspaces.
+
+Current design:
+- file content is indexed as overlapping chunks
+- chunk rows are stored in a local SQLite FTS5 database
+- lightweight metadata is still persisted in a pickle sidecar for incremental updates
 """
 import asyncio
 import os
 import pickle
+import sqlite3
 import time
 from pathlib import Path
 from typing import Dict, List, Optional, Any, Set
@@ -39,7 +44,7 @@ class SearchResult:
 
 class MemoryIndex:
     """
-    BM25-based memory index manager - Sandbox version
+    File-memory index manager for sandbox workspaces.
 
     Features:
     1. Incremental updates - only process changed files
@@ -79,6 +84,7 @@ class MemoryIndex:
     ]
     DEFAULT_FILE_PROCESS_CONCURRENCY = 8
     INDEX_SCHEMA_VERSION = 2
+    FTS_SCHEMA_VERSION = 1
     DEFAULT_CHUNK_SIZE = 1200
     DEFAULT_CHUNK_OVERLAP = 200
 
@@ -98,6 +104,7 @@ class MemoryIndex:
         self.workspace_path = workspace_path.rstrip('/')
         self.index_path = Path(index_path)
         self.index_path.parent.mkdir(parents=True, exist_ok=True)
+        self.fts_index_path = self.index_path.with_suffix(".sqlite3")
         logger.info(f"MemoryIndex: Index path created: {self.index_path},workspace_path: {self.workspace_path}")
         # In-memory data
         self.bm25 = None
@@ -116,6 +123,12 @@ class MemoryIndex:
 
         # Load existing index
         self._load_index()
+        self._ensure_fts_schema()
+        fts_has_documents = self._fts_has_documents()
+        if bool(self.documents) != fts_has_documents:
+            # Keep the sidecar metadata and the FTS store in sync. This also clears
+            # stale FTS rows left behind by older layouts or interrupted rebuilds.
+            self._rebuild_fts_index()
 
         elapsed = time.time() - start_time
         logger.info(f"MemoryIndex: Initialized in {elapsed:.3f}s")
@@ -129,7 +142,7 @@ class MemoryIndex:
                 with open(self.index_path, 'rb') as f:
                     data = pickle.load(f)
 
-                self.bm25 = data.get('bm25')
+                self.bm25 = None
                 self.documents = data.get('documents', {})
                 self._dir_mtime_cache = data.get('dir_mtime_cache', {})
                 schema_version = data.get('schema_version', 1)
@@ -183,7 +196,7 @@ class MemoryIndex:
         try:
             data = {
                 'schema_version': self.INDEX_SCHEMA_VERSION,
-                'bm25': self.bm25,
+                'bm25': None,
                 'documents': self.documents,
                 'path_to_doc_ids': self.path_to_doc_ids,
                 'dir_mtime_cache': self._dir_mtime_cache,
@@ -314,38 +327,123 @@ class MemoryIndex:
 
         return chunks
 
-    def _build_bm25(self) -> None:
-        """Build BM25 index"""
-        start_time = time.time()
+    def _connect_fts(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.fts_index_path)
+        conn.row_factory = sqlite3.Row
+        return conn
 
+    def _ensure_fts_schema(self) -> None:
+        with self._connect_fts() as conn:
+            conn.execute("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+            row = conn.execute("SELECT value FROM meta WHERE key = 'fts_schema_version'").fetchone()
+            current_version = row["value"] if row else None
+            if current_version != str(self.FTS_SCHEMA_VERSION):
+                conn.execute("DROP TABLE IF EXISTS memory_fts")
+                conn.execute("DELETE FROM meta")
+            conn.execute(
+                """
+                CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts
+                USING fts5(
+                    path UNINDEXED,
+                    search_text,
+                    content UNINDEXED,
+                    line_start UNINDEXED,
+                    line_end UNINDEXED,
+                    chunk_index UNINDEXED,
+                    tokenize='unicode61'
+                )
+                """
+            )
+            conn.execute(
+                "INSERT OR REPLACE INTO meta(key, value) VALUES ('fts_schema_version', ?)",
+                (str(self.FTS_SCHEMA_VERSION),),
+            )
+            conn.commit()
+
+    def _fts_has_documents(self) -> bool:
+        if not self.fts_index_path.exists():
+            return False
         try:
-            from rank_bm25 import BM25Okapi
+            with self._connect_fts() as conn:
+                row = conn.execute("SELECT COUNT(*) AS count FROM memory_fts").fetchone()
+                return bool(row and row["count"] > 0)
+        except Exception as e:
+            logger.warning(f"MemoryIndex: Failed to inspect FTS index: {e}")
+            return False
 
-            if not self.documents:
-                self.bm25 = None
-                return
+    def has_search_index(self) -> bool:
+        return bool(self.documents) and self._fts_has_documents()
 
-            # Prepare corpus
-            corpus = []
+    def _build_search_text(self, doc: FileDocument) -> str:
+        filename = os.path.basename(doc.path)
+        text = f"{filename} {doc.content}"
+        return " ".join(self._tokenize(text))
+
+    def _delete_file_from_fts(self, filepath: str) -> None:
+        self._ensure_fts_schema()
+        with self._connect_fts() as conn:
+            conn.execute("DELETE FROM memory_fts WHERE path = ?", (filepath,))
+            conn.commit()
+
+    def _sync_file_to_fts(self, filepath: str) -> None:
+        self._ensure_fts_schema()
+        doc_ids = self.path_to_doc_ids.get(filepath, [])
+        with self._connect_fts() as conn:
+            conn.execute("DELETE FROM memory_fts WHERE path = ?", (filepath,))
+            rows = []
+            for doc_id in doc_ids:
+                doc = self.documents.get(doc_id)
+                if not doc:
+                    continue
+                rows.append(
+                    (
+                        doc.path,
+                        self._build_search_text(doc),
+                        doc.content,
+                        str(doc.line_start),
+                        str(doc.line_end),
+                        str(doc.chunk_index),
+                    )
+                )
+            if rows:
+                conn.executemany(
+                    """
+                    INSERT INTO memory_fts(path, search_text, content, line_start, line_end, chunk_index)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    rows,
+                )
+            conn.commit()
+
+    def _rebuild_fts_index(self) -> None:
+        start_time = time.time()
+        self._ensure_fts_schema()
+        with self._connect_fts() as conn:
+            conn.execute("DELETE FROM memory_fts")
+            rows = []
             for doc_id in sorted(self.documents.keys()):
                 doc = self.documents[doc_id]
-                filename = os.path.basename(doc.path)
-                text = f"{filename} {doc.content}"
-                tokens = self._tokenize(text)
-                corpus.append(tokens)
-
-            # Build BM25
-            self.bm25 = BM25Okapi(corpus)
-
-            elapsed = time.time() - start_time
-            logger.info(f"MemoryIndex: Built BM25 index for {len(corpus)} documents in {elapsed:.3f}s")
-
-        except ImportError:
-            logger.error("MemoryIndex: Please install rank-bm25: pip install rank-bm25")
-            raise
-        except Exception as e:
-            logger.error(f"MemoryIndex: Failed to build BM25: {e}")
-            raise
+                rows.append(
+                    (
+                        doc.path,
+                        self._build_search_text(doc),
+                        doc.content,
+                        str(doc.line_start),
+                        str(doc.line_end),
+                        str(doc.chunk_index),
+                    )
+                )
+            if rows:
+                conn.executemany(
+                    """
+                    INSERT INTO memory_fts(path, search_text, content, line_start, line_end, chunk_index)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    rows,
+                )
+            conn.commit()
+        elapsed = time.time() - start_time
+        logger.info(f"MemoryIndex: Rebuilt SQLite FTS index for {len(rows)} chunks in {elapsed:.3f}s")
 
     def _is_path_blacklisted(self, path: str) -> bool:
         """Check if path is in blacklist"""
@@ -462,12 +560,14 @@ class MemoryIndex:
                     # mtime or size changed, treat as content changed and refresh directly.
                     content = await self._read_file_content(filepath)
                     self._replace_file_documents(filepath, content, mtime, size)
+                    self._sync_file_to_fts(filepath)
                     stats["updated"] += 1
                     logger.debug(f"MemoryIndex: Updated file {filepath}")
                 else:
                     # New file, add to index
                     content = await self._read_file_content(filepath)
                     self._replace_file_documents(filepath, content, mtime, size)
+                    self._sync_file_to_fts(filepath)
                     stats["added"] += 1
                     logger.debug(f"MemoryIndex: Added file {filepath}")
 
@@ -564,6 +664,7 @@ class MemoryIndex:
             try:
                 for doc_id in self.path_to_doc_ids.pop(filepath, []):
                     self.documents.pop(doc_id, None)
+                self._delete_file_from_fts(filepath)
                 stats["removed"] += 1
                 logger.debug(f"MemoryIndex: Removed file {filepath}")
             except Exception as e:
@@ -571,12 +672,14 @@ class MemoryIndex:
 
         stats["scan_time"] = time.time() - scan_start
 
-        # Rebuild BM25 index if needed
+        # Persist metadata if the file set changed. The FTS rows are updated inline
+        # during file processing and full rebuild is only needed on force refresh.
         build_start = time.time()
         has_changes = stats["added"] > 0 or stats["updated"] > 0 or stats["removed"] > 0
 
         if has_changes or force:
-            self._build_bm25()
+            if force:
+                self._rebuild_fts_index()
             stats["build_time"] = time.time() - build_start
 
             save_start = time.time()
@@ -658,55 +761,61 @@ class MemoryIndex:
         """
         start_time = time.time()
 
-        if not self.bm25 or not self.documents:
+        if not self.documents or not self._fts_has_documents():
             logger.warning("MemoryIndex: Index is empty, please update index first")
             return []
 
         try:
             query_tokens = self._tokenize(query)
-
             if not query_tokens:
                 return []
 
-            # Get scores for all documents
-            scores = self.bm25.get_scores(query_tokens)
-
-            # Get top_k results
-            top_indices = scores.argsort()[-top_k:][::-1]
-
             results = []
-            for idx in top_indices:
-                score = scores[idx]
-                if score <= 0:
+            match_expr = " OR ".join(f'"{token}"' for token in query_tokens)
+            row_limit = max(top_k * 5, top_k)
+            with self._connect_fts() as conn:
+                rows = conn.execute(
+                    """
+                    SELECT path, content, line_start, line_end, chunk_index, bm25(memory_fts) AS raw_score
+                    FROM memory_fts
+                    WHERE search_text MATCH ?
+                    ORDER BY raw_score
+                    LIMIT ?
+                    """,
+                    (match_expr, row_limit),
+                ).fetchall()
+
+            seen_paths = set()
+            for row in rows:
+                path = row["path"]
+                if path in seen_paths:
                     continue
+                seen_paths.add(path)
 
-                doc_id = list(sorted(self.documents.keys()))[idx]
-                doc = self.documents[doc_id]
+                chunk_content = row["content"] or ""
+                line_start = int(row["line_start"] or 1)
+                snippets = self._extract_snippets(chunk_content, query)
 
-                # Extract relevant snippets
-                snippets = self._extract_snippets(doc.content, query)
-
-                # Build preview from snippets or fallback to first 500 chars
                 if snippets:
-                    line_base = getattr(doc, "line_start", 1) - 1
+                    line_base = line_start - 1
                     preview = "\n\n".join([
                         f"[Line {line_base + s['line_number']}] {s['snippet']}"
                         for s in snippets
                     ])
                 else:
-                    preview = doc.content[:500]
-                    if len(doc.content) > 500:
+                    preview = chunk_content[:500]
+                    if len(chunk_content) > 500:
                         preview += "..."
 
+                raw_score = float(row["raw_score"]) if row["raw_score"] is not None else 0.0
                 results.append(SearchResult(
-                    path=doc.path,
-                    score=float(score),
+                    path=path,
+                    score=-raw_score,
                     content=preview,
-                    line_number=(
-                        getattr(doc, "line_start", 1) + snippets[0]["line_number"] - 1
-                        if snippets else getattr(doc, "line_start", 1)
-                    )
+                    line_number=(line_start + snippets[0]["line_number"] - 1) if snippets else line_start,
                 ))
+                if len(results) >= top_k:
+                    break
 
             elapsed = time.time() - start_time
             logger.info(f"MemoryIndex: Search '{query}' completed, found {len(results)} results in {elapsed:.3f}s")
@@ -732,6 +841,8 @@ class MemoryIndex:
 
         if self.index_path.exists():
             self.index_path.unlink()
+        if self.fts_index_path.exists():
+            self.fts_index_path.unlink()
 
         elapsed = time.time() - start_time
         logger.info(f"MemoryIndex: Index cleared in {elapsed:.3f}s")

--- a/sagents/tool/impl/memory_tool.py
+++ b/sagents/tool/impl/memory_tool.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 """
-Memory tool based on BM25 file system - Sandbox version
-Get workspace through session_id, build file index and support search
+Memory tool for workspace file memory and session-history retrieval.
+
+File memory currently uses a scoped chunk index; session history keeps the
+existing BM25-based retrieval path.
 """
 import hashlib
 import json
@@ -82,7 +84,7 @@ class FileMemoryRetriever:
 
             now = time.time()
             should_refresh = (
-                cache_entry.index.bm25 is None
+                not cache_entry.index.has_search_index()
                 or (now - cache_entry.last_refresh_at) >= self.INDEX_REFRESH_INTERVAL_SECONDS
             )
             if should_refresh:
@@ -317,7 +319,7 @@ class MemoryTool:
     @tool(
         description_i18n={
             "zh": "搜索 Agent 的记忆。包括工作空间中的长期记忆（代码文件、文档等）和本次会话的历史对话。返回最相关的内容。",
-            "en": "Search Agent's memory. Includes long-term memory (code files, docs) in workspace and current session history. Uses BM25 algorithm."
+            "en": "Search Agent's memory. Includes long-term memory (code files, docs) in workspace and current session history."
         },
         param_description_i18n={
             "query": {
@@ -392,7 +394,7 @@ class MemoryTool:
             }
 
     async def _search_file_memory(self, query: str, top_k: int, session_id: str) -> List[Dict[str, Any]]:
-        """Search file memory using cached BM25 index through sandbox"""
+        """Search file memory using the scoped file-memory index through sandbox."""
         try:
             from sagents.session_runtime import get_global_session_manager
 


### PR DESCRIPTION
## Summary
  - switch file-memory retrieval from chunked BM25 search to SQLite FTS5
  - keep session-history retrieval unchanged and still BM25-based
  - preserve the existing  external interface
  - keep chunk-based file indexing introduced in the previous phase
  - make file updates and deletions synchronize directly into the FTS index

  ## Background
  Memory search work has been split into clear phases:

  - P0: separate file memory and session history responsibilities, and remove repeated heavy work on the query path
  - P1: change file-memory retrieval from whole-file results to chunk-based results
  - P2: upgrade the file-memory backend itself

  This PR is the P2 phase for file memory only.

  The goal is to replace the file-memory BM25 backend with SQLite FTS5 while keeping the surrounding retrieval flow stable enough to isolate the
  backend change.

  ## Scope
  This PR is intentionally limited to:

  - It does not change:
  - session-history retrieval semantics
  - runtime/bootstrap structure
  - CLI command surface
  -  response contract

  ## What Changed

  ### 1. File memory now uses SQLite FTS5
  File-memory chunk rows are now stored in a SQLite FTS5 table instead of being searched through the previous in-memory BM25 backend.

  The chunk model from P1 is preserved:
  - each file is split into overlapping chunks
  - each chunk records path, content, chunk index, line start, and line end
  - query-time results are still deduplicated by file path

  ### 2. Pickle sidecar remains for metadata and incremental updates
  The existing pickle sidecar remains as lightweight metadata storage for:
  - chunk metadata
  - path-to-doc-id mapping
  - directory mtime cache

  This means the backend change is focused on file retrieval, not on rewriting the entire incremental-update flow.

  ### 3. FTS schema management and rebuild behavior
  A dedicated FTS schema version is now tracked.

  On initialization:
  - the FTS schema is created if missing
  - stale schema versions are rebuilt
  - if sidecar metadata and FTS rows become inconsistent, the FTS index is rebuilt to re-sync them

  This keeps the new FTS store from drifting away from the existing file metadata state.

  ### 4. Incremental file update and deletion sync
  When a file changes:
  - its chunk documents are regenerated
  - old FTS rows for that file are removed
  - new chunk rows are inserted

  When a file is deleted:
  - all chunk docs for that path are removed from the metadata map
  - matching FTS rows are deleted

  This is the key behavior needed for file-memory correctness after the backend swap.

  ### 5. Search still returns the same external shape
  The external file-memory results still behave the same way:
  - file path
  - content preview
  - absolute line number

  The implementation now queries:
  - SQLite FTS5 rows
  - ranks with 
  - deduplicates by path
  - keeps the most relevant chunk per file

  ## Validation

  ### Code-level checks
  - 

  ### Manual validation
  Using CLI workspace runs:
  1. verified file-memory search still hits the correct file for a unique marker
  2. verified result previews remain focused and chunk-level
  3. verified deleting a test file removes the old result and returns  on re-query

  Example successful deletion validation flow:
  - create a file containing a unique keyword
  - verify  finds it
  - remove the file
  - verify the same query returns an empty result

  ## Notes
  This PR intentionally focuses only on replacing the file-memory backend.

  It does not yet add:
  - benchmark reporting
  - hybrid reranking
  - session-history backend changes

  Those should be follow-up work if needed.