### PR TITLE
feat(chat): slash-trigger skill picker anywhere with multi-skill support

### DIFF
--- a/app/desktop/ui/src/components/chat/ChipInput.vue
+++ b/app/desktop/ui/src/components/chat/ChipInput.vue
@@ -11,8 +11,10 @@
     spellcheck="false"
     @input="handleInput"
     @keydown="forward('keydown', $event)"
+    @keyup="onCaretActivity('keyup', $event)"
+    @click="onCaretActivity('click', $event)"
     @paste="forward('paste', $event)"
-    @focus="forward('focus', $event)"
+    @focus="onCaretActivity('focus', $event)"
     @blur="forward('blur', $event)"
     @compositionstart="onCompositionStart"
     @compositionend="onCompositionEnd"
@@ -36,7 +38,8 @@ const emit = defineEmits([
   'compositionstart',
   'compositionend',
   'focus',
-  'blur'
+  'blur',
+  'caret-update'
 ])
 
 const editorRef = ref(null)
@@ -146,11 +149,44 @@ const readText = () => {
   return root ? nodeToText(root) : ''
 }
 
+// 记录最近一次落在编辑器内的光标 range，便于失焦后（如点击下拉选项）仍能精确删除/恢复。
+let lastRange = null
+const rememberCaret = () => {
+  const root = editorRef.value
+  if (!root) return
+  const sel = window.getSelection()
+  if (!sel || sel.rangeCount === 0) return
+  const r = sel.getRangeAt(0)
+  if (root.contains(r.endContainer)) {
+    lastRange = r.cloneRange()
+  }
+}
+
+const restoreCaret = () => {
+  if (!lastRange) return false
+  const root = editorRef.value
+  if (!root || !root.contains(lastRange.endContainer)) return false
+  const sel = window.getSelection()
+  if (!sel) return false
+  sel.removeAllRanges()
+  sel.addRange(lastRange.cloneRange())
+  return true
+}
+
 const handleInput = () => {
   if (isComposing.value) return
   const text = readText()
-  if (text === props.modelValue) return
-  emit('update:modelValue', text)
+  if (text !== props.modelValue) emit('update:modelValue', text)
+  rememberCaret()
+  emit('caret-update', { source: 'input' })
+}
+
+const onCaretActivity = (source, e) => {
+  if (source === 'focus') emit('focus', e)
+  if (isComposing.value) return
+  // 在 keyup/click/focus 时通知父组件重新计算 slash query 等基于光标的状态
+  rememberCaret()
+  emit('caret-update', { source })
 }
 
 const onCompositionStart = (e) => {
@@ -298,12 +334,69 @@ const setText = (text) => {
   emit('update:modelValue', text || '')
 }
 
+/** 取出"从编辑器开头到当前光标"之间的扁平文本（chip 会渲染为占位符 `![name](attachment://id)`）。 */
+const getTextBeforeCaret = () => {
+  const root = editorRef.value
+  if (!root) return ''
+  const sel = window.getSelection()
+  if (!sel || sel.rangeCount === 0) return ''
+  const range = sel.getRangeAt(0)
+  if (!root.contains(range.endContainer)) return ''
+  const r = document.createRange()
+  r.setStart(root, 0)
+  r.setEnd(range.endContainer, range.endOffset)
+  const tmp = document.createElement('div')
+  tmp.appendChild(r.cloneContents())
+  return nodeToText(tmp)
+}
+
+/**
+ * 检测光标紧挨着的 slash 查询，例如输入 "hello /sea" 光标在 'a' 后会返回 { keyword: 'sea', deleteLength: 4 }。
+ * 仅当 `/` 出现在行首或空白后才视为 slash 命令，避免与 URL 等结构冲突。
+ */
+const SKILL_QUERY_RE = /(?:^|[\s])\/([^\s/<>]*)$/
+const getSkillQuery = () => {
+  const text = getTextBeforeCaret()
+  const m = text.match(SKILL_QUERY_RE)
+  if (!m) return null
+  return { keyword: m[1] || '', deleteLength: (m[1] || '').length + 1 }
+}
+
+/** 删除光标前 N 个字符（基于 Selection.modify，过 chip/换行也按 1 字符跨过）。 */
+const deleteCharsBeforeCaret = (n) => {
+  if (!n || n <= 0) return
+  const root = editorRef.value
+  if (!root) return
+  // 调用时编辑器可能已失焦（例如点击 popup 选项），先聚焦并恢复上次记忆的 caret。
+  root.focus()
+  const sel = window.getSelection()
+  if (!sel) return
+  const inside = sel.rangeCount > 0 && root.contains(sel.getRangeAt(0).endContainer)
+  if (!inside) {
+    if (!restoreCaret()) return
+  }
+  if (typeof sel.modify !== 'function' || sel.rangeCount === 0) return
+  if (!sel.isCollapsed) sel.collapseToEnd()
+  for (let i = 0; i < n; i++) {
+    sel.modify('extend', 'backward', 'character')
+  }
+  if (sel.rangeCount > 0) {
+    sel.getRangeAt(0).deleteContents()
+    sel.collapseToStart()
+  }
+  rememberCaret()
+  handleInput()
+}
+
 defineExpose({
   focus: focusEditor,
   insertPlaceholder,
   insertText,
   setText,
-  getElement: () => editorRef.value
+  getElement: () => editorRef.value,
+  getTextBeforeCaret,
+  getSkillQuery,
+  deleteCharsBeforeCaret
 })
 </script>
 

--- a/app/desktop/ui/src/components/chat/MessageInput.vue
+++ b/app/desktop/ui/src/components/chat/MessageInput.vue
@@ -49,6 +49,7 @@
             :key="skill.name"
             class="px-4 py-2 cursor-pointer hover:bg-accent hover:text-accent-foreground flex items-center justify-between transition-colors text-sm"
             :class="{'bg-accent text-accent-foreground': index === selectedSkillIndex}"
+            @mousedown.prevent
             @click="selectSkill(skill)"
           >
             <div class="flex flex-col overflow-hidden">
@@ -60,13 +61,17 @@
       </div>
 
       <!-- 输入区域：包含技能标签和文本框 -->
-      <div class="flex items-start gap-2">
-        <!-- 选中的技能展示 -->
-        <div v-if="currentSkill" class="flex items-center gap-1 h-7 px-2.5 bg-primary/10 text-primary rounded-full text-xs font-medium whitespace-nowrap border border-primary/20 flex-shrink-0 mt-1">
-          <span class="max-w-[100px] truncate">@{{ currentSkill }}</span>
+      <div class="flex items-start gap-2 flex-wrap">
+        <!-- 选中的多个技能展示 -->
+        <div
+          v-for="(name, idx) in currentSkills"
+          :key="`skill-${idx}-${name}`"
+          class="flex items-center gap-1 h-7 px-2.5 bg-primary/10 text-primary rounded-full text-xs font-medium whitespace-nowrap border border-primary/20 flex-shrink-0 mt-1"
+        >
+          <span class="max-w-[100px] truncate">@{{ name }}</span>
           <button
             type="button"
-            @click="currentSkill = null"
+            @click="removeSkillAt(idx)"
             class="ml-0.5 w-3.5 h-3.5 flex items-center justify-center rounded-full hover:bg-primary/20"
           >
             <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
@@ -85,6 +90,7 @@
           @compositionstart="handleCompositionStart"
           @compositionend="handleCompositionEnd"
           @paste="handlePaste"
+          @caret-update="handleCaretUpdate"
         />
       </div>
 
@@ -248,7 +254,10 @@ const loadingSkills = ref(false)
 const skills = ref([])
 const selectedSkillIndex = ref(0)
 const skillKeyword = ref('')
-const currentSkill = ref(null)
+// 已选中的技能列表（按选择顺序），提交时全部以 <skill> 形式串联到头部。
+const currentSkills = ref([])
+// 当前命中的 slash 查询：{ keyword, deleteLength } —— deleteLength 用于在选中技能后从光标前删掉 `/keyword`。
+const activeSkillQuery = ref(null)
 
 const filteredSkills = computed(() => {
   // 获取 agent 配置的可用技能列表
@@ -279,14 +288,30 @@ watch(() => props.presetText, async (newVal) => {
   editorRef.value?.focus(true)
 })
 
-// 选中技能
+// 选中技能：将技能追加到列表，并把光标前 `/keyword` 字符串删除（保留其它正文）。
 const selectSkill = (skill) => {
-  currentSkill.value = skill.name
-  inputValue.value = ''
+  if (!skill || !skill.name) return
+  // 同名技能不重复追加，保留首次的位置即可
+  if (!currentSkills.value.includes(skill.name)) {
+    currentSkills.value = [...currentSkills.value, skill.name]
+  }
+  const query = activeSkillQuery.value
+  if (query && editorRef.value?.deleteCharsBeforeCaret) {
+    editorRef.value.deleteCharsBeforeCaret(query.deleteLength)
+  }
+  activeSkillQuery.value = null
   showSkillList.value = false
+  skillKeyword.value = ''
   nextTick(() => {
-    editorRef.value?.focus(true)
+    editorRef.value?.focus(false)
   })
+}
+
+const removeSkillAt = (idx) => {
+  if (idx < 0 || idx >= currentSkills.value.length) return
+  const next = currentSkills.value.slice()
+  next.splice(idx, 1)
+  currentSkills.value = next
 }
 
 // 文件上传相关状态
@@ -443,55 +468,74 @@ const processTauriFile = async (filePath) => {
   }
 }
 
-// 监听输入值变化
+// 解析粘贴/手动输入到头部的控制标签 + 多个连续 <skill>...</skill>
 const LEADING_CONTROL_TAG_RE = /^\s*(?:<enable_plan>\s*(?:true|false)\s*<\/enable_plan>\s*|<enable_deep_thinking>\s*(?:true|false)\s*<\/enable_deep_thinking>\s*)+/i
-const LEADING_SKILL_TAG_RE = /^<skill>(.*?)<\/skill>\s*/i
+const LEADING_SKILL_TAGS_RE = /^(?:\s*<skill>(.*?)<\/skill>\s*)+/i
+const SINGLE_SKILL_TAG_RE = /<skill>(.*?)<\/skill>/gi
 
-watch(inputValue, async (newVal) => {
-  // 如果在输入法组合状态中，不处理技能标签
+const ensureSkillsLoaded = async () => {
+  if (skills.value.length > 0 || loadingSkills.value) return
+  try {
+    loadingSkills.value = true
+    const res = await skillAPI.getSkills()
+    skills.value = Array.isArray(res?.skills) ? res.skills : []
+  } catch (error) {
+    console.error('获取技能列表失败:', error)
+    skills.value = []
+  } finally {
+    loadingSkills.value = false
+  }
+}
+
+watch(inputValue, (newVal) => {
   if (isComposing.value) return
-
-  // 检查是否包含技能标签（粘贴或手动输入）
+  // 头部如果出现一段连续的 <skill>xxx</skill>，自动剥离并并入 currentSkills（顺序保留、去重）
   const normalizedInput = newVal.replace(LEADING_CONTROL_TAG_RE, '')
-  const skillMatch = normalizedInput.match(LEADING_SKILL_TAG_RE)
-  if (skillMatch) {
-    currentSkill.value = skillMatch[1]
-    inputValue.value = normalizedInput.replace(skillMatch[0], '')
-    return
+  const skillBlock = normalizedInput.match(LEADING_SKILL_TAGS_RE)
+  if (!skillBlock) return
+  const names = []
+  let m
+  SINGLE_SKILL_TAG_RE.lastIndex = 0
+  while ((m = SINGLE_SKILL_TAG_RE.exec(skillBlock[0])) !== null) {
+    const name = (m[1] || '').trim()
+    if (name) names.push(name)
   }
-
-  if (newVal.startsWith('/')) {
-    const keyword = newVal.slice(1)
-    skillKeyword.value = keyword
-
-    // 如果技能列表为空，则获取
-    if (skills.value.length === 0 && !loadingSkills.value) {
-      try {
-        loadingSkills.value = true
-        console.log('Fetching skills...')
-        const res = await skillAPI.getSkills()
-        if (res.skills) {
-            skills.value = res.skills
-        }
-      } catch (error) {
-        console.error('获取技能列表失败:', error)
-        skills.value = []
-      } finally {
-        loadingSkills.value = false
-      }
-    }
-
-    showSkillList.value = true
-    selectedSkillIndex.value = 0
-  } else {
-    showSkillList.value = false
+  if (names.length === 0) return
+  const merged = currentSkills.value.slice()
+  for (const n of names) {
+    if (!merged.includes(n)) merged.push(n)
   }
+  currentSkills.value = merged
+  inputValue.value = normalizedInput.replace(skillBlock[0], '')
 })
 
+// 光标位置变化（input/keyup/click/focus）时，重新检测 slash 查询
+const handleCaretUpdate = async () => {
+  if (isComposing.value) return
+  const editor = editorRef.value
+  if (!editor || typeof editor.getSkillQuery !== 'function') {
+    activeSkillQuery.value = null
+    showSkillList.value = false
+    return
+  }
+  const query = editor.getSkillQuery()
+  if (!query) {
+    activeSkillQuery.value = null
+    showSkillList.value = false
+    return
+  }
+  activeSkillQuery.value = query
+  skillKeyword.value = query.keyword
+  selectedSkillIndex.value = 0
+  showSkillList.value = true
+  await ensureSkillsLoaded()
+}
+
 const buildHeadPrefix = () => {
+  // 多个 <skill> 标签按选择顺序串联，全部塞到头部
   let prefix = ''
-  if (currentSkill.value) {
-    prefix = `<skill>${currentSkill.value}</skill> `
+  if (currentSkills.value.length > 0) {
+    prefix = currentSkills.value.map(name => `<skill>${name}</skill>`).join(' ') + ' '
   }
   if (planEnabled.value) {
     prefix = `<enable_plan>true</enable_plan>` + (prefix ? ` ${prefix}` : '')
@@ -522,7 +566,7 @@ const hasSubmittableInput = () => {
   return Boolean(
     inputValue.value.trim() ||
     uploadedFiles.value.length > 0 ||
-    currentSkill.value
+    currentSkills.value.length > 0
   )
 }
 
@@ -532,7 +576,9 @@ const dispatchSubmit = (needInterrupt) => {
 
   inputValue.value = ''
   uploadedFiles.value = []
-  currentSkill.value = null
+  currentSkills.value = []
+  activeSkillQuery.value = null
+  showSkillList.value = false
 
   emit('sendMessage', plainText, {
     multimodalContent,
@@ -587,10 +633,10 @@ const handleKeyDown = (e) => {
     }
   }
 
-  // Backspace 删除技能（不在输入法组合状态时）
-  if (!composing && e.key === 'Backspace' && inputValue.value === '' && currentSkill.value) {
+  // Backspace：当输入为空时，删除最后一个已选技能（一次一个，符合 chip 行为）
+  if (!composing && e.key === 'Backspace' && inputValue.value === '' && currentSkills.value.length > 0) {
     e.preventDefault()
-    currentSkill.value = null
+    currentSkills.value = currentSkills.value.slice(0, -1)
     return
   }
 

--- a/app/server/web/src/components/chat/ChipInput.vue
+++ b/app/server/web/src/components/chat/ChipInput.vue
@@ -11,8 +11,10 @@
     spellcheck="false"
     @input="handleInput"
     @keydown="forward('keydown', $event)"
+    @keyup="onCaretActivity('keyup', $event)"
+    @click="onCaretActivity('click', $event)"
     @paste="forward('paste', $event)"
-    @focus="forward('focus', $event)"
+    @focus="onCaretActivity('focus', $event)"
     @blur="forward('blur', $event)"
     @compositionstart="onCompositionStart"
     @compositionend="onCompositionEnd"
@@ -36,7 +38,8 @@ const emit = defineEmits([
   'compositionstart',
   'compositionend',
   'focus',
-  'blur'
+  'blur',
+  'caret-update'
 ])
 
 const editorRef = ref(null)
@@ -146,11 +149,43 @@ const readText = () => {
   return root ? nodeToText(root) : ''
 }
 
+// 记录最近一次落在编辑器内的光标 range，便于失焦后（如点击下拉选项）仍能精确删除/恢复。
+let lastRange = null
+const rememberCaret = () => {
+  const root = editorRef.value
+  if (!root) return
+  const sel = window.getSelection()
+  if (!sel || sel.rangeCount === 0) return
+  const r = sel.getRangeAt(0)
+  if (root.contains(r.endContainer)) {
+    lastRange = r.cloneRange()
+  }
+}
+
+const restoreCaret = () => {
+  if (!lastRange) return false
+  const root = editorRef.value
+  if (!root || !root.contains(lastRange.endContainer)) return false
+  const sel = window.getSelection()
+  if (!sel) return false
+  sel.removeAllRanges()
+  sel.addRange(lastRange.cloneRange())
+  return true
+}
+
 const handleInput = () => {
   if (isComposing.value) return
   const text = readText()
-  if (text === props.modelValue) return
-  emit('update:modelValue', text)
+  if (text !== props.modelValue) emit('update:modelValue', text)
+  rememberCaret()
+  emit('caret-update', { source: 'input' })
+}
+
+const onCaretActivity = (source, e) => {
+  if (source === 'focus') emit('focus', e)
+  if (isComposing.value) return
+  rememberCaret()
+  emit('caret-update', { source })
 }
 
 const onCompositionStart = (e) => {
@@ -298,12 +333,66 @@ const setText = (text) => {
   emit('update:modelValue', text || '')
 }
 
+/** 取出"从编辑器开头到当前光标"之间的扁平文本（chip 渲染为占位符 `![name](attachment://id)`）。 */
+const getTextBeforeCaret = () => {
+  const root = editorRef.value
+  if (!root) return ''
+  const sel = window.getSelection()
+  if (!sel || sel.rangeCount === 0) return ''
+  const range = sel.getRangeAt(0)
+  if (!root.contains(range.endContainer)) return ''
+  const r = document.createRange()
+  r.setStart(root, 0)
+  r.setEnd(range.endContainer, range.endOffset)
+  const tmp = document.createElement('div')
+  tmp.appendChild(r.cloneContents())
+  return nodeToText(tmp)
+}
+
+/** 检测光标紧挨着的 slash 查询（仅当 `/` 出现在行首/空白后才识别，避免与 URL 冲突）。 */
+const SKILL_QUERY_RE = /(?:^|[\s])\/([^\s/<>]*)$/
+const getSkillQuery = () => {
+  const text = getTextBeforeCaret()
+  const m = text.match(SKILL_QUERY_RE)
+  if (!m) return null
+  return { keyword: m[1] || '', deleteLength: (m[1] || '').length + 1 }
+}
+
+/** 删除光标前 N 个字符（基于 Selection.modify）。 */
+const deleteCharsBeforeCaret = (n) => {
+  if (!n || n <= 0) return
+  const root = editorRef.value
+  if (!root) return
+  // 调用时编辑器可能已失焦（例如点击 popup 选项），先聚焦并恢复上次记忆的 caret。
+  root.focus()
+  const sel = window.getSelection()
+  if (!sel) return
+  const inside = sel.rangeCount > 0 && root.contains(sel.getRangeAt(0).endContainer)
+  if (!inside) {
+    if (!restoreCaret()) return
+  }
+  if (typeof sel.modify !== 'function' || sel.rangeCount === 0) return
+  if (!sel.isCollapsed) sel.collapseToEnd()
+  for (let i = 0; i < n; i++) {
+    sel.modify('extend', 'backward', 'character')
+  }
+  if (sel.rangeCount > 0) {
+    sel.getRangeAt(0).deleteContents()
+    sel.collapseToStart()
+  }
+  rememberCaret()
+  handleInput()
+}
+
 defineExpose({
   focus: focusEditor,
   insertPlaceholder,
   insertText,
   setText,
-  getElement: () => editorRef.value
+  getElement: () => editorRef.value,
+  getTextBeforeCaret,
+  getSkillQuery,
+  deleteCharsBeforeCaret
 })
 </script>
 

--- a/app/server/web/src/components/chat/MessageInput.vue
+++ b/app/server/web/src/components/chat/MessageInput.vue
@@ -46,6 +46,7 @@
             :key="skill.name"
             class="px-4 py-2 cursor-pointer hover:bg-accent hover:text-accent-foreground flex items-center justify-between transition-colors text-sm"
             :class="{ 'bg-accent text-accent-foreground': index === selectedSkillIndex }"
+            @mousedown.prevent
             @click="selectSkill(skill)"
           >
             <div class="flex flex-col overflow-hidden">
@@ -56,12 +57,16 @@
         </div>
       </div>
 
-      <div class="flex items-start gap-2">
-        <div v-if="currentSkill" class="flex items-center gap-1 h-7 px-2.5 bg-primary/10 text-primary rounded-full text-xs font-medium whitespace-nowrap border border-primary/20 flex-shrink-0 mt-1">
-          <span class="max-w-[100px] truncate">@{{ currentSkill }}</span>
+      <div class="flex items-start gap-2 flex-wrap">
+        <div
+          v-for="(name, idx) in currentSkills"
+          :key="`skill-${idx}-${name}`"
+          class="flex items-center gap-1 h-7 px-2.5 bg-primary/10 text-primary rounded-full text-xs font-medium whitespace-nowrap border border-primary/20 flex-shrink-0 mt-1"
+        >
+          <span class="max-w-[100px] truncate">@{{ name }}</span>
           <button
             type="button"
-            @click="currentSkill = null"
+            @click="removeSkillAt(idx)"
             class="ml-0.5 w-3.5 h-3.5 flex items-center justify-center rounded-full hover:bg-primary/20"
           >
             <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
@@ -80,6 +85,7 @@
           @compositionstart="handleCompositionStart"
           @compositionend="handleCompositionEnd"
           @paste="handlePaste"
+          @caret-update="handleCaretUpdate"
         />
       </div>
 
@@ -238,7 +244,10 @@ const loadingSkills = ref(false)
 const skills = ref([])
 const selectedSkillIndex = ref(0)
 const skillKeyword = ref('')
-const currentSkill = ref(null)
+// 已选中的技能列表（按选择顺序），提交时全部以 <skill> 形式串联到头部。
+const currentSkills = ref([])
+// 当前命中的 slash 查询：{ keyword, deleteLength } —— deleteLength 用于在选中技能后从光标前删掉 `/keyword`。
+const activeSkillQuery = ref(null)
 const uploadedFiles = ref([])
 const isComposing = ref(false)
 const isDraggingOver = ref(false)
@@ -259,7 +268,9 @@ watch(() => props.presetText, async (newVal) => {
 
 watch(() => props.agentId, () => {
   skills.value = []
-  currentSkill.value = null
+  currentSkills.value = []
+  activeSkillQuery.value = null
+  showSkillList.value = false
 })
 
 const toggleDeepThinking = () => {
@@ -285,12 +296,27 @@ const filteredSkills = computed(() => {
 })
 
 const selectSkill = (skill) => {
-  currentSkill.value = skill.name
-  inputValue.value = ''
+  if (!skill || !skill.name) return
+  if (!currentSkills.value.includes(skill.name)) {
+    currentSkills.value = [...currentSkills.value, skill.name]
+  }
+  const query = activeSkillQuery.value
+  if (query && editorRef.value?.deleteCharsBeforeCaret) {
+    editorRef.value.deleteCharsBeforeCaret(query.deleteLength)
+  }
+  activeSkillQuery.value = null
   showSkillList.value = false
+  skillKeyword.value = ''
   nextTick(() => {
-    editorRef.value?.focus(true)
+    editorRef.value?.focus(false)
   })
+}
+
+const removeSkillAt = (idx) => {
+  if (idx < 0 || idx >= currentSkills.value.length) return
+  const next = currentSkills.value.slice()
+  next.splice(idx, 1)
+  currentSkills.value = next
 }
 
 const getFileFromEntry = (fileEntry) => {
@@ -366,48 +392,70 @@ const handleDrop = async (e) => {
 }
 
 const LEADING_CONTROL_TAG_RE = /^\s*(?:<enable_plan>\s*(?:true|false)\s*<\/enable_plan>\s*|<enable_deep_thinking>\s*(?:true|false)\s*<\/enable_deep_thinking>\s*)+/i
-const LEADING_SKILL_TAG_RE = /^<skill>(.*?)<\/skill>\s*/i
+const LEADING_SKILL_TAGS_RE = /^(?:\s*<skill>(.*?)<\/skill>\s*)+/i
+const SINGLE_SKILL_TAG_RE = /<skill>(.*?)<\/skill>/gi
 
-watch(inputValue, async (newVal) => {
+const ensureSkillsLoaded = async () => {
+  if (skills.value.length > 0 || loadingSkills.value) return
+  try {
+    loadingSkills.value = true
+    const res = await skillAPI.getSkills({ agent_id: props.agentId })
+    skills.value = Array.isArray(res?.skills) ? res.skills : []
+  } catch (error) {
+    console.error('获取技能列表失败:', error)
+    skills.value = []
+  } finally {
+    loadingSkills.value = false
+  }
+}
+
+watch(inputValue, (newVal) => {
   if (isComposing.value) return
-
+  // 头部如果出现一段连续的 <skill>xxx</skill>，自动剥离并并入 currentSkills（顺序保留、去重）
   const normalizedInput = newVal.replace(LEADING_CONTROL_TAG_RE, '')
-  const skillMatch = normalizedInput.match(LEADING_SKILL_TAG_RE)
-  if (skillMatch) {
-    currentSkill.value = skillMatch[1]
-    inputValue.value = normalizedInput.replace(skillMatch[0], '')
+  const skillBlock = normalizedInput.match(LEADING_SKILL_TAGS_RE)
+  if (!skillBlock) return
+  const names = []
+  let m
+  SINGLE_SKILL_TAG_RE.lastIndex = 0
+  while ((m = SINGLE_SKILL_TAG_RE.exec(skillBlock[0])) !== null) {
+    const name = (m[1] || '').trim()
+    if (name) names.push(name)
+  }
+  if (names.length === 0) return
+  const merged = currentSkills.value.slice()
+  for (const n of names) {
+    if (!merged.includes(n)) merged.push(n)
+  }
+  currentSkills.value = merged
+  inputValue.value = normalizedInput.replace(skillBlock[0], '')
+})
+
+const handleCaretUpdate = async () => {
+  if (isComposing.value) return
+  const editor = editorRef.value
+  if (!editor || typeof editor.getSkillQuery !== 'function') {
+    activeSkillQuery.value = null
+    showSkillList.value = false
     return
   }
-
-  if (newVal.startsWith('/')) {
-    skillKeyword.value = newVal.slice(1)
-
-    if (skills.value.length === 0 && !loadingSkills.value) {
-      try {
-        loadingSkills.value = true
-        const res = await skillAPI.getSkills({ agent_id: props.agentId })
-        if (res.skills) {
-          skills.value = res.skills
-        }
-      } catch (error) {
-        console.error('获取技能列表失败:', error)
-        skills.value = []
-      } finally {
-        loadingSkills.value = false
-      }
-    }
-
-    showSkillList.value = true
-    selectedSkillIndex.value = 0
-  } else {
+  const query = editor.getSkillQuery()
+  if (!query) {
+    activeSkillQuery.value = null
     showSkillList.value = false
+    return
   }
-})
+  activeSkillQuery.value = query
+  skillKeyword.value = query.keyword
+  selectedSkillIndex.value = 0
+  showSkillList.value = true
+  await ensureSkillsLoaded()
+}
 
 const buildHeadPrefix = () => {
   let prefix = ''
-  if (currentSkill.value) {
-    prefix = `<skill>${currentSkill.value}</skill> `
+  if (currentSkills.value.length > 0) {
+    prefix = currentSkills.value.map(name => `<skill>${name}</skill>`).join(' ') + ' '
   }
   if (planEnabled.value) {
     prefix = `<enable_plan>true</enable_plan>` + (prefix ? ` ${prefix}` : '')
@@ -438,7 +486,7 @@ const hasSubmittableInput = () => {
   return Boolean(
     inputValue.value.trim() ||
     uploadedFiles.value.length > 0 ||
-    currentSkill.value
+    currentSkills.value.length > 0
   )
 }
 
@@ -448,7 +496,9 @@ const dispatchSubmit = (needInterrupt) => {
 
   inputValue.value = ''
   uploadedFiles.value = []
-  currentSkill.value = null
+  currentSkills.value = []
+  activeSkillQuery.value = null
+  showSkillList.value = false
 
   emit('sendMessage', plainText, {
     multimodalContent,
@@ -499,9 +549,10 @@ const handleKeyDown = (e) => {
     }
   }
 
-  if (!composing && e.key === 'Backspace' && inputValue.value === '' && currentSkill.value) {
+  // Backspace：当输入为空时，删除最后一个已选技能
+  if (!composing && e.key === 'Backspace' && inputValue.value === '' && currentSkills.value.length > 0) {
     e.preventDefault()
-    currentSkill.value = null
+    currentSkills.value = currentSkills.value.slice(0, -1)
     return
   }
 

--- a/change_log.md
+++ b/change_log.md
@@ -1,4 +1,8 @@
 
+2026-04-17 修复 slash 触发选中后 `/` 未删除：点击下拉项时 contenteditable 失焦导致 Selection.modify 失效。下拉项加 `@mousedown.prevent` 阻止失焦；ChipInput 同时记录 lastRange，`deleteCharsBeforeCaret` 在调用时主动 focus + 必要时恢复 range，键鼠两条路径都能正确删掉触发的 `/keyword`。
+
+2026-04-17 输入框任意位置 `/` 触发技能选择 + 多技能支持：ChipInput 增加基于光标的 `getSkillQuery` / `deleteCharsBeforeCaret`（用 Selection.modify 跨 chip 安全删除），并在 input/keyup/click 抛 `caret-update`。MessageInput 用 `currentSkills` 数组承载多个技能 chip，选中后自动删除光标前 `/keyword`，提交时把所有 `<skill>name</skill>` 串联到消息头部；解析支持多个连续 `<skill>` 标签，Backspace 在空输入时逐个回删。Web 与 Desktop 同步。
+
 2026-04-17 修复 ChipInput 附件 chip 看起来"裸字"问题：chip 节点是 JS createElement 动态生成的，不带 Vue scoped 的 data-v 属性，导致 `<style scoped>` 里的 `.chip-input__chip` 选择器全部失效。把 chip 相关样式拆到非 scoped `<style>` 块，同时把外观调成更明显的卡片：圆角矩形 + 主题色细描边 + 半透明底 + 轻投影 + hover 反馈。Web 与 Desktop 同步。
 
 2026-04-17 桌面端图片走 HTTP 静态化与 server 端统一：sidecar 新增 `GET /api/oss/file/{agent_id}/{filename}`，`POST /api/oss/upload` 改为返回 `http://127.0.0.1:<port>/api/oss/file/...` URL；agent_base `_process_multimodal_content` 把 localhost 的 sage 文件 URL 反解回 `~/.sage/agents/<agent_id>/upload_files/<filename>` 再走"本地图片→base64"，避免远程 LLM 拉不到 localhost。前端 desktop MessageRenderer 删除 convertFileSrc/isLocalPath 分支，与 server-web 共用同一份 `<img src="http(s)://...">` 渲染路径。


### PR DESCRIPTION
## Summary
- Trigger the skill picker on `/` at any caret position (not just at the start of the input), so users can mention skills mid-sentence.
- Support selecting multiple skills; each selection becomes a removable chip and all chips are emitted at the message head as `<skill>name</skill>` tags (in order, de-duplicated).
- Fix: when selecting a skill via mouse click, the triggering `/keyword` is now correctly removed. The dropdown items use `@mousedown.prevent` to keep the editor focused, and `ChipInput.deleteCharsBeforeCaret` re-focuses + restores the saved caret range as a defensive fallback.

## Implementation notes
- `ChipInput` exposes `getTextBeforeCaret`, `getSkillQuery`, `deleteCharsBeforeCaret` and emits a new `caret-update` event from input/keyup/click/focus.
- `MessageInput` switches `currentSkill` (single) → `currentSkills` (array). Backspace on empty input pops the last chip. Pasting `<skill>...</skill> <skill>...</skill> ...` at the head is auto-extracted into chips.
- Slash regex requires `/` to be at start or right after whitespace, so URLs like `https://...` won't trigger the picker.
- Mirrored across `app/desktop/ui` and `app/server/web`.

## Test plan
- [ ] Type `hello /` mid-sentence → picker appears; arrow keys navigate; Enter selects.
- [ ] Click a skill in the picker → `/keyword` is removed and a chip appears.
- [ ] Add multiple different skills → multiple chips, all sent as `<skill>...</skill> <skill>...</skill> ...` at head on submit.
- [ ] Backspace on empty input removes the last chip one at a time.
- [ ] Paste `<skill>foo</skill> <skill>bar</skill> hi` → 2 chips + remaining text.
- [ ] URLs containing `/` (e.g. `https://example.com/x`) do not trigger the picker.
