### PR TITLE
fix(desktop): classify user vs system skills and reorder tabs

### DIFF
--- a/app/desktop/core/bootstrap.py
+++ b/app/desktop/core/bootstrap.py
@@ -87,9 +87,17 @@ async def initialize_skill_manager():
         sage_skills_dir = user_home / ".sage" / "skills"
         sage_skills_dir.mkdir(parents=True, exist_ok=True)
         
-        # 添加到 skill manager
+        # 添加到 skill manager（内置/同步至 ~/.sage/skills，与 cfg.skill_dir 一致）
         skill_manager_instance.add_skill_dir(str(sage_skills_dir))
         logger.info(f"已添加技能目录: {sage_skills_dir}")
+
+        # 用户导入的技能目录（与 server 的 user_dir/<userId>/skills 一致，便于 list_skills 区分「我的」）
+        cfg = get_startup_config()
+        if cfg:
+            user_skills_dir = Path(cfg.user_dir) / DEFAULT_DESKTOP_USER_ID / "skills"
+            user_skills_dir.mkdir(parents=True, exist_ok=True)
+            skill_manager_instance.add_skill_dir(str(user_skills_dir))
+            logger.info(f"已添加用户技能目录: {user_skills_dir}")
         
         return skill_manager_instance
     except Exception as e:

--- a/app/desktop/ui/src/views/SkillList.vue
+++ b/app/desktop/ui/src/views/SkillList.vue
@@ -347,25 +347,31 @@ const editingSkill = ref(null)
 const skillContent = ref('')
 const saving = ref(false)
 
-// Groups Configuration
+const isMineSkill = (s) => {
+  if (s?.dimension) return s.dimension !== 'system'
+  return !!(s?.user_id || s?.owner_user_id)
+}
+const isSystemSkill = (s) => !isMineSkill(s)
+
+// Groups Configuration（顺序：我的技能、系统技能、全部技能）
 const groups = computed(() => [
-  { 
-    id: 'all', 
-    label: t('skills.allSkills') || 'All Skills', 
+  {
+    id: 'mine',
+    label: t('skills.mySkills') || 'My Skills',
+    icon: User,
+    count: skills.value.filter(isMineSkill).length
+  },
+  {
+    id: 'system',
+    label: t('skills.systemSkills') || 'System Skills',
+    icon: Shield,
+    count: skills.value.filter(isSystemSkill).length
+  },
+  {
+    id: 'all',
+    label: t('skills.allSkills') || 'All Skills',
     icon: Layers,
     count: skills.value.length
-  },
-  { 
-    id: 'mine', 
-    label: t('skills.mySkills') || 'My Skills', 
-    icon: User,
-    count: skills.value.filter(s => s.user_id === currentUserId.value).length
-  },
-  { 
-    id: 'system', 
-    label: t('skills.systemSkills') || 'System Skills', 
-    icon: Shield,
-    count: skills.value.filter(s => s.user_id !== currentUserId.value).length
   }
 ])
 
@@ -375,9 +381,9 @@ const displayedSkills = computed(() => {
 
   // Group filtering
   if (selectedGroup.value === 'mine') {
-    result = result.filter(s => s.user_id === currentUserId.value)
+    result = result.filter(isMineSkill)
   } else if (selectedGroup.value === 'system') {
-    result = result.filter(s => s.user_id !== currentUserId.value)
+    result = result.filter(isSystemSkill)
   }
 
   // Search filtering

--- a/change_log.md
+++ b/change_log.md
@@ -1,4 +1,6 @@
 
+2026-04-17 桌面端技能列表：前端按后端 `dimension` 字段判定我的/系统（不再依赖前端拿不到的 userid），分类正确；Tab 顺序调整为「我的技能 → 系统技能 → 全部技能」。
+2026-04-17 桌面端技能：用户 ZIP 导入写入 `~/.sage/users/<用户>/skills`，`list_skills` 返回 `user_id`/`dimension`；`SkillManager` 注册新技能时在所有 skill 目录中解析路径，与「我的技能/系统技能」筛选及同步到 Agent 逻辑一致。
 2026-04-16 修复 SeatbeltIsolation/BwrapIsolation 同步 subprocess.run 阻塞 asyncio 事件循环导致服务无响应的严重 Bug，改为 async def + asyncio.to_thread 异步执行，与 SubprocessIsolation 保持一致。
 2026-04-16 移除 `sagents/agent/agent_base.py` 中未使用的 `User` 导入，避免 sagents 依赖 `common.models`。
 2026-04-16 delete_agent 在删除 DB 记录后调用 delete_agent_workspace_on_host，清理宿主机上该 Agent 工作区（desktop/server）；与本地/直通/远程 bind 挂载路径一致；未镜像到宿主机的纯远端数据不在此删除。

--- a/common/services/skill_service.py
+++ b/common/services/skill_service.py
@@ -136,6 +136,23 @@ def _is_desktop_mode() -> bool:
     return _get_cfg().app_mode == "desktop"
 
 
+def _desktop_user_skills_root(user_id: str) -> str:
+    """Desktop 用户技能目录：与 server 的 user_dir/<id>/skills 一致。"""
+    cfg = _get_cfg()
+    return os.path.normpath(os.path.join(cfg.user_dir, user_id, "skills"))
+
+
+def _desktop_skill_owner_user_id(skill_path: str, current_user_id: str) -> str:
+    """根据磁盘路径判断是否为当前用户的技能（用于 list_skills）。"""
+    if not current_user_id:
+        return ""
+    root = _desktop_user_skills_root(current_user_id)
+    sp = os.path.normpath(skill_path)
+    if sp == root or sp.startswith(root + os.sep):
+        return current_user_id
+    return ""
+
+
 def _set_permissions_recursive(path: str, dir_mode: int = 0o755, file_mode: int = 0o644) -> None:
     try:
         if os.path.isdir(path):
@@ -376,10 +393,20 @@ async def list_skills(
         # Disabled temporarily: do not auto-sync agent workspace skills into ~/.sage/skills during desktop skill listing.
         # _sync_desktop_agent_skills()
         tm.reload()
-        return [
-            {"name": skill.name, "description": skill.description}
-            for skill in list(tm.list_skill_info())
-        ]
+        out: List[Dict[str, Any]] = []
+        for skill in list(tm.list_skill_info()):
+            uid = _desktop_skill_owner_user_id(skill.path, current_user_id)
+            out.append(
+                {
+                    "name": skill.name,
+                    "description": skill.description,
+                    "user_id": uid,
+                    "dimension": "user" if uid else "system",
+                    "owner_user_id": uid or None,
+                    "path": skill.path,
+                }
+            )
+        return out
 
     all_skills = _collect_server_skills()
     allowed_skills = None
@@ -1124,7 +1151,9 @@ async def _process_server_zip_to_dir(
             shutil.rmtree(temp_extract_dir)
 
 
-async def _process_desktop_zip_and_register(tm: Any, zip_path: str, original_filename: str) -> Tuple[bool, str]:
+async def _process_desktop_zip_and_register(
+    tm: Any, zip_path: str, original_filename: str, user_id: str
+) -> Tuple[bool, str]:
     temp_extract_dir = tempfile.mkdtemp()
     try:
         with zipfile.ZipFile(zip_path, "r") as zip_ref:
@@ -1134,9 +1163,12 @@ async def _process_desktop_zip_and_register(tm: Any, zip_path: str, original_fil
         if not skill_dir_name or not source_dir:
             return False, "未找到有效的技能结构 (缺少 SKILL.md)"
 
-        sage_skills_dir = Path.home() / ".sage" / "skills"
-        sage_skills_dir.mkdir(parents=True, exist_ok=True)
-        target_path = os.path.join(str(sage_skills_dir), skill_dir_name)
+        if not user_id:
+            return False, "桌面端导入技能需要有效的用户 ID"
+
+        user_skills_root = _desktop_user_skills_root(user_id)
+        os.makedirs(user_skills_root, exist_ok=True)
+        target_path = os.path.join(user_skills_root, skill_dir_name)
         if os.path.exists(target_path):
             try:
                 shutil.rmtree(target_path)
@@ -1183,7 +1215,9 @@ async def import_skill_by_file(
             tm = get_skill_manager()
             if not tm:
                 raise SageHTTPException(status_code=500, detail="技能管理器未初始化")
-            success, message = await _process_desktop_zip_and_register(tm, tmp_file_path, file.filename)
+            success, message = await _process_desktop_zip_and_register(
+                tm, tmp_file_path, file.filename, user_id
+            )
         else:
             cfg = _get_cfg()
             if is_agent and agent_id:
@@ -1242,7 +1276,9 @@ async def import_skill_by_url(
             tm = get_skill_manager()
             if not tm:
                 raise SageHTTPException(status_code=500, detail="技能管理器未初始化")
-            success, message = await _process_desktop_zip_and_register(tm, tmp_file_path, filename)
+            success, message = await _process_desktop_zip_and_register(
+                tm, tmp_file_path, filename, user_id
+            )
         else:
             cfg = _get_cfg()
             if is_agent and agent_id:

--- a/sagents/skill/skill_manager.py
+++ b/sagents/skill/skill_manager.py
@@ -355,15 +355,19 @@ class SkillManager:
         Returns:
             Optional[str]: The skill name if successful, None otherwise
         """
-        # 使用第一个 skill_dirs 作为默认工作区
         if not self.skill_dirs:
             logger.error("No skill directories configured")
             return None
-        
-        skill_workspace = self.skill_dirs[0]
-        skill_path = os.path.join(skill_workspace, skill_dir_name)
-        if not os.path.exists(skill_path):
-            logger.error(f"Skill directory not found: {skill_path}")
+
+        # Prefer later-added workspaces (e.g. desktop user skills dir after system dir)
+        skill_path = None
+        for workspace in reversed(self.skill_dirs):
+            candidate = os.path.join(workspace, skill_dir_name)
+            if os.path.exists(candidate):
+                skill_path = candidate
+                break
+        if not skill_path:
+            logger.error(f"Skill directory not found for '{skill_dir_name}' in any skill workspace")
             return None
 
         skill_name = self._load_skill_from_dir(skill_path)


### PR DESCRIPTION
## Summary
- Route desktop ZIP/URL skill imports to `~/.sage/users/<userId>/skills` so user uploads are distinguishable from default system skills
- Desktop `list_skills` returns `user_id` / `dimension` / `path`; `SkillManager.register_new_skill` resolves the skill dir across all configured workspaces (user dir wins on name collision)
- Bootstrap registers the per-user skills directory with the global SkillManager
- Frontend `SkillList.vue` classifies via the `dimension` field (instead of the missing desktop `userid`) and reorders tabs to: My Skills → System Skills → All Skills

## Test plan
- [ ] Fresh desktop launch: default skills appear under "系统技能"
- [ ] Import a ZIP/URL skill → appears under "我的技能"; counts add up in "全部技能"
- [ ] Tab order is My / System / All; switching tabs filters correctly
- [ ] Existing sync-to-agent flow still finds user skill (user dir preferred over system)


Made with [Cursor](https://cursor.com)