### PR TITLE
fix(web): remove agent dimension from skill list to prevent page freeze

### DIFF
--- a/app/server/web/src/composables/skill/useSkillList.js
+++ b/app/server/web/src/composables/skill/useSkillList.js
@@ -1,13 +1,11 @@
 import { ref, computed, onMounted } from 'vue'
 import { skillAPI } from '../../api/skill.js'
-import { agentAPI } from '../../api/agent.js'
 import { getCurrentUser } from '../../utils/auth.js'
 import { toast } from 'vue-sonner'
 
 export function useSkillList(t) {
   // State
   const skills = ref([])
-  const agents = ref([]) // Agent列表，用于获取agent名称
   const loading = ref(false)
   const searchTerm = ref('')
   const selectedDimension = ref('system')
@@ -44,46 +42,8 @@ export function useSkillList(t) {
   const counts = computed(() => ({
     system: skills.value.filter(s => s.dimension === 'system').length,
     user: skills.value.filter(s => s.dimension === 'user').length,
-    agent: skills.value.filter(s => s.dimension === 'agent').length
   }))
 
-  // Agent名称映射表
-  const agentNameMap = computed(() => {
-    const map = {}
-    agents.value.forEach(agent => {
-      map[agent.id] = agent.name
-    })
-    return map
-  })
-
-  // Group skills by agent for agent dimension view
-  const groupedAgentSkills = computed(() => {
-    const groups = {}
-    skills.value
-      .filter(s => s.dimension === 'agent')
-      .filter(skill => {
-        if (!searchTerm.value.trim()) return true
-        const query = searchTerm.value.toLowerCase()
-        return skill.name.toLowerCase().includes(query) ||
-          (skill.description && skill.description.toLowerCase().includes(query))
-      })
-      .forEach(skill => {
-        const agentId = skill.agent_id || 'unknown'
-        // 优先使用agent列表中的名称，其次使用skill中的agent_name，最后使用agentId
-        const agentName = agentNameMap.value[agentId] || skill.agent_name || agentId
-        if (!groups[agentId]) {
-          groups[agentId] = {
-            agentId,
-            agentName,
-            skills: []
-          }
-        }
-        groups[agentId].skills.push(skill)
-      })
-    return Object.values(groups)
-  })
-
-  // Displayed skills filtered by current dimension and search term.
   const displayedSkills = computed(() => {
     let result = skills.value
 
@@ -91,7 +51,6 @@ export function useSkillList(t) {
       result = result.filter(skill => skill.dimension === selectedDimension.value)
     }
 
-    // Search filtering (client-side)
     if (searchTerm.value.trim()) {
       const query = searchTerm.value.toLowerCase()
       result = result.filter(skill =>
@@ -104,15 +63,12 @@ export function useSkillList(t) {
   })
 
   const isImportDisabled = computed(() => {
-    // Upload mode requires file
     if (importMode.value === 'upload') {
       if (!selectedFile.value) return true
     }
-    // URL mode requires URL
     if (importMode.value === 'url') {
       if (!importUrl.value) return true
     }
-    // System dimension requires admin
     if (importTargetDimension.value === 'system') {
       if (!isAdmin.value) return true
     }
@@ -124,7 +80,6 @@ export function useSkillList(t) {
     switch (dimension) {
       case 'system': return 'default'
       case 'user': return 'secondary'
-      case 'agent': return 'outline'
       default: return 'secondary'
     }
   }
@@ -133,7 +88,6 @@ export function useSkillList(t) {
     switch (dimension) {
       case 'system': return 'Shield'
       case 'user': return 'User'
-      case 'agent': return 'Bot'
       default: return 'Box'
     }
   }
@@ -142,19 +96,13 @@ export function useSkillList(t) {
     switch (dimension) {
       case 'system': return t('skills.system') || 'System'
       case 'user': return t('skills.user') || 'User'
-      case 'agent': return t('skills.agent') || 'Agent'
       default: return dimension
     }
   }
 
-  // Check if user can edit a skill
   const canEdit = (skill) => {
     if (skill.dimension === 'system') {
-      return isAdmin.value // Only admin can edit system skills
-    }
-    if (skill.dimension === 'agent') {
-      // Agent skills can be edited by the owner
-      return skill.owner_user_id === currentUserId.value
+      return isAdmin.value
     }
     return skill.owner_user_id === currentUserId.value
   }
@@ -162,30 +110,19 @@ export function useSkillList(t) {
   const canDelete = (skill) => {
     if (isAdmin.value) return true
     if (skill.dimension === 'system') return false
-    if (skill.dimension === 'agent') {
-      return skill.owner_user_id === currentUserId.value
-    }
     return skill.owner_user_id === currentUserId.value
   }
 
   // API Methods
-  const loadSkills = async () => {
-    try {
+  const loadSkills = async ({ silent = false } = {}) => {
+    if (!silent) {
       loading.value = true
-
-      // 并行请求skills和agents
-      const [skillsResponse, agentsResponse] = await Promise.all([
-        skillAPI.getSkills(),
-        agentAPI.getAgents().catch(() => []) // 如果获取agents失败，返回空数组
-      ])
-
-      if (skillsResponse.skills) {
-        skills.value = skillsResponse.skills
+    }
+    try {
+      const response = await skillAPI.getSkills()
+      if (response.skills) {
+        skills.value = response.skills
       }
-
-      // 保存agent列表用于显示agent名称
-      // 后端返回格式: [...]
-      agents.value = agentsResponse || []
     } catch (error) {
       console.error('Failed to load skills:', error)
       toast.error(t('skills.loadFailed') || 'Failed to load skills')
@@ -252,7 +189,7 @@ export function useSkillList(t) {
         })
       }
 
-      await loadSkills()
+      await loadSkills({ silent: true })
       showImportModal.value = false
       selectedFile.value = null
       importUrl.value = ''
@@ -267,7 +204,6 @@ export function useSkillList(t) {
   }
 
   const openEditModal = async (skill) => {
-    // Check if can edit
     if (!canEdit(skill)) {
       toast.error(t('skills.noEditPermission') || 'You do not have permission to edit this skill')
       return
@@ -296,7 +232,7 @@ export function useSkillList(t) {
       await skillAPI.updateSkillContent(editingSkill.value.name, skillContent.value)
       toast.success(t('skills.updateSuccess') || 'Skill updated successfully')
       showEditModal.value = false
-      loadSkills()
+      loadSkills({ silent: true })
     } catch (error) {
       console.error('Failed to update skill:', error)
       toast.error(t('skills.updateFailed') || 'Failed to update skill')
@@ -305,12 +241,8 @@ export function useSkillList(t) {
     }
   }
 
-  // 用于存储要删除的skill的agentId
-  const skillToDeleteAgentId = ref(null)
-
-  const confirmDelete = (skill, agentId = null) => {
+  const confirmDelete = (skill) => {
     skillToDelete.value = skill
-    skillToDeleteAgentId.value = agentId // 保存agentId用于删除
     showDeleteDialog.value = true
   }
 
@@ -319,14 +251,11 @@ export function useSkillList(t) {
 
     try {
       deleting.value = true
-      // 如果是Agent维度的skill，传入agent_id
-      const agentId = skillToDeleteAgentId.value
-      await skillAPI.deleteSkill(skillToDelete.value.name, agentId)
+      await skillAPI.deleteSkill(skillToDelete.value.name)
       toast.success(t('skills.deleteSuccess') || 'Skill deleted successfully')
       showDeleteDialog.value = false
       skillToDelete.value = null
-      skillToDeleteAgentId.value = null
-      await loadSkills()
+      await loadSkills({ silent: true })
     } catch (error) {
       toast.error(t('skills.deleteFailed') || 'Failed to delete skill')
     } finally {
@@ -371,7 +300,6 @@ export function useSkillList(t) {
     counts,
     displayedSkills,
     isImportDisabled,
-    groupedAgentSkills,
 
     // Methods
     getDimensionBadgeVariant,

--- a/app/server/web/src/views/SkillList.vue
+++ b/app/server/web/src/views/SkillList.vue
@@ -5,7 +5,7 @@
       <div class="flex items-center justify-between gap-4">
         <div class="p-4 md:px-6 pb-4 flex items-center gap-2 overflow-x-auto no-scrollbar pb-1">
           <Tabs v-model="selectedDimension" class="w-full">
-            <TabsList class="grid w-full max-w-md grid-cols-3 bg-transparent h-auto gap-2">
+            <TabsList class="grid w-full max-w-md grid-cols-2 bg-transparent h-auto gap-2">
               <TabsTrigger value="system" class="gap-2 rounded-full border data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary shadow-none">
               <Shield class="h-4 w-4" />
               <span>{{ t('skills.system') }}</span>
@@ -15,11 +15,6 @@
               <User class="h-4 w-4" />
               <span>{{ t('skills.mine')  }}</span>
               <span class="ml-1 text-xs opacity-70 bg-black/10 dark:bg-white/10 px-1.5 rounded-full">{{ counts.user }}</span>
-            </TabsTrigger>
-              <TabsTrigger value="agent" class="gap-2 rounded-full border data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary shadow-none">
-              <Bot class="h-4 w-4" />
-              <span>{{ t('skills.agent') }}</span>
-              <span class="ml-1 text-xs opacity-70 bg-black/10 dark:bg-white/10 px-1.5 rounded-full">{{ counts.agent }}</span>
             </TabsTrigger>
             </TabsList>
           </Tabs>
@@ -59,8 +54,6 @@
           </Button>
         </div>
       </div>
-
- 
     </div>
 
     <!-- Main Content Area -->
@@ -87,134 +80,8 @@
 
       <ScrollArea v-else class="h-full">
         <div class="space-y-2 pr-4">
-          <!-- Agent Dimension: Group by Agent -->
-          <div v-if="selectedDimension === 'agent' && viewMode === 'card'">
-            <div v-for="group in groupedAgentSkills" :key="group.agentId" class="mb-6">
-              <!-- Agent Group Header -->
-              <div class="flex items-center gap-2 mb-3 px-2">
-                <Bot class="h-4 w-4 text-muted-foreground" />
-                <span class="text-sm font-medium text-muted-foreground">{{ group.agentName }}</span>
-                <Badge variant="secondary" class="text-xs">{{ group.skills?.length || 0 }}</Badge>
-              </div>
-              <!-- Agent Skills -->
-              <div class="grid gap-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
-                <Card v-for="skill in group.skills" :key="skill.name"
-                  class="group hover:shadow-md transition-all duration-300 border-muted/60 hover:border-primary/50 bg-card">
-                  <CardHeader class="flex flex-row items-start gap-4 space-y-0 pb-3">
-                    <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary group-hover:bg-primary group-hover:text-primary-foreground transition-colors">
-                      <Box class="h-5 w-5" />
-                    </div>
-                    <div class="space-y-1 overflow-hidden flex-1">
-                      <div class="flex items-center justify-between">
-                        <CardTitle class="text-base truncate" :title="skill.name">
-                          {{ skill.name }}
-                        </CardTitle>
-                        <DropdownMenu v-if="canEdit(skill) || canDelete(skill)">
-                          <DropdownMenuTrigger as-child>
-                            <Button variant="ghost" size="icon" class="h-7 w-7 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity">
-                              <MoreVertical class="h-4 w-4" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end" class="w-40">
-                            <DropdownMenuItem v-if="canEdit(skill)" @click="openEditModal(skill)">
-                              <Edit class="h-4 w-4 mr-2" />
-                              {{ t('skills.edit') }}
-                            </DropdownMenuItem>
-                            <DropdownMenuSeparator v-if="canEdit(skill) && canDelete(skill)" />
-                            <DropdownMenuItem v-if="canDelete(skill)" class="text-destructive focus:text-destructive" @click="confirmDelete(skill, group.agentId)">
-                              <Trash2 class="h-4 w-4 mr-2" />
-                              {{ t('skills.delete') }}
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      </div>
-                      <CardDescription class="line-clamp-2 text-xs">
-                        {{ skill.description || t('skills.noDescription') }}
-                      </CardDescription>
-                    </div>
-                  </CardHeader>
-                  <CardContent class="pt-0 pb-3">
-                    <div class="flex items-center gap-2 mt-2 text-xs text-muted-foreground">
-                      <Badge variant="outline" class="text-[10px]">
-                        {{ group.agentName }}
-                      </Badge>
-                    </div>
-                  </CardContent>
-                </Card>
-              </div>
-            </div>
-          </div>
-
-          <!-- Other Dimensions: Grid Cards -->
-          <div v-else-if="selectedDimension === 'agent'" class="space-y-4 pb-20">
-            <Card
-              class="border-dashed border-2 cursor-pointer hover:border-primary/50 hover:bg-muted/50 transition-all duration-300"
-              @click="openImportModal"
-            >
-              <CardContent class="py-3 flex items-center gap-3 text-muted-foreground hover:text-primary transition-colors">
-                <Plus class="h-4 w-4" />
-                <span class="font-medium">{{ t('skills.import') }}</span>
-              </CardContent>
-            </Card>
-
-            <div v-for="group in groupedAgentSkills" :key="`list-${group.agentId}`" class="space-y-2">
-              <div class="flex items-center gap-2 px-2">
-                <Bot class="h-4 w-4 text-muted-foreground" />
-                <span class="text-sm font-medium text-muted-foreground">{{ group.agentName }}</span>
-                <Badge variant="secondary" class="text-xs">{{ group.skills?.length || 0 }}</Badge>
-              </div>
-
-              <Card
-                v-for="skill in group.skills"
-                :key="`list-${group.agentId}-${skill.name}`"
-                class="group border-muted/60 hover:border-primary/40 transition-all"
-              >
-                <CardContent class="py-3">
-                  <div class="flex items-start gap-3">
-                    <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
-                      <Box class="h-4 w-4" />
-                    </div>
-                    <div class="min-w-0 flex-1">
-                      <div class="flex items-center justify-between gap-2">
-                        <div class="min-w-0">
-                          <div class="font-medium text-sm truncate" :title="skill.name">{{ skill.name }}</div>
-                          <div class="text-xs text-muted-foreground line-clamp-1 mt-0.5">
-                            {{ skill.description || t('skills.noDescription') }}
-                          </div>
-                        </div>
-                        <div class="flex items-center gap-1">
-                          <Button
-                            v-if="canEdit(skill)"
-                            variant="ghost"
-                            size="icon"
-                            class="h-7 w-7 text-muted-foreground hover:text-primary"
-                            @click.stop="openEditModal(skill)"
-                          >
-                            <Edit class="h-4 w-4" />
-                          </Button>
-                          <Button
-                            v-if="canDelete(skill)"
-                            variant="ghost"
-                            size="icon"
-                            class="h-7 w-7 text-muted-foreground hover:text-destructive"
-                            @click.stop="confirmDelete(skill, group.agentId)"
-                          >
-                            <Trash2 class="h-4 w-4" />
-                          </Button>
-                        </div>
-                      </div>
-                      <div class="mt-2 inline-flex items-center gap-1 bg-primary/5 px-2 py-1 rounded text-primary/80 text-xs">
-                        <Bot class="h-3 w-3" />
-                        <span>{{ group.agentName }}</span>
-                      </div>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
-          </div>
-
-          <div v-else-if="viewMode === 'card'" class="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 pb-20">
+          <!-- Card View -->
+          <div v-if="viewMode === 'card'" class="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 pb-20">
             <Card
               class="flex flex-col items-center justify-center border-dashed border-2 cursor-pointer hover:border-primary/50 hover:bg-muted/50 transition-all duration-300 min-h-[140px]"
               @click="openImportModal"
@@ -269,7 +136,7 @@
                   <Badge variant="outline" class="text-[10px]">
                     {{ selectedDimension === 'system' ? t('skills.system') : t('skills.mine') }}
                   </Badge>
-                        <Badge v-if="skill.owner_user_id === currentUser.userid" variant="secondary" class="text-[10px]">
+                  <Badge v-if="skill.owner_user_id === currentUser.userid" variant="secondary" class="text-[10px]">
                     {{ t('skills.mySkill') }}
                   </Badge>
                 </div>
@@ -277,6 +144,7 @@
             </Card>
           </div>
 
+          <!-- List View -->
           <div v-else class="space-y-2 pb-20">
             <Card
               class="border-dashed border-2 cursor-pointer hover:border-primary/50 hover:bg-muted/50 transition-all duration-300"
@@ -468,12 +336,7 @@
         <CardHeader>
           <CardTitle class="text-lg">{{ t('skills.deleteConfirmTitle') || 'Delete Confirmation' }}</CardTitle>
           <CardDescription>
-            <template v-if="skillToDelete?.dimension === 'agent'">
-              {{ t('skills.deleteAgentSkillConfirm') || '即将删除 Agent 工作空间下的 Skill，是否确认？' }}
-            </template>
-            <template v-else>
-              {{ t('skills.deleteSkillConfirm', { name: skillToDelete?.name }) || `确定要删除 Skill "${skillToDelete?.name}" 吗？此操作无法撤销。` }}
-            </template>
+            {{ t('skills.deleteSkillConfirm', { name: skillToDelete?.name }) || `确定要删除 Skill "${skillToDelete?.name}" 吗？此操作无法撤销。` }}
           </CardDescription>
         </CardHeader>
         <CardFooter class="flex justify-end gap-3 pt-4">
@@ -502,7 +365,6 @@ import {
   Trash2,
   User,
   Shield,
-  Bot,
   Edit,
   LayoutGrid,
   List,
@@ -578,12 +440,8 @@ const {
   counts,
   displayedSkills,
   isImportDisabled,
-  groupedAgentSkills,
 
   // Methods
-  getDimensionBadgeVariant,
-  getDimensionIcon,
-  getDimensionLabel,
   canEdit,
   canDelete,
   openImportModal,

--- a/change_log.md
+++ b/change_log.md
@@ -1,4 +1,6 @@
 
+2026-04-14 修复 Web 端技能列表页保存后卡住：移除 Agent 维度 Tab 及 getAgents 并行调用，loadSkills 改为仅调 getSkills；保存/导入/删除后静默刷新不再全屏 loading。
+
 2026-04-14 提取 agent 工作空间路径管理为独立模块 `agent_workspace.py`，重构 chat_service/skill_service/agent_service 统一调用新接口；server 模式下新增技能自动同步逻辑；content-script.js 加 IIFE 初始化守卫防重复执行。
 
 2026-02-22 12:40:00 Prompts Update: Enhanced Fibre Sub-Agent (Strand) prompts to include full Orchestrator capabilities (planning, decomposition, delegation) while retaining mandatory task result reporting requirement.


### PR DESCRIPTION
## Summary
- Remove `getAgents()` parallel call from `loadSkills()` in the web skill list page, which was causing the page to freeze when the agent API responded slowly
- Remove the Agent dimension tab and agent-grouped views from SkillList, keeping only System and User tabs
- Add silent refresh mode to `loadSkills()` so save/import/delete operations refresh data in the background without showing a full-screen loading spinner

## Test plan
- [ ] Open the web skill list page and verify only "System" and "User" tabs are shown
- [ ] Edit a skill, save it, and confirm the page does not freeze
- [ ] Import a skill and confirm the list refreshes without full-screen loading
- [ ] Delete a skill and confirm the list refreshes without full-screen loading

Made with [Cursor](https://cursor.com)