### PR TITLE
feat(agent): delete host workspace when removing agent

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -1,4 +1,6 @@
 
+2026-04-16 delete_agent 在删除 DB 记录后调用 delete_agent_workspace_on_host，清理宿主机上该 Agent 工作区（desktop/server）；与本地/直通/远程 bind 挂载路径一致；未镜像到宿主机的纯远端数据不在此删除。
+
 2026-04-15 新增 POST /api/skills/sync-workspace-skills 接口，支持按 Agent 配置批量同步 skills 到 workspace，purge_extra 可清理多余 skill；server 与 desktop 共用同一业务逻辑。
 
 2026-04-14 修复 Web 端技能列表页保存后卡住：移除 Agent 维度 Tab 及 getAgents 并行调用，loadSkills 改为仅调 getSkills；保存/导入/删除后静默刷新不再全屏 loading。

--- a/common/services/agent_service.py
+++ b/common/services/agent_service.py
@@ -501,6 +501,72 @@ async def update_agent(
     return orm_obj
 
 
+def _remove_agent_workspace_directory(
+    workspace_path: Path,
+    agent_id: str,
+    user_id: str,
+) -> Dict[str, Any]:
+    """删除单个 Agent 工作区目录（若存在）。返回与 delete_server_agent_workspace 一致的结构。"""
+    wp_str = str(workspace_path)
+    if not workspace_path.exists():
+        return {
+            "agent_id": agent_id,
+            "user_id": user_id,
+            "workspace_path": wp_str,
+            "deleted": False,
+        }
+    shutil.rmtree(workspace_path)
+    logger.info(
+        f"已删除Agent工作空间: agent_id={agent_id}, user_id={user_id}, path={wp_str}"
+    )
+    return {
+        "agent_id": agent_id,
+        "user_id": user_id,
+        "workspace_path": wp_str,
+        "deleted": True,
+    }
+
+
+def delete_agent_workspace_on_host(agent_id: str, user_id: str = "") -> Dict[str, Any]:
+    """
+    删除当前 app_mode 下 Agent 在宿主机上的工作区目录。
+
+    本地/直通沙箱直接使用该路径；远程沙箱若通过 workspace_mount 将宿主机目录绑定到容器，
+    删除宿主机目录即可同步清理挂载内容。未镜像到本机路径的纯远端数据不在此处理。
+    """
+    cfg = _get_cfg()
+    if cfg.app_mode == "desktop":
+        workspace_path = Path(
+            get_agent_workspace_root(
+                agent_id,
+                app_mode="desktop",
+                ensure_exists=False,
+            )
+        )
+        return _remove_agent_workspace_directory(workspace_path, agent_id, user_id or "")
+
+    uid = (user_id or "").strip()
+    if not uid:
+        logger.warning(
+            f"删除 Agent 工作空间跳过: server 模式缺少 user_id, agent_id={agent_id}"
+        )
+        return {
+            "agent_id": agent_id,
+            "user_id": "",
+            "workspace_path": "",
+            "deleted": False,
+        }
+    workspace_path = Path(
+        get_agent_workspace_root(
+            agent_id,
+            user_id=uid,
+            app_mode="server",
+            ensure_exists=False,
+        )
+    )
+    return _remove_agent_workspace_directory(workspace_path, agent_id, uid)
+
+
 async def delete_agent(
     agent_id: str,
     user_id: Optional[str] = None,
@@ -528,7 +594,13 @@ async def delete_agent(
             error_detail="forbidden",
         )
 
+    owner_uid = existing_config.user_id or user_id or ""
     await dao.delete_by_id(agent_id)
+    try:
+        delete_agent_workspace_on_host(agent_id, owner_uid)
+    except Exception as e:
+        logger.error(
+            f"删除 Agent 工作空间失败: agent_id={agent_id}, error={e}")
     logger.info(f"Agent {agent_id} 删除成功")
     return existing_config
 
@@ -987,22 +1059,7 @@ async def delete_server_agent_file(agent_id: str, user_id: str, file_path: str) 
 
 async def delete_server_agent_workspace(agent_id: str, user_id: str) -> Dict[str, Any]:
     workspace_path = Path(get_server_agent_workspace_path(agent_id, user_id))
-    if not workspace_path.exists():
-        return {
-            "agent_id": agent_id,
-            "user_id": user_id,
-            "workspace_path": str(workspace_path),
-            "deleted": False,
-        }
-
-    shutil.rmtree(workspace_path)
-    logger.info(f"已删除Agent工作空间: agent_id={agent_id}, user_id={user_id}, path={workspace_path}")
-    return {
-        "agent_id": agent_id,
-        "user_id": user_id,
-        "workspace_path": str(workspace_path),
-        "deleted": True,
-    }
+    return _remove_agent_workspace_directory(workspace_path, agent_id, user_id)
 
 
 async def get_desktop_file_workspace(agent_id: str) -> Dict[str, Any]:

--- a/common/services/test_agent_service_workspace_delete.py
+++ b/common/services/test_agent_service_workspace_delete.py
@@ -48,3 +48,27 @@ def test_delete_server_agent_workspace_returns_false_when_missing(tmp_path, monk
     assert result["deleted"] is False
     assert result["agent_id"] == "agent_demo"
     assert result["user_id"] == "user_a"
+
+
+def test_delete_agent_workspace_on_host_desktop_removes_tree(tmp_path, monkeypatch):
+    agents_root = tmp_path / "agents_mount"
+    agents_root.mkdir()
+    monkeypatch.setenv("SAGE_AGENTS_PATH", str(agents_root))
+    cfg = config.StartupConfig(
+        app_mode="desktop",
+        logs_dir=str(tmp_path / "logs"),
+        session_dir=str(tmp_path / "sessions"),
+        agents_dir=str(tmp_path / "agents_unused"),
+        skill_dir=str(tmp_path / "skills"),
+        user_dir=str(tmp_path / "users"),
+    )
+    monkeypatch.setattr(config, "_GLOBAL_STARTUP_CONFIG", cfg, raising=False)
+
+    ws = agents_root / "agent_desktop"
+    ws.mkdir()
+    (ws / "x.txt").write_text("z", encoding="utf-8")
+
+    result = agent_service.delete_agent_workspace_on_host("agent_desktop", "")
+
+    assert result["deleted"] is True
+    assert not ws.exists()


### PR DESCRIPTION
Deletes the agent workspace on disk after removing the agent record (desktop and server). Refactors shared rmtree helper; adds desktop test for delete_agent_workspace_on_host.