### PR TITLE
fix: align CLI skill visibility with runtime

### DIFF
--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -133,6 +133,7 @@ def build_argument_parser() -> argparse.ArgumentParser:
 
     skills_parser = subparsers.add_parser("skills", help="List available CLI skills")
     skills_parser.add_argument("--user-id", dest="user_id", default=default_user_id)
+    skills_parser.add_argument("--agent-id", dest="agent_id", help="Show the skills currently available to a specific agent")
     skills_parser.add_argument("--workspace", dest="workspace", help="Include skills from a specific workspace directory")
     skills_parser.add_argument("--json", action="store_true", help="Print skills as JSON")
 
@@ -360,12 +361,13 @@ async def _stream_request(request, json_output: bool, stats_output: bool, worksp
     return 0
 
 
-def _build_request(args: argparse.Namespace, task: str):
+async def _build_request(args: argparse.Namespace, task: str):
     from app.cli.service import build_run_request, validate_requested_skills
 
-    skills = validate_requested_skills(
+    skills = await validate_requested_skills(
         requested_skills=args.skills,
         user_id=args.user_id,
+        agent_id=args.agent_id,
         workspace=args.workspace,
     )
 
@@ -383,9 +385,9 @@ def _build_request(args: argparse.Namespace, task: str):
 async def _run_command(args: argparse.Namespace) -> int:
     from app.cli.service import cli_runtime, validate_cli_runtime_requirements
 
-    request = _build_request(args, args.task)
-    validate_cli_runtime_requirements()
     async with cli_runtime(verbose=args.verbose):
+        validate_cli_runtime_requirements()
+        request = await _build_request(args, args.task)
         await _stream_request(request, args.json, args.stats, workspace=args.workspace)
     return 0
 
@@ -436,8 +438,8 @@ async def _chat_command(args: argparse.Namespace) -> int:
                 print(args.session_id)
                 continue
 
-            request = _build_request(args, prompt)
             validate_cli_runtime_requirements()
+            request = await _build_request(args, prompt)
             await _stream_request(request, args.json, args.stats, workspace=args.workspace)
     return 0
 
@@ -545,15 +547,29 @@ async def _sessions_command(args: argparse.Namespace) -> int:
     return 0
 
 
-def _skills_command(args: argparse.Namespace) -> int:
-    from app.cli.service import list_available_skills
+async def _skills_command(args: argparse.Namespace) -> int:
+    from app.cli.service import cli_db_runtime, list_available_skills
 
-    result = list_available_skills(user_id=args.user_id, workspace=args.workspace)
+    if args.agent_id:
+        async with cli_db_runtime(verbose=False):
+            result = await list_available_skills(
+                user_id=args.user_id,
+                agent_id=args.agent_id,
+                workspace=args.workspace,
+            )
+    else:
+        result = await list_available_skills(
+            user_id=args.user_id,
+            agent_id=None,
+            workspace=args.workspace,
+        )
     if args.json:
         print(json.dumps(result, ensure_ascii=False, indent=2))
         return 0
 
     print(f"user_id: {result['user_id']}")
+    if result.get("agent_id"):
+        print(f"agent_id: {result['agent_id']}")
     if result.get("workspace"):
         print(f"workspace: {result['workspace']}")
     print(f"total: {result.get('total', 0)}")
@@ -629,7 +645,7 @@ async def _main_async(args: argparse.Namespace) -> int:
         if args.command == "sessions":
             return await _sessions_command(args)
         if args.command == "skills":
-            return _skills_command(args)
+            return await _skills_command(args)
         if args.command == "config" and args.config_command == "show":
             return _config_show_command(args)
         if args.command == "config" and args.config_command == "init":

--- a/app/cli/service.py
+++ b/app/cli/service.py
@@ -254,6 +254,7 @@ def collect_doctor_info() -> Dict[str, Any]:
     env_files = [shared_env_file]
     if os.path.exists(project_env_file):
         env_files.append(project_env_file)
+    session_registry_db = os.path.join(cfg.session_dir, "sessions_index.sqlite")
     dependency_status = _dependency_status()
     issues = _collect_runtime_issues(cfg)
     status = "ok"
@@ -280,6 +281,8 @@ def collect_doctor_info() -> Dict[str, Any]:
         "agents_dir_exists": os.path.exists(cfg.agents_dir),
         "session_dir": cfg.session_dir,
         "session_dir_exists": os.path.exists(cfg.session_dir),
+        "session_registry_db": session_registry_db,
+        "session_registry_db_exists": os.path.exists(session_registry_db),
         "logs_dir": cfg.logs_dir,
         "logs_dir_exists": os.path.exists(cfg.logs_dir),
         "dependencies": dependency_status,
@@ -296,6 +299,7 @@ def collect_config_info() -> Dict[str, Any]:
     env_files = [shared_env_file]
     if os.path.exists(project_env_file):
         env_files.append(project_env_file)
+    session_registry_db = os.path.join(cfg.session_dir, "sessions_index.sqlite")
     return {
         "env_file": effective_env_file,
         "env_files": env_files,
@@ -308,6 +312,7 @@ def collect_config_info() -> Dict[str, Any]:
         "default_llm_model_name": cfg.default_llm_model_name,
         "agents_dir": cfg.agents_dir,
         "session_dir": cfg.session_dir,
+        "session_registry_db": session_registry_db,
         "logs_dir": cfg.logs_dir,
         "env_sources": {
             "SAGE_HOME": local_defaults["sage_home"],
@@ -463,15 +468,51 @@ async def list_sessions(
     }
 
 
-def list_available_skills(
+async def list_available_skills(
     *,
     user_id: Optional[str] = None,
+    agent_id: Optional[str] = None,
     workspace: Optional[str] = None,
 ) -> Dict[str, Any]:
     from sagents.skill.skill_manager import SkillManager
 
     cfg = init_cli_config(init_logging=False)
     resolved_user_id = user_id or get_default_cli_user_id()
+    if agent_id:
+        from common.services import skill_service
+
+        agent_skills = await skill_service.get_agent_available_skills(
+            agent_id=agent_id,
+            current_user_id=resolved_user_id,
+            role="admin" if resolved_user_id == "admin" else "user",
+        )
+        skills = []
+        source_counts: Dict[str, int] = {}
+        for item in agent_skills:
+            source_name = item.get("source_dimension") or item.get("dimension") or "unknown"
+            source_counts[source_name] = source_counts.get(source_name, 0) + 1
+            skills.append(
+                {
+                    "name": item.get("name"),
+                    "description": item.get("description"),
+                    "source": source_name,
+                    "path": item.get("path"),
+                    "need_update": bool(item.get("need_update")),
+                    "agent_id": agent_id,
+                }
+            )
+        skills.sort(key=lambda item: item["name"] or "")
+        return {
+            "user_id": resolved_user_id,
+            "agent_id": agent_id,
+            "workspace": None,
+            "sources": [],
+            "total": len(skills),
+            "source_counts": source_counts,
+            "list": skills,
+            "errors": [],
+        }
+
     skill_sources: List[Dict[str, Any]] = []
     skills_map: Dict[str, Dict[str, Any]] = {}
 
@@ -523,6 +564,7 @@ def list_available_skills(
 
     return {
         "user_id": resolved_user_id,
+        "agent_id": None,
         "workspace": os.path.abspath(workspace) if workspace else None,
         "sources": skill_sources,
         "total": len(skills),
@@ -532,22 +574,25 @@ def list_available_skills(
     }
 
 
-def validate_requested_skills(
+async def validate_requested_skills(
     *,
     requested_skills: Optional[List[str]],
     user_id: Optional[str] = None,
+    agent_id: Optional[str] = None,
     workspace: Optional[str] = None,
 ) -> List[str]:
     normalized = [skill.strip() for skill in (requested_skills or []) if skill and skill.strip()]
     if not normalized:
         return []
 
-    result = list_available_skills(user_id=user_id, workspace=workspace)
+    result = await list_available_skills(user_id=user_id, agent_id=agent_id, workspace=workspace)
     available_names = {item["name"] for item in result.get("list", [])}
     missing = [skill for skill in normalized if skill not in available_names]
     if missing:
         available_display = ", ".join(sorted(available_names)) if available_names else "(none)"
         next_steps = ["Run `sage skills` to inspect currently visible skills."]
+        if agent_id:
+            next_steps[0] = f"Run `sage skills --agent-id {agent_id}` to inspect the skills currently available to that agent."
         if workspace:
             next_steps.append(
                 f"Run `sage skills --workspace {os.path.abspath(workspace)}` to inspect workspace skills."

--- a/docs/en/CLI.md
+++ b/docs/en/CLI.md
@@ -124,6 +124,7 @@ It reports:
 - effective env file path and existence
 - auth mode and DB type
 - important directories such as `agents_dir`, `session_dir`, and `logs_dir`
+- the SQLite session registry path under `session_dir`
 - dependency availability
 - runtime errors, warnings, and suggested next steps
 
@@ -247,16 +248,20 @@ Examples:
 sage skills
 sage skills --json
 sage skills --workspace /path/to/project
+sage skills --agent-id my-agent
 ```
 
 The output includes:
 
 - current user id
+- optional agent id
 - optional workspace
 - total visible skills
 - per-source counts
 - skill names and descriptions
 - source-level errors, if any
+
+When `--agent-id` is provided, the CLI shows the skills currently available to that specific agent after the newer agent-skill sync logic is applied.
 
 ## Skills In CLI
 

--- a/docs/zh/CLI.md
+++ b/docs/zh/CLI.md
@@ -124,6 +124,7 @@ sage run --user-id alice --stats "用一句话介绍你自己。"
 - 实际生效的环境文件路径和是否存在
 - auth mode 和 db type
 - `agents_dir`、`session_dir`、`logs_dir` 等关键目录
+- `session_dir` 下的 SQLite session registry 路径
 - 依赖是否可用
 - 运行时错误、警告和建议下一步
 
@@ -247,16 +248,20 @@ sage sessions inspect --messages 8 <session_id>
 sage skills
 sage skills --json
 sage skills --workspace /path/to/project
+sage skills --agent-id my-agent
 ```
 
 输出会包含：
 
 - 当前用户 id
+- 可选的 agent id
 - 可选的 workspace
 - 当前可见 skill 总数
 - 每个 source 下的数量
 - skill 名称和描述
 - source 层面的错误信息（如果有）
+
+当传入 `--agent-id` 时，CLI 会按当前 Agent 实际可用的 skill 集合来展示结果，而不是只看本地可见 skill。
 
 ## CLI 中的 Skill
 


### PR DESCRIPTION
## Summary
- align `sage skills` with the newer runtime/agent skill visibility model
- add `sage skills --agent-id ...` to inspect the skills actually available to a specific agent
- validate `--skill` against agent-scoped skill availability when `--agent-id` is provided
- expose the new session registry database path in `sage doctor` and `sage config show`
- update the CLI guide in both English and Chinese

## Background
Recent upstream changes introduced:
- a new session registry backed by SQLite
- newer agent-skill sync behavior
- runtime/session internals that changed the effective source of truth for some CLI-facing information

The CLI command surface did not need a broad refactor, but a few places became misaligned with the new runtime behavior.

## What Changed

### 1. `sage skills --agent-id`
The CLI now supports:

```bash
sage skills --agent-id <agent_id>
```

This shows the skills actually available to a specific agent after the newer agent-skill sync logic is applied, instead of only listing locally
visible skill directories.

### 2. Agent-aware --skill validation

When run, chat, or resume is used with both:

- --agent-id
- --skill

the requested skills are now validated against the current agent-visible skill set instead of only the generic local skill list.

This prevents a mismatch where:

- the CLI previously accepted a skill as locally visible
- but that skill was not actually available to the selected agent at runtime

### 3. Better runtime/session visibility in CLI diagnostics

doctor and config show now include the new session registry database path:

- session_registry_db
- session_registry_db_exists

This makes it easier to reason about the newer session runtime layout and diagnose CLI/session issues.

### 4. CLI docs updated

The dedicated CLI guide was updated in:

- docs/en/CLI.md
- docs/zh/CLI.md

The guide now documents:

- sage skills --agent-id
- the new session registry visibility in diagnostics

## Scope

This PR stays inside the CLI and CLI docs layer:

- app/cli/main.py
- app/cli/service.py
- docs/en/CLI.md
- docs/zh/CLI.md

It does not attempt to refactor shared runtime behavior. It only aligns the CLI with already-merged runtime/session/skill changes.

## Validation

- python -m py_compile app/cli/main.py app/cli/service.py
- python -m app.cli.main --help
- python -m app.cli.main skills --help
- python -m app.cli.main skills --json
- python -m app.cli.main doctor
- python -m app.cli.main config show

## Notes

A small regression was also fixed while doing this work:

- plain sage skills remains lightweight
- only sage skills --agent-id ... needs the heavier runtime/database path"