### PR TITLE
Refactor session registry and fix Fibre backend delegation

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -1,4 +1,7 @@
 
+2026-04-17 修复 desktop 模式下 populate_request_from_agent_config 用 agent 的 systemContext 直接覆盖 request.system_context，导致子 session 的 parent_session_id 等字段丢失；改为统一 merge（request 值优先）。同时 Fibre 子 session 冲突检查改为按 parent_session_id 判断，允许同一父 session 复用已结束的子 session_id；_delegate_task_via_backend 对流式 tool_calls.arguments 的空串/不完整 JSON 跳过而不再报 ERROR。
+2026-04-16 修复 Fibre 多层后端委派：parent_session_id 自动从 system_context 提取；子 session 不再继承父的 custom_sub_agents，改由后端 auto_all 自动配置；server 端 populate_request 补齐 auto_all 扩展逻辑；create_agent 处理"已存在"返回视为成功。
+2026-04-16 重构 SessionManager：用 SQLite 中央注册表（sessions_index.sqlite）替换内存字典 _all_session_paths 和启动全量扫描，首次启动自动迁移；Fibre delegate_tasks 增加手动 session_id 全局冲突校验。
 2026-04-16 移除 `sagents/agent/agent_base.py` 中未使用的 `User` 导入，避免 sagents 依赖 `common.models`。
 2026-04-16 delete_agent 在删除 DB 记录后调用 delete_agent_workspace_on_host，清理宿主机上该 Agent 工作区（desktop/server）；与本地/直通/远程 bind 挂载路径一致；未镜像到宿主机的纯远端数据不在此删除。
 

--- a/common/services/chat_service.py
+++ b/common/services/chat_service.py
@@ -565,10 +565,7 @@ async def populate_request_from_agent_config(
         if agent_config.get("moreSuggest") is not None and request.more_suggest is None:
             request.more_suggest = agent_config.get("moreSuggest")
         if agent_config.get("systemContext") is not None:
-            if _is_desktop_mode():
-                request.system_context = agent_config.get("systemContext")
-            else:
-                _merge_dict(request, "system_context", agent_config.get("systemContext"))
+            _merge_dict(request, "system_context", agent_config.get("systemContext"))
         if agent_config.get("systemPrefix") is not None:
             request.system_prefix = agent_config.get("systemPrefix")
         if agent_config.get("memoryType") is not None:
@@ -577,6 +574,20 @@ async def populate_request_from_agent_config(
             request.available_knowledge_bases = agent_config.get("availableKnowledgeBases")
         if agent_config.get("availableSubAgentIds") is not None and request.available_sub_agent_ids is None:
             request.available_sub_agent_ids = agent_config.get("availableSubAgentIds")
+
+        # auto_all: when subAgentSelectionMode is "auto_all" (or defaults to it),
+        # auto-populate available_sub_agent_ids with all agents (excluding self)
+        if request.agent_mode == "fibre" and not request.available_sub_agent_ids:
+            selection_mode = agent_config.get("subAgentSelectionMode") or agent_config.get("sub_agent_selection_mode")
+            configured_ids = agent_config.get("availableSubAgentIds")
+            if selection_mode is None:
+                selection_mode = "manual" if configured_ids else "auto_all"
+            if selection_mode == "auto_all":
+                all_agents = await AgentConfigDao().get_all()
+                request.available_sub_agent_ids = [
+                    a.agent_id for a in all_agents
+                    if a.agent_id and a.agent_id != request.agent_id
+                ]
 
     if request.agent_name is None:
         request.agent_name = "Sage Assistant"

--- a/sagents/agent/fibre/backend_client.py
+++ b/sagents/agent/fibre/backend_client.py
@@ -129,10 +129,8 @@ class FibreBackendClient:
                     logger.info(f"[Backend API] Create agent response: status={resp.status}, body={resp_text}")
                     if resp.status == 200:
                         data = json.loads(resp_text)
-                        # Check success by "success" field or "code" field
                         is_success = data.get("success") or data.get("code") == 200
                         if is_success:
-                            # 后端返回的 data 可能是对象或包含 agent_id 的字符串
                             resp_data = data.get("data")
                             if isinstance(resp_data, dict):
                                 return resp_data.get("agent_id", agent_id)
@@ -140,6 +138,15 @@ class FibreBackendClient:
                                 return resp_data
                             else:
                                 return agent_id
+                    # "已存在" means the agent is already stored in backend — treat as success
+                    try:
+                        err_data = json.loads(resp_text)
+                        err_msg = err_data.get("message", "") or err_data.get("error_detail", "")
+                        if "已存在" in err_msg:
+                            logger.info(f"[Backend API] Agent '{name}' already exists in backend, treating as stored")
+                            return agent_id
+                    except (json.JSONDecodeError, AttributeError):
+                        pass
                     logger.warning(f"Failed to create agent via backend: {resp_text}")
                     return None
         except Exception as e:

--- a/sagents/agent/fibre/orchestrator.py
+++ b/sagents/agent/fibre/orchestrator.py
@@ -671,6 +671,17 @@ class FibreOrchestrator:
                 validation_errors.append(f"Task {i}: Agent '{agent_id}' not found")
                 continue
             
+            # Global conflict check: if session_id already registered under a DIFFERENT parent, reject
+            existing_workspace = self.sub_session_manager.get_session_workspace(session_id)
+            if existing_workspace:
+                registered_parent = self.sub_session_manager.get_parent_session_id(session_id)
+                if registered_parent and registered_parent != caller_session_id:
+                    validation_errors.append(
+                        f"Task {i}: Session ID '{session_id}' already belongs to parent session '{registered_parent}'. "
+                        f"Please choose a different session_id or leave it empty for auto-generation."
+                    )
+                    continue
+
             # Check if session is already running (only for internal sessions)
             # Note: Backend-managed sessions are not tracked in sub_session_manager
             existing_session = self.sub_session_manager.get_live_session(session_id)
@@ -929,6 +940,9 @@ class FibreOrchestrator:
             parent_ctx.pop('当前AgentId', None)
             parent_ctx.pop('private_workspace', None)
             parent_ctx.pop('file_permission', None)
+            # 子 session 应从后端 list_agents 拉取可用 agent，而非继承父 session 配置后重复创建
+            parent_ctx.pop('custom_sub_agents', None)
+            parent_ctx.pop('available_sub_agents', None)
             system_context.update(parent_ctx)
 
         # Set external_paths (current task's workspace)
@@ -974,18 +988,21 @@ class FibreOrchestrator:
 
                 for chunk in chunks:
                     if chunk.tool_calls:
-                        logger.debug(f"[Orchestrator] Chunk has tool_calls: {chunk.tool_calls}")
                         for tc in chunk.tool_calls:
                             func_name = tc.get("function", {}).get("name") if isinstance(tc, dict) else getattr(getattr(tc, "function", None), "name", None)
-                            logger.debug(f"[Orchestrator] Checking tool call: {func_name}")
                             if func_name == "sys_finish_task":
-                                args_str = tc.get("function", {}).get("arguments", "{}") if isinstance(tc, dict) else getattr(getattr(tc, "function", None), "arguments", "{}")
+                                args_str = tc.get("function", {}).get("arguments", "") if isinstance(tc, dict) else getattr(getattr(tc, "function", None), "arguments", "")
+                                # 流式传输中 arguments 是按 chunk 累积的，可能为空或不完整 JSON；
+                                # 只在可解析为完整 JSON 时更新结果
+                                if not args_str or not args_str.strip():
+                                    continue
                                 try:
                                     args = json.loads(args_str)
-                                    task_result = f"Task finished: {args.get('status')}. Result: {args.get('result')}"
-                                    logger.info(f"[Orchestrator] sys_finish_task called with status={args.get('status')}, result={args.get('result')[:200]}...")
-                                except Exception as e:
-                                    logger.error(f"Error parsing sys_finish_task arguments: {e}")
+                                except json.JSONDecodeError:
+                                    continue
+                                task_result = f"Task finished: {args.get('status')}. Result: {args.get('result')}"
+                                result_preview = str(args.get('result') or '')[:200]
+                                logger.info(f"[Orchestrator] sys_finish_task called with status={args.get('status')}, result={result_preview}...")
 
             if parent_session and parent_session.should_interrupt():
                 return f"SubSessionID: {session_id}\nInterrupted by parent session"

--- a/sagents/session_registry.py
+++ b/sagents/session_registry.py
@@ -1,0 +1,147 @@
+"""
+SQLite-backed central registry for session ID → workspace path mapping.
+
+Replaces the in-memory dict ``_all_session_paths`` that previously required
+a full directory scan on every startup.
+"""
+
+import os
+import sqlite3
+import threading
+import time
+from typing import Dict, Optional
+
+from sagents.utils.logger import logger
+
+
+class SessionRegistry:
+    """Thread-safe SQLite registry that maps session_id to its workspace path.
+
+    Paths are stored as **relative paths** under ``root_dir`` so the registry
+    remains valid even if ``root_dir`` is moved to a different location.
+    """
+
+    _CREATE_TABLE = """
+        CREATE TABLE IF NOT EXISTS sessions (
+            session_id       TEXT PRIMARY KEY,
+            workspace        TEXT NOT NULL,
+            parent_session_id TEXT,
+            created_at       REAL NOT NULL
+        )
+    """
+
+    def __init__(self, db_path: str, root_dir: str):
+        self._db_path = db_path
+        self._root_dir = os.path.abspath(root_dir)
+        self._lock = threading.Lock()
+        os.makedirs(os.path.dirname(db_path) or ".", exist_ok=True)
+        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute(self._CREATE_TABLE)
+        self._conn.commit()
+
+    def _to_relative(self, workspace: str) -> str:
+        """Convert an absolute workspace path to a path relative to root_dir."""
+        abs_ws = os.path.abspath(workspace)
+        try:
+            return os.path.relpath(abs_ws, self._root_dir)
+        except ValueError:
+            return abs_ws
+
+    def _to_absolute(self, rel_path: str) -> str:
+        """Convert a stored relative path back to an absolute path."""
+        if os.path.isabs(rel_path):
+            return rel_path
+        return os.path.join(self._root_dir, rel_path)
+
+    def register(
+        self,
+        session_id: str,
+        workspace: str,
+        parent_session_id: Optional[str] = None,
+    ) -> None:
+        rel_ws = self._to_relative(workspace)
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT INTO sessions (session_id, workspace, parent_session_id, created_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(session_id) DO UPDATE SET
+                    workspace = excluded.workspace,
+                    parent_session_id = COALESCE(excluded.parent_session_id, sessions.parent_session_id)
+                """,
+                (session_id, rel_ws, parent_session_id, time.time()),
+            )
+            self._conn.commit()
+
+    def register_batch(
+        self,
+        entries: list,
+    ) -> None:
+        """Bulk-insert ``[(session_id, workspace, parent_session_id), ...]``."""
+        now = time.time()
+        with self._lock:
+            self._conn.executemany(
+                """
+                INSERT OR IGNORE INTO sessions (session_id, workspace, parent_session_id, created_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                [(sid, self._to_relative(ws), pid, now) for sid, ws, pid in entries],
+            )
+            self._conn.commit()
+
+    def get_workspace(self, session_id: str) -> Optional[str]:
+        """Return the **absolute** workspace path for *session_id*, or ``None``."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT workspace FROM sessions WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+        return self._to_absolute(row[0]) if row else None
+
+    def exists(self, session_id: str) -> bool:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT 1 FROM sessions WHERE session_id = ? LIMIT 1",
+                (session_id,),
+            ).fetchone()
+        return row is not None
+
+    def is_sub_session(self, session_id: str) -> bool:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT parent_session_id FROM sessions WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+        return row is not None and row[0] is not None
+
+    def get_parent_session_id(self, session_id: str) -> Optional[str]:
+        """Return the parent_session_id for *session_id*, or ``None``."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT parent_session_id FROM sessions WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+        return row[0] if row else None
+
+    def remove(self, session_id: str) -> None:
+        with self._lock:
+            self._conn.execute(
+                "DELETE FROM sessions WHERE session_id = ?",
+                (session_id,),
+            )
+            self._conn.commit()
+
+    def list_all(self) -> Dict[str, str]:
+        """Return ``{session_id: absolute_workspace_path}``."""
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT session_id, workspace FROM sessions"
+            ).fetchall()
+        return {row[0]: self._to_absolute(row[1]) for row in rows}
+
+    def close(self) -> None:
+        try:
+            self._conn.close()
+        except Exception:
+            pass

--- a/sagents/session_runtime.py
+++ b/sagents/session_runtime.py
@@ -435,6 +435,11 @@ class Session:
         skill_manager: Optional[Union[SkillManager, SkillProxy]],
         parent_session_id: Optional[str] = None,
     ) -> SessionContext:
+        if not parent_session_id and system_context:
+            parent_session_id = system_context.get("parent_session_id")
+            if parent_session_id:
+                logger.info(f"SessionRuntime: 从 system_context 中提取 parent_session_id={parent_session_id}")
+
         if self.session_context:
             self._cache_session_workspace(session_id, self.session_context)
             if tool_manager:
@@ -856,7 +861,11 @@ class Session:
         try:
             manager = get_global_session_manager()
             if manager:
-                manager.cache_session_workspace(session_id, session_context.session_workspace)
+                manager.cache_session_workspace(
+                    session_id,
+                    session_context.session_workspace,
+                    parent_session_id=getattr(session_context, 'parent_session_id', None),
+                )
         except Exception as e:
             logger.warning(f"SAgent: 缓存会话路径失败: {e}")
 
@@ -886,46 +895,52 @@ class SessionManager:
         self.session_root_space = str(session_root_space)
         self.enable_obs = enable_obs
         self._sessions: Dict[str, Session] = {}
-        # 格式: {session_id: workspace_path}
-        self._all_session_paths: Dict[str, str] = {}
-        self._scan_all_sessions()
 
-    def _scan_all_sessions(self):
-        """启动时扫描所有会话（根会话+子会话），建立 ID 到 workspace 的映射"""
+        from sagents.session_registry import SessionRegistry
+        db_path = os.path.join(self.session_root_space, "sessions_index.sqlite")
+        need_migrate = not os.path.exists(db_path)
+        os.makedirs(self.session_root_space, exist_ok=True)
+        self._registry = SessionRegistry(db_path, root_dir=self.session_root_space)
+        if need_migrate:
+            self._migrate_from_filesystem()
+
+    def _migrate_from_filesystem(self):
+        """One-time migration: scan existing directories and populate the SQLite registry."""
         if not os.path.exists(self.session_root_space):
             logger.info(f"SessionManager: Session root space does not exist: {self.session_root_space}")
             return
-        
-        logger.debug(f"SessionManager: Scanning all sessions in {self.session_root_space}")
-        
+
+        logger.info(f"SessionManager: Migrating existing sessions from {self.session_root_space} into SQLite registry")
+        entries = []
         for entry in os.listdir(self.session_root_space):
             entry_path = os.path.join(self.session_root_space, entry)
             if not os.path.isdir(entry_path):
                 continue
-                
-            # 检查是否是根会话
+
             if os.path.exists(os.path.join(entry_path, "session_context.json")) or os.path.exists(os.path.join(entry_path, "messages.json")):
-                self._all_session_paths[entry] = entry_path
-                logger.debug(f"Found root session: {entry}")
-            
-            # 扫描子会话
+                entries.append((entry, entry_path, None))
+                logger.debug(f"Migrating root session: {entry}")
+
             sub_sessions_dir = os.path.join(entry_path, "sub_sessions")
             if os.path.exists(sub_sessions_dir):
                 for sub_entry in os.listdir(sub_sessions_dir):
                     sub_entry_path = os.path.join(sub_sessions_dir, sub_entry)
                     if os.path.isdir(sub_entry_path):
                         if os.path.exists(os.path.join(sub_entry_path, "session_context.json")) or os.path.exists(os.path.join(sub_entry_path, "messages.json")):
-                            self._all_session_paths[sub_entry] = sub_entry_path
-                            logger.debug(f"Found sub session: {sub_entry}")
-        
-        logger.info(f"SessionManager: Found {len(self._all_session_paths)} sessions total")
+                            entries.append((sub_entry, sub_entry_path, entry))
+                            logger.debug(f"Migrating sub session: {sub_entry}")
+
+        if entries:
+            self._registry.register_batch(entries)
+        logger.info(f"SessionManager: Migrated {len(entries)} sessions into SQLite registry")
 
     def _is_sub_session(self, session_id: str) -> bool:
-        """判断是否为子会话（通过检查路径是否包含 sub_sessions）"""
-        if session_id not in self._all_session_paths:
-            return False
-        path = self._all_session_paths[session_id]
-        return "sub_sessions" in path
+        """判断是否为子会话"""
+        return self._registry.is_sub_session(session_id)
+
+    def get_parent_session_id(self, session_id: str) -> Optional[str]:
+        """获取父会话 ID"""
+        return self._registry.get_parent_session_id(session_id)
 
     def get_session_workspace(self, session_id: str, only_all_session_paths: bool = False) -> Optional[str]:
         """
@@ -933,27 +948,17 @@ class SessionManager:
         
         Args:
             session_id: 会话 ID（全局唯一）
+            only_all_session_paths: 保留参数以兼容旧调用，行为不变
         
         Returns:
             工作区路径，找不到则返回 None
         """
-        # 1. 首先尝试从内存缓存获取
-        if session_id in self._all_session_paths:
-            return self._all_session_paths[session_id]
-        if only_all_session_paths:
-            return None
-        # 2. 如果内存中没有，重新扫描会话目录
-        # 这处理了会话在其他进程中创建的情况
-        logger.debug(f"SessionManager: Session {session_id} not in cache, rescanning...")
-        self._scan_all_sessions()
-        
-        # 3. 再次尝试获取
-        return self._all_session_paths.get(session_id)
+        return self._registry.get_workspace(session_id)
 
-    def cache_session_workspace(self, session_id: str, session_workspace: Optional[str]):
+    def cache_session_workspace(self, session_id: str, session_workspace: Optional[str], parent_session_id: Optional[str] = None):
         if not session_id or not session_workspace:
             return
-        self._all_session_paths[session_id] = os.path.abspath(session_workspace)
+        self._registry.register(session_id, session_workspace, parent_session_id=parent_session_id)
 
     def get_or_create(
         self,


### PR DESCRIPTION
## Summary
- Replace in-memory `_all_session_paths` with a SQLite-backed `SessionRegistry` (paths stored relative to `session_root_space`) and migrate on first startup.
- Fix Fibre backend delegation so sub-sessions are correctly nested under their parent: propagate `parent_session_id` through `system_context`, stop desktop mode from wholesale-overwriting `request.system_context`, and refine the global sub-session conflict check to key off `parent_session_id`.
- Make Fibre sub-agent selection consistent with the UI: `auto_all` is auto-populated in the shared `populate_request_from_agent_config`, `create_agent` treats "already exists" as success, and sub-sessions no longer inherit the parent's `custom_sub_agents`.
- Also covers earlier branch work: remove unused `User` import from `AgentBase`; delete host workspace when removing an agent.

## Test plan
- [ ] Desktop + backend: delegate a task from a root session to a sub-agent via backend; verify the sub-session is created under `<parent>/sub_sessions/<sub_id>` and `parent_session_id` is set in `session_context.json`.
- [ ] Delegate two levels deep (sub → sub-sub); verify both layers go through backend API and nesting is correct.
- [ ] Re-use a finished sub-session id under the same parent; verify no conflict error, but cross-parent reuse still rejected.
- [ ] Restart server; verify `sessions_index.sqlite` is created / migrated and `get_session_workspace` returns without a full filesystem scan.
- [ ] `auto_all` agent on server: starting a chat pulls in every other agent as custom sub-agent; `manual` mode still respects the configured list.
- [ ] Remove an agent; verify host workspace under `~/.sage/agents/<agent_id>` is cleaned up.

Made with [Cursor](https://cursor.com)