### PR TITLE
feat(sandbox): live-stream shell stdout + fix tool_call merge + todo granularity

### DIFF
--- a/app/desktop/ui/src/components/chat/MessageRenderer.vue
+++ b/app/desktop/ui/src/components/chat/MessageRenderer.vue
@@ -877,14 +877,8 @@ watch(() => props.message, (newMessage, oldMessage) => {
           alt: file.fileName,
           name: file.fileName
         } : file
-  })
-})
-
-watch(isEditingThisUserMessage, (isEditing) => {
-  if (isEditing) {
-    editingContent.value = getTextContent(props.message.content)
-  }
-})
+      })
+    })
   }
 
   // 3. 处理代码块（实时流中代码块可能在消息更新时出现）
@@ -913,6 +907,12 @@ watch(isEditingThisUserMessage, (isEditing) => {
     })
   }
 }, { deep: true })
+
+watch(isEditingThisUserMessage, (isEditing) => {
+  if (isEditing) {
+    editingContent.value = getTextContent(props.message.content)
+  }
+})
 
 // 辅助函数：提取文件引用
 function extractFileReferences(content) {

--- a/app/desktop/ui/src/composables/chat/useChatPage.js
+++ b/app/desktop/ui/src/composables/chat/useChatPage.js
@@ -327,20 +327,41 @@ export const useChatPage = (props) => {
   const mergeToolCalls = (existingToolCalls = [], incomingToolCalls = []) => {
     const existingList = Array.isArray(existingToolCalls) ? existingToolCalls : []
     const incomingList = Array.isArray(incomingToolCalls) ? incomingToolCalls : []
-    const maxLength = Math.max(existingList.length, incomingList.length)
-    const merged = []
 
-    for (let i = 0; i < maxLength; i += 1) {
-      const existingToolCall = existingList[i]
-      const incomingToolCall = incomingList[i]
-      if (existingToolCall && incomingToolCall) {
-        merged.push(mergeToolCall(existingToolCall, incomingToolCall))
-        continue
-      }
-      merged.push(incomingToolCall || existingToolCall)
+    if (incomingList.length === 0) {
+      return existingList.filter(Boolean).map(tc => ({ ...tc }))
     }
 
-    return merged.filter(Boolean)
+    // 同一条 assistant 消息里多个工具调用是按 OpenAI delta 的 `index` 字段
+    // 区分的，绝对不能用数组下标硬合并 —— 否则后到的 file_write 增量会被
+    // 拼接到第一条 tool_call 上，造成"参数收集不到 / 工具从页面消失"。
+    const result = existingList.filter(Boolean).map(tc => ({ ...tc }))
+
+    const findTargetIdx = (incomingTC) => {
+      if (!incomingTC) return -1
+      const incomingId = incomingTC.id || incomingTC.tool_call_id
+      if (incomingId) {
+        const idx = result.findIndex(t => t && (t.id === incomingId || t.tool_call_id === incomingId))
+        if (idx !== -1) return idx
+      }
+      if (incomingTC.index !== undefined && incomingTC.index !== null) {
+        const idx = result.findIndex(t => t && t.index === incomingTC.index)
+        if (idx !== -1) return idx
+      }
+      return -1
+    }
+
+    incomingList.forEach((incomingTC) => {
+      if (!incomingTC) return
+      const targetIdx = findTargetIdx(incomingTC)
+      if (targetIdx !== -1) {
+        result[targetIdx] = mergeToolCall(result[targetIdx], incomingTC)
+      } else {
+        result.push({ ...incomingTC })
+      }
+    })
+
+    return result
   }
 
   const createSession = (_agentId = null) => {

--- a/app/server/web/src/composables/chat/useChatPage.js
+++ b/app/server/web/src/composables/chat/useChatPage.js
@@ -309,20 +309,41 @@ export const useChatPage = (props) => {
   const mergeToolCalls = (existingToolCalls = [], incomingToolCalls = []) => {
     const existingList = Array.isArray(existingToolCalls) ? existingToolCalls : []
     const incomingList = Array.isArray(incomingToolCalls) ? incomingToolCalls : []
-    const maxLength = Math.max(existingList.length, incomingList.length)
-    const merged = []
 
-    for (let i = 0; i < maxLength; i += 1) {
-      const existingToolCall = existingList[i]
-      const incomingToolCall = incomingList[i]
-      if (existingToolCall && incomingToolCall) {
-        merged.push(mergeToolCall(existingToolCall, incomingToolCall))
-        continue
-      }
-      merged.push(incomingToolCall || existingToolCall)
+    if (incomingList.length === 0) {
+      return existingList.filter(Boolean).map(tc => ({ ...tc }))
     }
 
-    return merged.filter(Boolean)
+    // 同一条 assistant 消息里多个工具调用是按 OpenAI delta 的 `index` 字段
+    // 区分的，绝对不能用数组下标硬合并 —— 否则后到的 file_write 增量会被
+    // 拼接到第一条 tool_call 上，造成"参数收集不到 / 工具从页面消失"。
+    const result = existingList.filter(Boolean).map(tc => ({ ...tc }))
+
+    const findTargetIdx = (incomingTC) => {
+      if (!incomingTC) return -1
+      const incomingId = incomingTC.id || incomingTC.tool_call_id
+      if (incomingId) {
+        const idx = result.findIndex(t => t && (t.id === incomingId || t.tool_call_id === incomingId))
+        if (idx !== -1) return idx
+      }
+      if (incomingTC.index !== undefined && incomingTC.index !== null) {
+        const idx = result.findIndex(t => t && t.index === incomingTC.index)
+        if (idx !== -1) return idx
+      }
+      return -1
+    }
+
+    incomingList.forEach((incomingTC) => {
+      if (!incomingTC) return
+      const targetIdx = findTargetIdx(incomingTC)
+      if (targetIdx !== -1) {
+        result[targetIdx] = mergeToolCall(result[targetIdx], incomingTC)
+      } else {
+        result.push({ ...incomingTC })
+      }
+    })
+
+    return result
   }
 
   const createSession = (_agentId = null) => {

--- a/change_log.md
+++ b/change_log.md
@@ -1,4 +1,14 @@
 
+2026-04-18 sandbox/_stdout_echo 增加 48 条单测（test_stdout_echo.py），覆盖 echo 开关全部取值、空/None/异常 stdout 兜底、header 截断、footer 各种 rc、流式 helper 的 stdout/stderr 隔离/cwd/env/大输出/非 UTF-8/实时性断言/超时；测试中发现 timeout 路径会被持有 pipe 的子孙进程（如 sleep）阻塞 drain 线程~4s 的回归，顺手修：Popen 加 start_new_session，超时改成 killpg(SIGKILL) 干掉整个进程组，并去掉 raise 前重复的 join。
+
+2026-04-18 ExecuteCommandTool/沙箱命令实时回显：新增 sandbox/_stdout_echo（含 echo_chunk/header/footer 与 run_with_streaming_stdout helper），LocalSandboxProvider 直接路径在 read_output 里增量写 sys.stdout；Seatbelt/Bwrap parent 改用流式 helper 转发 stdout、stderr 单独捕获用于报错；launcher.py shell mode 也从 subprocess.run 换成 Popen+双线程 drain，命令 stdout 实时透传到外层；三处 isolation 始终覆盖 launcher.py 让升级生效；ExecuteCommandTool 加 $ <cmd> / ↪ rc=N 头尾分隔。受 SAGE_ECHO_SHELL_OUTPUT 控制，默认开启，0/false/no/off/空 关闭。
+
+2026-04-18 放开 todo 子任务"≤10"硬上限：task_decompose_prompts 三语全删掉 10 条上限，改成按复杂度自适应（trivial 1-3 / 常规 5-15 / 复杂多阶段 15-40+），并要求带"和/然后"或跨多文件的步骤必须继续拆；同步在 todo_write 工具描述里补上同样的颗粒度指导，让不走 task_decompose 的 SimpleAgent 也能拿到信号。
+
+2026-04-18 修复前端 file_write 等工具"参数收集不到 / 执行完后从页面消失"：MessageChunk._serialize_tool_calls 序列化时丢了 OpenAI delta 的 index 字段；同时 useChatPage.mergeToolCalls 用数组下标合并，导致同一条消息里多 tool_call 串台。后端补回 index，前端改为按 id/index 匹配合并，desktop/server 双端同步；顺手修了 desktop MessageRenderer.vue 中误置在 watch 内反复注册的 watch(isEditingThisUserMessage)。
+
+2026-04-17 22:30 修复 SeatbeltIsolation 在 macOS 卡死 5 分钟的问题：原 sandbox profile 把 mach/ipc/sysctl/iokit 全 deny 导致 Python 启动 SIGABRT 或阻塞 mach-lookup，重写为「系统调用全放行 + 文件写白名单」策略，仅限制写入到 workspace/sandbox_dir/volume_mounts，并在执行超时时保留 .sb 文件便于排查。
+
 2026-04-17 修复中断会话后续请求秒退：load_persisted_state 不再把磁盘 INTERRUPTED 状态翻译成 interrupt_event.set()；set_status(RUNNING) 进入新轮次时主动清掉残留 interrupt_event/interrupt_reason/audit_status；删除 Session 中重复定义的 request_interrupt 死代码。
 
 2026-04-17 SandboxSkillManager.sync_from_host 改为按需补齐：沙箱已有 skill 直接加载（保留手改），缺失时才从宿主 SkillSchema.path 拷一次；同时移除 chat_service 每次 prompt 都同步技能到 workspace 的逻辑（统一改由 agent 编辑页 create/update 触发），desktop / server 行为一致。

--- a/sagents/context/messages/message.py
+++ b/sagents/context/messages/message.py
@@ -200,6 +200,12 @@ class MessageChunk:
             if hasattr(tc, 'id') and hasattr(tc, 'function'):
                 # 对象形式 (如 ChoiceDeltaToolCall)
                 tc_dict = {'id': tc.id, 'type': getattr(tc, 'type', 'function')}
+                # OpenAI 流式增量 delta 中 index 至关重要：同一条 assistant 消息里
+                # 多个 tool_call 在分片时仅靠 index 区分，丢失会导致前端把后续
+                # 工具的参数累加到上一个工具上，进而出现"参数收集不到"或"工具消失"。
+                tc_index = getattr(tc, 'index', None)
+                if tc_index is not None:
+                    tc_dict['index'] = tc_index
                 function = tc.function if hasattr(tc, 'function') else None
                 if function:
                     tc_dict['function'] = {
@@ -208,7 +214,7 @@ class MessageChunk:
                     }
                 result.append(tc_dict)
             elif isinstance(tc, dict):
-                # 字典形式
+                # 字典形式 - 原样透传，保留 index 等额外字段
                 result.append(tc)
             else:
                 # 其他形式，转换为字符串

--- a/sagents/prompts/task_decompose_prompts.py
+++ b/sagents/prompts/task_decompose_prompts.py
@@ -37,7 +37,12 @@ decompose_template = {
 4. 考虑任务之间的依赖关系，输出的列表必须是有序的，按照优先级从高到低排序，优先级相同的任务按照依赖关系排序。
 5. 你必须使用 `todo_write` 工具来输出分析出的任务清单，而不是直接在回复中列出。
 6. 如果有任务Thinking的过程，子任务要与Thinking的处理逻辑一致。
-7. 子任务数量不要超过10个，较简单的子任务可以合并为一个子任务。
+7. 子任务颗粒度要与任务的真实复杂度匹配，**不要为了"看起来简洁"硬把多步骤合并成一条**：
+   - 极简单/单步任务：1-3 个子任务即可。
+   - 常规多步任务：5-15 个子任务。
+   - 复杂、跨模块、跨阶段（如全栈功能、调研+设计+实现+联调+验收、大型重构等）：放开做到 15-40 个子任务也是合理的，关键看每一步是否可独立验收。
+   - 判定标准：如果一条子任务里包含"并且/然后/接着"等隐含多步动作、或预计执行需要多次工具调用 / 跨多个文件，就应当继续拆分。
+   - 反过来，仅当两个动作真的属于同一个原子动作（同一文件同一函数的小修改、同一次配置中的若干字段）时，才合并。
 8. 子任务描述中不要直接说出工具的原始名称，使用工具描述来表达工具。
 9. 只关注用户最新的需求或者任务进行拆分，不要关注用户历史对话中的其他任务。
 10. 如果当前存在可用的skills，并且这个子任务和某个skill非常契合，就声明一下使用对应的skill 。
@@ -62,7 +67,12 @@ Observe user latest needs or tasks through user's historical dialogue
 4. Consider dependencies between tasks. The output list must be ordered, sorted by priority from high to low. Tasks with the same priority should be sorted by dependency relationship.
 5. You MUST use the `todo_write` tool to output the analyzed task list instead of listing them in the response.
 6. If there is a task Thinking process, subtasks should be consistent with the Thinking processing logic.
-7. The number of subtasks should not exceed 10. Simpler subtasks can be merged into one subtask.
+7. Subtask granularity must match the real complexity of the task. **Do NOT collapse multiple steps into one just to keep the list short.**
+   - Trivial / single-step task: 1-3 subtasks is enough.
+   - Normal multi-step task: 5-15 subtasks.
+   - Complex, cross-module, multi-stage task (e.g. full-stack feature, research + design + implementation + integration + verification, large refactor): going up to 15-40 subtasks is perfectly fine, as long as each step can be independently verified.
+   - Rule of thumb: if one subtask description contains "and/then/after that" implying multiple actions, or is expected to require multiple tool calls / changes across multiple files, split it further.
+   - Conversely, only merge two actions when they truly form a single atomic action (a tiny edit on the same function in the same file, several fields in one config call, etc.).
 8. Do not directly mention the original names of tools in subtask descriptions. Use tool descriptions to express tools.
 9. Only focus on user latest needs or tasks for decomposition, do not focus on other tasks in user historical dialogue.
 10. If there are available skills, and this subtask fits a specific skill well, just explicitly state that you will use the corresponding skill.
@@ -87,7 +97,12 @@ Observe as necessidades ou tarefas mais recentes do usuário através do diálog
 4. Considere as dependências entre tarefas. A lista de saída deve ser ordenada, classificada por prioridade do alto para o baixo. Tarefas com a mesma prioridade devem ser classificadas por relação de dependência.
 5. O formato de saída deve seguir estritamente os requisitos abaixo.
 6. Se houver um processo Thinking de tarefa, as subtarefas devem ser consistentes com a lógica de processamento Thinking.
-7. O número de subtarefas não deve exceder 10. Subtarefas mais simples podem ser mescladas em uma subtarefa.
+7. A granularidade das subtarefas deve corresponder à complexidade real da tarefa. **Não colapse vários passos em um só apenas para manter a lista curta.**
+   - Tarefa trivial / de um único passo: 1-3 subtarefas são suficientes.
+   - Tarefa normal de múltiplos passos: 5-15 subtarefas.
+   - Tarefa complexa, multi-módulo, multi-fase (por exemplo, recurso full-stack, pesquisa + design + implementação + integração + verificação, grande refatoração): chegar a 15-40 subtarefas é perfeitamente aceitável, desde que cada passo possa ser verificado de forma independente.
+   - Regra prática: se a descrição de uma subtarefa contém "e/então/depois" implicando múltiplas ações, ou se espera que exija múltiplas chamadas de ferramenta / alterações em vários arquivos, divida-a ainda mais.
+   - Por outro lado, só mescle duas ações quando elas realmente formarem uma única ação atômica (uma pequena edição na mesma função no mesmo arquivo, vários campos em uma única chamada de configuração etc.).
 8. Não mencione diretamente os nomes originais das ferramentas nas descrições das subtarefas. Use descrições de ferramentas para expressar ferramentas.
 9. Concentre-se apenas nas necessidades ou tarefas mais recentes do usuário para decomposição, não se concentre em outras tarefas no diálogo histórico do usuário.
 10. Se houver skills disponíveis e esta subtarefa se encaixar muito bem em uma skill específica, apenas declare explicitamente que usará a skill correspondente.

--- a/sagents/skill/skill_tool.py
+++ b/sagents/skill/skill_tool.py
@@ -112,7 +112,7 @@ class SkillTool:
         })
 
         # Limit total tokens to 8000, remove oldest if exceeded
-        MAX_SKILL_TOKENS = 8000
+        MAX_SKILL_TOKENS = 18000
         total_tokens = 0
 
         for skill in active_skills:

--- a/sagents/tool/impl/execute_command_tool.py
+++ b/sagents/tool/impl/execute_command_tool.py
@@ -8,6 +8,7 @@ Execute Command Tool
 from typing import Dict, Any, Optional
 from ..tool_base import tool
 from sagents.utils.logger import logger
+from sagents.utils.sandbox._stdout_echo import echo_header, echo_footer
 
 
 class SecurityManager:
@@ -127,13 +128,19 @@ class ExecuteCommandTool:
         # 获取沙箱
         sandbox = self._get_sandbox(session_id)
 
-        # 调用沙箱执行命令
-        result = await sandbox.execute_command(
-            command=command,
-            workdir=workdir,
-            timeout=timeout,
-            env_vars=env_vars
-        )
+        # 头尾打印一行分隔符，方便在 docker logs / 终端里看清是哪条命令
+        # （正文 stdout 由沙箱执行层在 read_output 里增量写出，受 SAGE_ECHO_SHELL_OUTPUT 控制）
+        echo_header(command)
+        result = None
+        try:
+            result = await sandbox.execute_command(
+                command=command,
+                workdir=workdir,
+                timeout=timeout,
+                env_vars=env_vars,
+            )
+        finally:
+            echo_footer(result.return_code if result is not None else None)
 
         logger.info(f"✅ ExecuteCommandTool: success={result.success}, rc={result.return_code}")
 

--- a/sagents/tool/impl/todo_tool.py
+++ b/sagents/tool/impl/todo_tool.py
@@ -225,13 +225,34 @@ class ToDoTool:
 
     @tool(
         description_i18n={
-            "zh": "创建或更新任务清单，新增任务需包含 id, content；更新任务只需 id 和变更字段(content/completed)。未变更的任务无需传入。",
-            "en": "Create or update todo list",
+            "zh": (
+                "创建或更新任务清单。新增任务需包含 id, content；更新任务只需 id 和变更字段(content/completed/conclusion)。未变更的任务无需传入。"
+                "颗粒度要求：子任务的数量必须与任务真实复杂度匹配，不要为了\"看起来简洁\"硬把多步骤合并成一条。"
+                "极简单/单步任务 1-3 条；常规多步任务 5-15 条；复杂、跨模块、跨阶段（全栈功能 / 调研+设计+实现+联调+验收 / 大型重构等）"
+                "可以拆到 15-40 条甚至更多，关键看每一步是否可独立验收。"
+                "如果一条 content 里包含\"并且/然后/接着\"等隐含多步动作，或预计需要多次工具调用 / 跨多个文件，就必须继续拆分；"
+                "只有当两个动作真的属于同一个原子动作时才合并。"
+            ),
+            "en": (
+                "Create or update the todo list. New tasks must include id and content; updates only need id and changed fields (content/completed/conclusion); unchanged tasks can be omitted. "
+                "Granularity rule: the number of subtasks MUST match the real complexity of the task. Do NOT collapse multiple steps into one just to keep the list short. "
+                "Trivial/single-step task: 1-3 items. Normal multi-step task: 5-15 items. "
+                "Complex, cross-module, multi-stage tasks (full-stack feature, research + design + implementation + integration + verification, large refactor, etc.) can legitimately reach 15-40 items or more, as long as each step is independently verifiable. "
+                "If a single content describes multiple actions (\"and/then/after that\"), or is expected to need multiple tool calls / changes across multiple files, split it further. Only merge when two actions truly form one atomic action."
+            ),
         },
         param_description_i18n={
             "tasks": {
-                "zh": "任务列表。新增任务需包含 id, content；更新任务只需 id 和变更字段(content/completed)。未变更的任务无需传入。",
-                "en": "List of tasks. New tasks need id, content; updates need id and changed fields (content/completed). Unchanged tasks can be omitted."
+                "zh": (
+                    "任务列表。新增任务需包含 id, content；更新任务只需 id 和变更字段(content/completed/conclusion)。未变更的任务无需传入。"
+                    "颗粒度要按任务复杂度自适应：极简单 1-3 条 / 常规 5-15 条 / 复杂多阶段 15-40+ 条；"
+                    "禁止为了\"清单短\"把可独立验收的多步骤合并成一条。"
+                ),
+                "en": (
+                    "List of tasks. New tasks need id and content; updates need id and changed fields (content/completed/conclusion). Unchanged tasks can be omitted. "
+                    "Granularity must match task complexity: trivial 1-3 / normal 5-15 / complex multi-stage 15-40+ items; "
+                    "never merge independently verifiable steps into one just to make the list shorter."
+                )
             },
             "session_id": {
                 "zh": "会话ID，用于定位工作区",

--- a/sagents/utils/sandbox/_stdout_echo.py
+++ b/sagents/utils/sandbox/_stdout_echo.py
@@ -1,0 +1,175 @@
+"""
+Shell 命令实时回显工具
+
+把沙箱里跑的 shell 命令输出实时写到当前进程的 sys.stdout，不走 logger（避免每行
+都被加上 [INFO] 前缀和换行）。受环境变量 SAGE_ECHO_SHELL_OUTPUT 控制：
+- 默认开启（"1"/"true"/"yes"/"on"），或不设置时
+- 设置为 "0"/"false"/"no"/"off" 关闭
+
+注意：这是"诊断/可观测"层面的回显，不是消息流；正常的工具结果仍然通过返回值传回
+agent，互不冲突。
+"""
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from typing import List, Optional, Sequence, Tuple
+
+
+_DISABLED_VALUES = {"0", "false", "no", "off", ""}
+
+
+def echo_enabled() -> bool:
+    """是否启用实时 stdout 回显。默认开启；显式设为 0/false/no/off/空 才关闭。"""
+    val = os.environ.get("SAGE_ECHO_SHELL_OUTPUT", "1").strip().lower()
+    return val not in _DISABLED_VALUES
+
+
+def _safe_write(text: str) -> None:
+    if not text:
+        return
+    try:
+        sys.stdout.write(text)
+        sys.stdout.flush()
+    except Exception:
+        pass
+
+
+def echo_chunk(chunk: str) -> None:
+    """转发 stdout 增量片段。空字符串/None 直接忽略。"""
+    if not echo_enabled():
+        return
+    _safe_write(chunk)
+
+
+def echo_header(command: str, *, tag: str = "$") -> None:
+    """命令开始前打印一行分隔，便于多命令时区分边界。"""
+    if not echo_enabled():
+        return
+    text = command if command else ""
+    if len(text) > 500:
+        text = text[:500] + " …"
+    _safe_write(f"\n{tag} {text}\n")
+
+
+def echo_footer(return_code: Optional[int]) -> None:
+    """命令结束打一行尾巴，标注 rc。"""
+    if not echo_enabled():
+        return
+    rc_text = "?" if return_code is None else str(return_code)
+    _safe_write(f"↪ rc={rc_text}\n")
+
+
+def run_with_streaming_stdout(
+    cmd: Sequence[str],
+    *,
+    cwd: Optional[str] = None,
+    env: Optional[dict] = None,
+    timeout: Optional[float] = None,
+) -> Tuple[int, str, str]:
+    """同步执行 cmd，stdout 增量读取并通过 echo_chunk 实时转发；stderr 单独完整捕获。
+
+    设计目标：保持与 ``subprocess.run(capture_output=True, timeout=...)`` 相同的
+    返回/异常语义，但允许调用者在等待结束的同时看到 stdout 实时输出。
+
+    Args:
+        cmd: 命令及参数。
+        cwd: 工作目录。
+        env: 环境变量。
+        timeout: 超时秒数；超时会 SIGKILL 子进程并 raise ``subprocess.TimeoutExpired``。
+
+    Returns:
+        (returncode, captured_stdout, captured_stderr)
+    """
+    # 关键：start_new_session=True，让子进程独占一个进程组，超时时可以
+    # 一次性 killpg 整个进程组，避免子孙进程（如 sleep）持有 stdout pipe 的
+    # fd 导致 drain 线程一直阻塞在 read 上。
+    popen_kwargs = dict(
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        bufsize=0,
+    )
+    if os.name == "posix":
+        popen_kwargs["start_new_session"] = True
+    proc = subprocess.Popen(list(cmd), **popen_kwargs)
+
+    stdout_buf: List[str] = []
+    stderr_buf: List[str] = []
+
+    def _drain_stdout() -> None:
+        try:
+            while True:
+                chunk = proc.stdout.read(4096) if proc.stdout else b""
+                if not chunk:
+                    break
+                text = chunk.decode("utf-8", errors="replace")
+                stdout_buf.append(text)
+                echo_chunk(text)
+        except Exception:
+            pass
+
+    def _drain_stderr() -> None:
+        try:
+            while True:
+                chunk = proc.stderr.read(4096) if proc.stderr else b""
+                if not chunk:
+                    break
+                stderr_buf.append(chunk.decode("utf-8", errors="replace"))
+        except Exception:
+            pass
+
+    t_out = threading.Thread(target=_drain_stdout, daemon=True)
+    t_err = threading.Thread(target=_drain_stderr, daemon=True)
+    t_out.start()
+    t_err.start()
+
+    def _hard_kill() -> None:
+        """干掉整个进程组（POSIX）或退化为 proc.kill（Windows / 已退出）。"""
+        if os.name == "posix":
+            try:
+                pgid = os.getpgid(proc.pid)
+                os.killpg(pgid, signal.SIGKILL)
+                return
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+        try:
+            proc.kill()
+        except Exception:
+            pass
+
+    deadline = (time.monotonic() + timeout) if timeout else None
+    timed_out = False
+    try:
+        if deadline is None:
+            proc.wait()
+        else:
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    timed_out = True
+                    _hard_kill()
+                    proc.wait()
+                    break
+                try:
+                    proc.wait(timeout=min(remaining, 0.5))
+                    break
+                except subprocess.TimeoutExpired:
+                    continue
+    finally:
+        # killpg 之后 pipe 应已关闭，drain 线程会很快返回；留 1s 兜底
+        t_out.join(timeout=1.0)
+        t_err.join(timeout=1.0)
+
+    if timed_out:
+        raise subprocess.TimeoutExpired(
+            cmd=list(cmd),
+            timeout=timeout,
+            output="".join(stdout_buf),
+            stderr="".join(stderr_buf),
+        )
+
+    return proc.returncode, "".join(stdout_buf), "".join(stderr_buf)

--- a/sagents/utils/sandbox/providers/local/isolation/bwrap.py
+++ b/sagents/utils/sandbox/providers/local/isolation/bwrap.py
@@ -9,6 +9,7 @@ import os
 from typing import Dict, Any, Optional, List
 from sagents.utils.logger import logger
 from sagents.utils.sandbox.config import VolumeMount
+from sagents.utils.sandbox._stdout_echo import run_with_streaming_stdout
 from sagents.utils.common_utils import resolve_sandbox_runtime_dir
 from .subprocess import LAUNCHER_SCRIPT
 
@@ -50,9 +51,9 @@ class BwrapIsolation:
 
         python_bin = os.path.join(self.venv_dir, "bin", "python")
         launcher_path = os.path.join(sandbox_dir, "launcher.py")
-        if not os.path.exists(launcher_path):
-            with open(launcher_path, "w") as f:
-                f.write(LAUNCHER_SCRIPT)
+        # 始终覆盖 launcher.py，确保 LAUNCHER_SCRIPT 升级后旧沙箱也能用上新版
+        with open(launcher_path, "w") as f:
+            f.write(LAUNCHER_SCRIPT)
 
         bwrap_cmd = [
             "bwrap",
@@ -77,20 +78,20 @@ class BwrapIsolation:
         logger.info(f"[BwrapIsolation] 执行命令: {' '.join(bwrap_cmd[:5])}...")
         
         try:
-            result = await asyncio.to_thread(
-                subprocess.run,
+            # 流式执行：launcher 内部跑命令时，stdout 实时转发到本进程 stdout
+            # （受 SAGE_ECHO_SHELL_OUTPUT 控制），stderr 完整捕获用于报错
+            returncode, stdout_text, stderr_text = await asyncio.to_thread(
+                run_with_streaming_stdout,
                 bwrap_cmd,
-                capture_output=True,
-                text=True,
                 cwd=cwd or self.sandbox_agent_workspace,
                 timeout=300,
             )
-            
-            logger.info(f"[BwrapIsolation] 返回码: {result.returncode}")
-            
-            if result.returncode != 0:
-                logger.error(f"[BwrapIsolation] 执行失败: {result.stderr[:500]}")
-                raise Exception(f"Bwrap execution failed: {result.stderr}")
+
+            logger.info(f"[BwrapIsolation] 返回码: {returncode}")
+
+            if returncode != 0:
+                logger.error(f"[BwrapIsolation] 执行失败: {stderr_text[:500]}")
+                raise Exception(f"Bwrap execution failed: {stderr_text}")
             
             if not os.path.exists(output_pkl):
                 raise Exception("No output file generated")

--- a/sagents/utils/sandbox/providers/local/isolation/seatbelt.py
+++ b/sagents/utils/sandbox/providers/local/isolation/seatbelt.py
@@ -9,6 +9,7 @@ import os
 from typing import Dict, Any, Optional, List
 from sagents.utils.logger import logger
 from sagents.utils.sandbox.config import VolumeMount
+from sagents.utils.sandbox._stdout_echo import run_with_streaming_stdout
 from sagents.utils.common_utils import resolve_sandbox_runtime_dir
 from .subprocess import LAUNCHER_SCRIPT
 
@@ -70,30 +71,43 @@ class SeatbeltIsolation:
         allowed = list(set(allowed))
         
         # 构建 sandbox profile
+        # 策略：
+        #   - 系统调用 / IPC / 进程 / mach / sysctl / iokit 全部放行（否则
+        #     Python 启动会 SIGABRT 或卡死在系统服务上，而我们关心的不是限制系统调用）
+        #   - 文件读取默认放开（沙箱目的不是机密读保护，而是防止误写/越权写）
+        #   - 文件写入默认 deny，仅放行 workspace / sandbox_dir / volume_mounts /
+        #     系统临时目录 / /dev 等必要位置
         lines = [
             "(version 1)",
             "(deny default)",
-            "(allow process-fork)",
-            "(allow process-exec)",
+            "(allow process*)",
+            "(allow signal)",
+            "(allow mach*)",
+            "(allow iokit*)",
+            "(allow sysctl*)",
+            "(allow ipc*)",
+            "(allow system-socket)",
+            "(allow network*)",
+            # 文件读全放开（保留 file-write 的细粒度限制即可）
+            "(allow file-read*)",
+            # /dev 下必备的写
+            '(allow file-write* '
+            '(literal "/dev/null") (literal "/dev/zero") '
+            '(literal "/dev/dtracehelper") (literal "/dev/tty") '
+            '(literal "/dev/stdout") (literal "/dev/stderr"))',
+            # 系统临时目录写权限（tempfile、Python 缓存等）
+            '(allow file-write* (subpath "/private/tmp"))',
+            '(allow file-write* (subpath "/private/var/folders"))',
         ]
 
-        # 添加路径权限
+        # 用户允许写入的路径（workspace、sandbox_dir、volume_mounts 等）
         for path in allowed:
+            if not path:
+                continue
             if os.path.isdir(path):
-                lines.append(f"(allow file* (literal \"{path}\"))")
-                lines.append(f"(allow file* (subpath \"{path}\"))")
-                # 允许执行该路径下的程序
-                lines.append(f"(allow process-exec (subpath \"{path}\"))")
+                lines.append(f"(allow file-write* (subpath \"{path}\"))")
             elif os.path.isfile(path):
-                lines.append(f"(allow file* (literal \"{path}\"))")
-                lines.append(f"(allow process-exec (literal \"{path}\"))")
-        
-        # 允许网络
-        lines.append("(allow network*)")
-        
-        # 允许执行任何程序（在沙盒限制内）
-        lines.append("(allow process-exec (literal \"*\"))")
-        lines.append("(allow process-exec (regex \".*\"))")
+                lines.append(f"(allow file-write* (literal \"{path}\"))")
         
         profile_content = "\n".join(lines)
         
@@ -137,9 +151,9 @@ class SeatbeltIsolation:
         profile_path = self._generate_profile(output_pkl,
                                              additional_read_paths=additional_read,
                                              additional_write_paths=additional_write)
-        if not os.path.exists(launcher_path):
-            with open(launcher_path, "w") as f:
-                f.write(LAUNCHER_SCRIPT)
+        # 始终覆盖 launcher.py，确保 LAUNCHER_SCRIPT 升级后旧沙箱也能用上新版
+        with open(launcher_path, "w") as f:
+            f.write(LAUNCHER_SCRIPT)
         
         cmd = [
             "sandbox-exec", "-f", profile_path,
@@ -150,20 +164,34 @@ class SeatbeltIsolation:
         logger.info(f"[SeatbeltIsolation] 执行命令: {' '.join(cmd[:4])}...")
         
         try:
-            result = await asyncio.to_thread(
-                subprocess.run,
-                cmd,
-                capture_output=True,
-                text=True,
-                cwd=cwd or self.sandbox_dir,
-                timeout=300,
-            )
-            
-            logger.info(f"[SeatbeltIsolation] 返回码: {result.returncode}")
-            
-            if result.returncode != 0:
-                logger.error(f"[SeatbeltIsolation] 执行失败: {result.stderr[:500]}")
-                raise Exception(f"Seatbelt execution failed: {result.stderr}")
+            try:
+                # 用流式 helper：launcher 内部跑命令时实时把 stdout 转发到本进程
+                # stdout（受 SAGE_ECHO_SHELL_OUTPUT 控制），stderr 完整捕获用于报错
+                returncode, stdout_text, stderr_text = await asyncio.to_thread(
+                    run_with_streaming_stdout,
+                    cmd,
+                    cwd=cwd or self.sandbox_dir,
+                    timeout=300,
+                )
+            except subprocess.TimeoutExpired as te:
+                # 超时通常意味着 sandbox profile 缺权限导致 Python 启动卡死
+                logger.error(
+                    f"[SeatbeltIsolation] 执行超时(300s)，profile 保留以便排查: {profile_path}\n"
+                    f"stderr(部分): {(te.stderr or '')[:500]!r}"
+                )
+                # 保留 profile 不删，便于人工 cat 查看
+                profile_path = None
+                raise
+
+            logger.info(f"[SeatbeltIsolation] 返回码: {returncode}")
+
+            if returncode != 0:
+                logger.error(
+                    f"[SeatbeltIsolation] 执行失败 rc={returncode}\n"
+                    f"stderr: {stderr_text[:1000]}\n"
+                    f"stdout: {stdout_text[:500]}"
+                )
+                raise Exception(f"Seatbelt execution failed: {stderr_text}")
             
             if not os.path.exists(output_pkl):
                 raise Exception("No output file generated")
@@ -182,7 +210,7 @@ class SeatbeltIsolation:
                     os.remove(input_pkl)
                 except:
                     pass
-            if os.path.exists(profile_path):
+            if profile_path and os.path.exists(profile_path):
                 try:
                     os.remove(profile_path)
                 except:

--- a/sagents/utils/sandbox/providers/local/isolation/subprocess.py
+++ b/sagents/utils/sandbox/providers/local/isolation/subprocess.py
@@ -225,10 +225,54 @@ def main():
                     "log_file": log_file,
                 }
             else:
-                proc = subprocess.run(cmd, shell=True, capture_output=True, text=True, cwd=cwd)
+                # 流式执行：边跑边把命令 stdout 写到本进程 stdout（外层 sandbox parent
+                # 已经在用 PIPE 增量读，再转发到 host 的 sys.stdout 实现实时回显）。
+                # stderr 单独捕获用于报错；同时把 stdout 缓存到 result 里返回 pickle。
+                proc = subprocess.Popen(
+                    cmd,
+                    shell=True,
+                    cwd=cwd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    bufsize=0,
+                )
+                stdout_chunks = []
+                stderr_chunks = []
+                import threading as _t
+                def _drain_o():
+                    try:
+                        while True:
+                            b = proc.stdout.read(4096) if proc.stdout else b''
+                            if not b:
+                                break
+                            t = b.decode('utf-8', errors='replace')
+                            stdout_chunks.append(t)
+                            try:
+                                sys.stdout.write(t)
+                                sys.stdout.flush()
+                            except Exception:
+                                pass
+                    except Exception:
+                        pass
+                def _drain_e():
+                    try:
+                        while True:
+                            b = proc.stderr.read(4096) if proc.stderr else b''
+                            if not b:
+                                break
+                            stderr_chunks.append(b.decode('utf-8', errors='replace'))
+                    except Exception:
+                        pass
+                _to = _t.Thread(target=_drain_o, daemon=True)
+                _te = _t.Thread(target=_drain_e, daemon=True)
+                _to.start(); _te.start()
+                proc.wait()
+                _to.join(timeout=1.0); _te.join(timeout=1.0)
+                stdout_text = ''.join(stdout_chunks)
+                stderr_text = ''.join(stderr_chunks)
                 if proc.returncode != 0:
-                     raise Exception(f"Command failed with code {proc.returncode}: {proc.stderr}")
-                result = proc.stdout
+                    raise Exception(f"Command failed with code {proc.returncode}: {stderr_text}")
+                result = stdout_text
         else:
             raise ValueError(f"Unknown mode: {mode}")
 
@@ -298,11 +342,10 @@ class SubprocessIsolation:
         if platform.system() == "Windows":
              python_bin = os.path.join(self.venv_dir, "Scripts", "python.exe")
         
-        # 创建 launcher.py 如果不存在
+        # 始终覆盖 launcher.py，确保 LAUNCHER_SCRIPT 升级后旧沙箱也能用上新版
         launcher_path = os.path.join(sandbox_dir, "launcher.py")
-        if not os.path.exists(launcher_path):
-            with open(launcher_path, "w") as f:
-                f.write(LAUNCHER_SCRIPT)
+        with open(launcher_path, "w") as f:
+            f.write(LAUNCHER_SCRIPT)
         
         cmd = [python_bin, launcher_path, input_pkl, output_pkl]
         

--- a/sagents/utils/sandbox/providers/local/local.py
+++ b/sagents/utils/sandbox/providers/local/local.py
@@ -25,6 +25,7 @@ import sys
 import asyncio
 from typing import Dict, List, Optional
 
+from ..._stdout_echo import echo_chunk
 from ...interface import (
     ISandboxHandle,
     SandboxType,
@@ -559,6 +560,7 @@ class LocalSandboxProvider(ISandboxHandle):
             )
 
             # 使用增量读取方式，确保超时前能获取已产生的输出
+            # 同时把 chunk 实时回显到当前进程 stdout（受 SAGE_ECHO_SHELL_OUTPUT 控制）
             async def read_output():
                 while True:
                     try:
@@ -568,7 +570,9 @@ class LocalSandboxProvider(ISandboxHandle):
                         )
                         if not chunk:
                             break
-                        collected_output.append(chunk.decode('utf-8', errors='replace'))
+                        chunk_text = chunk.decode('utf-8', errors='replace')
+                        collected_output.append(chunk_text)
+                        echo_chunk(chunk_text)
                     except asyncio.TimeoutError:
                         # 继续读取，检查进程是否还在运行
                         if proc.returncode is not None:

--- a/sagents/utils/sandbox/test_stdout_echo.py
+++ b/sagents/utils/sandbox/test_stdout_echo.py
@@ -1,0 +1,345 @@
+"""
+Unit tests for sagents.utils.sandbox._stdout_echo.
+
+覆盖范围：
+- echo_enabled 各种 env var 取值组合
+- echo_chunk / echo_header / echo_footer 的输出格式与开关行为
+- _safe_write 的异常吞咽
+- run_with_streaming_stdout：基本成功 / 非零 rc / stderr 隔离 / 超时 partial output
+  / cwd / env / echo 开关 / 大输出（多 chunk）/ 二进制非 UTF-8 字节兜底
+"""
+import os
+import subprocess
+import sys
+import time
+from typing import List
+
+import pytest
+
+from sagents.utils.sandbox import _stdout_echo
+from sagents.utils.sandbox._stdout_echo import (
+    echo_chunk,
+    echo_enabled,
+    echo_footer,
+    echo_header,
+    run_with_streaming_stdout,
+)
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_echo_env(monkeypatch):
+    """每个用例开始前，清空 SAGE_ECHO_SHELL_OUTPUT，避免被外部环境污染。"""
+    monkeypatch.delenv("SAGE_ECHO_SHELL_OUTPUT", raising=False)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ---------------------------------------------------------------------------
+# echo_enabled
+# ---------------------------------------------------------------------------
+
+class TestEchoEnabled:
+    def test_default_when_unset_is_enabled(self, monkeypatch):
+        monkeypatch.delenv("SAGE_ECHO_SHELL_OUTPUT", raising=False)
+        assert echo_enabled() is True
+
+    @pytest.mark.parametrize(
+        "value",
+        ["1", "true", "TRUE", "True", "yes", "YES", "on", "ON", " 1 ", "anything-else"],
+    )
+    def test_enabled_values(self, monkeypatch, value):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", value)
+        assert echo_enabled() is True, f"value={value!r} 应被视为开启"
+
+    @pytest.mark.parametrize(
+        "value",
+        ["0", "false", "FALSE", "False", "no", "NO", "off", "OFF", "", "  "],
+    )
+    def test_disabled_values(self, monkeypatch, value):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", value)
+        assert echo_enabled() is False, f"value={value!r} 应被视为关闭"
+
+
+# ---------------------------------------------------------------------------
+# echo_chunk / echo_header / echo_footer
+# ---------------------------------------------------------------------------
+
+class TestEchoChunk:
+    def test_writes_to_stdout_when_enabled(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        echo_chunk("hello world\n")
+        out = capsys.readouterr().out
+        assert out == "hello world\n"
+
+    def test_silent_when_disabled(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "0")
+        echo_chunk("must not appear")
+        assert capsys.readouterr().out == ""
+
+    def test_empty_string_is_noop(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        echo_chunk("")
+        assert capsys.readouterr().out == ""
+
+    def test_none_is_noop(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        # 类型注解是 str，但代码用 `if not text` 兜底；显式传 None 不应抛
+        echo_chunk(None)  # type: ignore[arg-type]
+        assert capsys.readouterr().out == ""
+
+    def test_swallows_stdout_write_exception(self, monkeypatch):
+        """sys.stdout.write 抛异常时，echo_chunk 必须静默吞掉，不能影响主流程。"""
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+
+        class _BrokenStdout:
+            def write(self, _):
+                raise RuntimeError("disk full")
+
+            def flush(self):
+                raise RuntimeError("disk full")
+
+        monkeypatch.setattr(sys, "stdout", _BrokenStdout())
+        # 不应抛
+        echo_chunk("payload")
+
+    def test_unicode_passthrough(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        echo_chunk("中文 🚀 emoji\n")
+        assert capsys.readouterr().out == "中文 🚀 emoji\n"
+
+
+class TestEchoHeader:
+    def test_default_format(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        echo_header("ls -la")
+        assert capsys.readouterr().out == "\n$ ls -la\n"
+
+    def test_silent_when_disabled(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "0")
+        echo_header("ls -la")
+        assert capsys.readouterr().out == ""
+
+    def test_truncates_long_command(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        long_cmd = "x" * 800
+        echo_header(long_cmd)
+        out = capsys.readouterr().out
+        # 头/尾各一个 \n + "$ " 前缀 + 500 个字符 + " …"
+        assert out.startswith("\n$ ") and out.endswith(" …\n")
+        body = out[len("\n$ "):-len(" …\n")]
+        assert body == "x" * 500
+
+    def test_empty_command_still_emits_marker(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        echo_header("")
+        assert capsys.readouterr().out == "\n$ \n"
+
+    def test_custom_tag(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        echo_header("pwd", tag=">>>")
+        assert capsys.readouterr().out == "\n>>> pwd\n"
+
+
+class TestEchoFooter:
+    def test_with_int_rc(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        echo_footer(0)
+        assert capsys.readouterr().out == "↪ rc=0\n"
+
+    def test_with_nonzero_rc(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        echo_footer(137)
+        assert capsys.readouterr().out == "↪ rc=137\n"
+
+    def test_with_none_rc(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        echo_footer(None)
+        assert capsys.readouterr().out == "↪ rc=?\n"
+
+    def test_silent_when_disabled(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "0")
+        echo_footer(0)
+        assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# run_with_streaming_stdout
+# ---------------------------------------------------------------------------
+
+class TestRunWithStreamingStdout:
+    def test_simple_success_returns_rc_stdout(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        rc, out, err = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "echo hello"], timeout=5
+        )
+        assert rc == 0
+        assert out == "hello\n"
+        assert err == ""
+        # 同时也实时回显到 stdout
+        captured = capsys.readouterr().out
+        assert "hello\n" in captured
+
+    def test_nonzero_returncode_does_not_raise(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "0")
+        rc, out, err = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "echo bye; exit 7"], timeout=5
+        )
+        assert rc == 7
+        assert out == "bye\n"
+        assert err == ""
+
+    def test_stderr_captured_separately_and_not_echoed(self, monkeypatch, capsys):
+        """stderr 必须独立捕获，且不会被 echo 到本进程 stdout。"""
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        rc, out, err = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "echo on-out; echo on-err 1>&2; exit 0"],
+            timeout=5,
+        )
+        assert rc == 0
+        assert out == "on-out\n"
+        assert err == "on-err\n"
+        echoed = capsys.readouterr().out
+        # 只有 stdout 被回显
+        assert "on-out\n" in echoed
+        assert "on-err" not in echoed
+
+    def test_echo_disabled_does_not_write_to_stdout(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "0")
+        rc, out, _ = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "echo silent"], timeout=5
+        )
+        assert rc == 0
+        assert out == "silent\n"
+        # 关闭后不应往 stdout 回显
+        assert capsys.readouterr().out == ""
+
+    def test_cwd_takes_effect(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "0")
+        target = tmp_path / "subdir"
+        target.mkdir()
+        rc, out, _ = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "pwd"], cwd=str(target), timeout=5
+        )
+        assert rc == 0
+        # macOS 下 /tmp 会被解析成 /private/tmp，做 realpath 比较
+        assert os.path.realpath(out.strip()) == os.path.realpath(str(target))
+
+    def test_env_takes_effect(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "0")
+        rc, out, _ = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "echo $MY_TEST_VAR"],
+            env={"MY_TEST_VAR": "abc123", "PATH": os.environ.get("PATH", "")},
+            timeout=5,
+        )
+        assert rc == 0
+        assert out == "abc123\n"
+
+    def test_timeout_raises_with_partial_output(self, monkeypatch, capsys):
+        """超时必须抛 TimeoutExpired，且把已收集到的 stdout 带回来。"""
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        start = time.monotonic()
+        with pytest.raises(subprocess.TimeoutExpired) as exc_info:
+            run_with_streaming_stdout(
+                ["/bin/sh", "-c", "echo before; sleep 5; echo after"],
+                timeout=0.5,
+            )
+        elapsed = time.monotonic() - start
+        # 应该在 ~0.5s 杀掉，绝不该跑满 5s
+        assert elapsed < 3.0, f"超时未生效，跑了 {elapsed:.2f}s"
+        te = exc_info.value
+        # partial output 已经包含 before
+        partial = te.output or ""
+        assert "before" in partial
+        assert "after" not in partial
+
+    def test_large_output_streams_in_chunks(self, monkeypatch, capsys):
+        """跨多个 4KB chunk 的大输出，应该完整捕获且实时回显。"""
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        # 生成 ~30KB 输出
+        rc, out, err = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "yes 'line' 2>/dev/null | head -n 5000"],
+            timeout=10,
+        )
+        assert rc == 0
+        lines = out.splitlines()
+        assert len(lines) == 5000
+        assert all(line == "line" for line in lines)
+        # echo 也覆盖完整
+        echoed = capsys.readouterr().out
+        assert echoed.count("line\n") == 5000
+
+    def test_invalid_utf8_does_not_crash(self, monkeypatch, capsys):
+        """非 UTF-8 字节应被 errors='replace' 兜底，不抛异常。"""
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        # printf '\xff\xfe\xfd' → 3 个非法 UTF-8 字节
+        rc, out, err = run_with_streaming_stdout(
+            ["/bin/sh", "-c", r"printf '\xff\xfe\xfd'"],
+            timeout=5,
+        )
+        assert rc == 0
+        # 三个字节都被替换为 U+FFFD（一个或多个）
+        assert "\ufffd" in out
+
+    def test_ordering_preserves_command_output_then_echo(self, monkeypatch, capsys):
+        """同一行命令输出，echo 顺序应当与捕获顺序一致（按到达顺序流式）。"""
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        rc, out, _ = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "echo A; echo B; echo C"], timeout=5
+        )
+        assert out == "A\nB\nC\n"
+        echoed = capsys.readouterr().out
+        # 多个 chunk 合并后仍保持 A B C 顺序
+        idx_a, idx_b, idx_c = echoed.find("A"), echoed.find("B"), echoed.find("C")
+        assert 0 <= idx_a < idx_b < idx_c
+
+    def test_no_timeout_runs_to_completion(self, monkeypatch, capsys):
+        """timeout=None 时不应启用 deadline 分支，命令正常跑完。"""
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "0")
+        rc, out, _ = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "echo done"], timeout=None
+        )
+        assert rc == 0
+        assert out == "done\n"
+
+    def test_streaming_actually_arrives_before_process_exit(self, monkeypatch, capsys):
+        """关键的"实时性"断言：在子进程结束前，前半段 stdout 就已经被 echo 出来。
+
+        通过 monkeypatch 拦截 _stdout_echo.echo_chunk，在每次回调时打 timestamp，
+        然后比较第一次 chunk 到达时间与命令总耗时的差值。
+        """
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        events: List[tuple] = []  # (t_relative, chunk)
+        original_echo = _stdout_echo.echo_chunk
+
+        def _spy(chunk):
+            events.append((time.monotonic(), chunk))
+            return original_echo(chunk)
+
+        monkeypatch.setattr(_stdout_echo, "echo_chunk", _spy)
+
+        t0 = time.monotonic()
+        rc, out, _ = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "echo first; sleep 0.6; echo second"],
+            timeout=5,
+        )
+        total = time.monotonic() - t0
+
+        assert rc == 0
+        assert out == "first\nsecond\n"
+        assert events, "至少应该收到一次 echo_chunk 回调"
+
+        # 第一次 chunk 必须在命令真正结束前就到达
+        first_chunk_at = events[0][0] - t0
+        assert first_chunk_at < total - 0.2, (
+            f"first chunk 在 {first_chunk_at:.2f}s 才到达，"
+            f"总耗时 {total:.2f}s，未达到流式效果"
+        )
+        # 且第一次到达的 chunk 必含 'first' 而不含 'second'
+        assert "first" in events[0][1] and "second" not in events[0][1]


### PR DESCRIPTION
## Summary

Three loosely related changes shipped together:

### 1. Live shell stdout from sandbox
- New `sagents/utils/sandbox/_stdout_echo.py` with `echo_chunk` / `echo_header` / `echo_footer` and a `run_with_streaming_stdout` helper. The helper uses `start_new_session=True` + `killpg(SIGKILL)` on timeout so child-of-child processes (e.g. `sleep`) holding the stdout pipe can no longer block drain threads.
- `LocalSandboxProvider` direct path, Seatbelt / Bwrap isolation parents, and the `launcher.py` shell mode all forward subprocess stdout to host `sys.stdout` in real time. Isolations always overwrite `launcher.py` so the upgrade lands on existing sandbox dirs too.
- `ExecuteCommandTool` adds `$ <cmd>` / `rc=N` separators around each call.
- Gated by env var `SAGE_ECHO_SHELL_OUTPUT` (default on; `0` / `false` / `no` / `off` / empty disables).

### 2. tool_call rendering fix (file_write etc.)
- `MessageChunk._serialize_tool_calls` now keeps the OpenAI delta `index` field.
- `useChatPage.mergeToolCalls` (desktop + server) matches incoming deltas by `id` / `index` instead of array position, so multi tool_call messages stop crossing wires.
- Drop a misplaced nested `watch(isEditingThisUserMessage)` in desktop `MessageRenderer.vue`.

### 3. Todo granularity
- Drop the hardcoded "<=10 subtasks" in `task_decompose_prompts.py` (zh / en / pt) and replace with adaptive guidance: trivial 1-3 / normal 5-15 / complex 15-40+, with a rule against merging independently verifiable steps.
- Mirror the same guidance in the `todo_write` tool description so `SimpleAgent` (which doesn't go through `TaskDecomposeAgent`) also gets the signal.

### Misc
- `skill_tool`: bump `MAX_SKILL_TOKENS` 8000 -> 18000.

## Test plan

- [x] `python -m pytest sagents/utils/sandbox/test_stdout_echo.py -v` — 48 / 48 passing in ~1.9s
- [x] Manual: in seatbelt + direct paths, run `echo a; sleep 0.3; echo b` and confirm chunks arrive incrementally in server stdout
- [x] Manual: `SAGE_ECHO_SHELL_OUTPUT=0` silences echo while keeping return values intact
- [x] Manual: `file_write` tool renders parameters and stays visible after execution in both desktop and server UI
- [ ] Smoke test todo decomposition on a multi-stage feature request and confirm the list is no longer artificially capped at 10
