### PR TITLE
fix(session): clear stale interrupt state on new run

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -1,4 +1,6 @@
 
+2026-04-17 修复中断会话后续请求秒退：load_persisted_state 不再把磁盘 INTERRUPTED 状态翻译成 interrupt_event.set()；set_status(RUNNING) 进入新轮次时主动清掉残留 interrupt_event/interrupt_reason/audit_status；删除 Session 中重复定义的 request_interrupt 死代码。
+
 2026-04-17 SandboxSkillManager.sync_from_host 改为按需补齐：沙箱已有 skill 直接加载（保留手改），缺失时才从宿主 SkillSchema.path 拷一次；同时移除 chat_service 每次 prompt 都同步技能到 workspace 的逻辑（统一改由 agent 编辑页 create/update 触发），desktop / server 行为一致。
 
 2026-04-17 修复 search_memory 卡顿：ISandboxHandle 新增 get_mtime（默认基于 list_directory(parent)），Local/Passthrough provider override 为 os.path.getmtime；MemoryIndex._get_dir_mtime 改走 sandbox.get_mtime，不再每个目录都启 sandbox-exec 跑 stat，递归扫描从秒级降到近瞬时，且不破坏沙箱抽象。

--- a/sagents/session_runtime.py
+++ b/sagents/session_runtime.py
@@ -141,6 +141,17 @@ class Session:
         self.status = status
         if status == SessionStatus.INTERRUPTED:
             self.interrupt_event.set()
+        elif status == SessionStatus.RUNNING:
+            # 进入新的运行周期，清掉历史中断状态（可能来自上一轮被中断后持久化的状态）
+            if self.interrupt_event.is_set() or self.interrupt_reason:
+                logger.info(
+                    f"SessionRuntime: Session {self.session_id} entering RUNNING, "
+                    f"clearing stale interrupt state (reason={self.interrupt_reason!r})"
+                )
+            self.interrupt_event.clear()
+            self.interrupt_reason = None
+            if self.session_context and isinstance(getattr(self.session_context, "audit_status", None), dict):
+                self.session_context.audit_status.pop("interrupt_reason", None)
         if self.session_context:
             self.session_context.end_time = time.time() if status in {SessionStatus.COMPLETED, SessionStatus.ERROR, SessionStatus.INTERRUPTED} else self.session_context.end_time
         if status in {SessionStatus.COMPLETED, SessionStatus.ERROR, SessionStatus.INTERRUPTED}:
@@ -162,14 +173,6 @@ class Session:
                         logger.warning(
                             f"SessionRuntime: cascade {status.value} to child session {child_session_id} failed: {exc}"
                         )
-
-    def request_interrupt(self, message: str = "用户请求中断", cascade: bool = True) -> bool:
-        self.interrupt_reason = message
-        if self.session_context:
-            self.session_context.audit_status["interrupt_reason"] = message
-        self.interrupt_event.set()
-        self.set_status(SessionStatus.INTERRUPTED, cascade=cascade)
-        return True
 
     def should_interrupt(self) -> bool:
         if self.interrupt_event.is_set():
@@ -275,8 +278,11 @@ class Session:
                 if isinstance(agent_config, dict):
                     self.session_context.agent_config = agent_config
                 self.session_context.message_manager.messages = self._load_persisted_messages()
-                if self.status == SessionStatus.INTERRUPTED:
-                    self.interrupt_event.set()
+                # 注意：这里不再根据持久化的 INTERRUPTED 状态去 set interrupt_event。
+                # interrupt_event 是用于"当前运行周期"的中断信号，磁盘里的 INTERRUPTED 仅是上一轮
+                # 结束时的历史状态。如果在加载时把 event 置位，下一次新的 run_stream 进入时即使
+                # set_status(RUNNING)，FlowExecutor 仍会因 should_interrupt() 为 True 而立刻退出。
+                # 当前轮次是否需要中断，由 SessionManager.interrupt_session(...) 在运行期再次触发。
             except Exception as exc:
                 logger.warning(f"SessionRuntime: 恢复 session {self.session_id} 快照失败: {exc}")
                 return False


### PR DESCRIPTION
## Summary

修复"上一次会话被中断后，下一次发消息会立刻在 FlowExecutor 入口被打成 `interrupted before executing sequence` 并秒退"的问题。

根因：`Session.load_persisted_state()` 在从磁盘恢复时，只要持久化的 `status == INTERRUPTED`，就会调用 `self.interrupt_event.set()`。但 `interrupt_event` 是用于**当前运行周期**的实时信号，磁盘里的 `INTERRUPTED` 仅是上一轮结束时的历史状态。结果新一轮 `run_stream_with_flow` 即使调用了 `set_status(RUNNING)`，`should_interrupt()` 仍因 event 已 set 而返回 True，FlowExecutor 立刻退出。

## Changes

- `load_persisted_state`：不再根据持久化的 `INTERRUPTED` 状态去 `interrupt_event.set()`；当前轮次是否需要中断，由 `SessionManager.interrupt_session(...)` 在运行期再次触发。
- `set_status(RUNNING)`：进入新运行周期时主动清掉残留的 `interrupt_event` / `interrupt_reason` / `audit_status["interrupt_reason"]`，并打 INFO 日志便于观测；作为防御性兜底，覆盖"内存里复用了带旧状态的 Session/Context"的边界情况。
- 移除 `Session` 中重复定义的 `request_interrupt`（前一个被后一个静默覆盖，是死代码）。
- `change_log.md` 追加日志一行。

## Test plan

- [ ] 复现路径：触发一次会话中断 → 该会话写盘 `status=INTERRUPTED` → 用同一 `session_id` 再次发送消息 → 不再出现 `FlowExecutor: session ... interrupted before executing sequence`，且对话能正常进入 agent 流程。
- [ ] 中断本身仍然有效：在新一轮运行中点击中断 → `interrupt_session` 能正常将 event 置位并停在下一个检查点。
- [ ] 子会话级联中断不受影响（`set_status` 的 cascade 分支未改）。


Made with [Cursor](https://cursor.com)