### PR TITLE
refactor(sagents): split agent_base + dedupe session/sandbox boilerplate

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -1,4 +1,10 @@
 
+2026-04-20 23:51 复用样板：agent_session_helper 增 get_session_sandbox()；file_system/memory/execute_command/image_understanding 4 个 tool 的 _get_sandbox 改为单行调用；compress_history、web_fetcher、todo、skill、content_saver、fibre/tools 共 8 处 get_global_session_manager+get_live_session 模板替换为 get_live_session/get_live_session_context helper；image_understanding._get_mime_type 改用 multimodal_image.get_mime_type。
+
+2026-04-20 架构文档拆分为多二级章节（zh+en）：父页 ARCHITECTURE 重写为流程图导览，新增 app/server、app/desktop、app/others 三篇，sagents 拆为 overview / agent-flow / session-context / tool-skill / sandbox-obs 五篇；以 mermaid 图为主，仅保留二开示例代码；修复带 () 与 / 的 subgraph 标题语法；docs/README 索引同步更新。
+
+2026-04-20 拆分 agent_base.py（1673→1291 行）：图片多模态、消息清洗、流→非流合并、stream tag 判断、session 辅助分别抽到 sagents/utils/{multimodal_image,message_sanitizer,stream_merger,stream_tag_parser,agent_session_helper}.py，base 内对应方法保留薄封装，外部 agent 调用零改动。
+
 2026-04-20 用户消息气泡优化：1) 收紧 max-w 到 80%/70% 并补 break-all/min-w-0，防止长内容溢出页面宽度；2) 仿 codex 加「显示更多 / 收起」折叠（>240 字或 >8 行触发，max-h 200px + 底部渐隐遮罩），按钮挪到时间行最左侧；desktop / server 双端同步。
 
 2026-04-20 修复 MessageInput 输入 / 后方向键不能切换技能：handleCaretUpdate 在 keyup 时无脑把 selectedSkillIndex 重置为 0，导致 ArrowUp/Down 看似不生效；改为仅在 keyword 真的变了才重置，并加 watch 把 index 夹回 filteredSkills 范围。同步把 placeholder 改为「输入您的消息... (Shift+Enter 换行 · 输入 / 选择技能)」让用户知道有这个入口。

--- a/docs/en/ARCHITECTURE.md
+++ b/docs/en/ARCHITECTURE.md
@@ -1,92 +1,119 @@
 ---
-layout: default
+
+## layout: default
 title: Architecture
 nav_order: 4
-description: "Repository and subsystem architecture"
+has_children: true
+description: "Repository and subsystem architecture overview, with sub-pages for apps and the sagents core runtime"
 lang: en
 ref: architecture
----
 
 {% include lang_switcher.html %}
 
 # Architecture
 
-## Repository Overview
+Sage is a layered codebase, not a single binary. The architecture chapter is split into two main tracks:
 
-Sage is structured as a layered repository rather than a single binary. The main top-level subsystems are:
+- **App architecture**: each user-facing entry (web server, desktop, CLI, examples, browser extension, etc.), its shape, startup path and boundary.
+- **Core runtime `sagents/` architecture**: the session and agent engine shared by every app — the actual driver of "one conversation / one task".
 
-- `sagents/`: core runtime and orchestration
-- `app/server/`: main FastAPI application and web client
-- `app/desktop/`: desktop-local application stack
-- `examples/`: lightweight runnable examples
-- `mcp_servers/`: built-in MCP server implementations
-- `release_notes/`: release-specific notes outside the main docs set
+This chapter has multiple sub-pages. This page is just the index and high-level map; details live in the children.
 
-## High-Level Dependency Shape
+## Repository Map
+
+```mermaid
+flowchart TB
+    subgraph G_App ["App Layer (app/)"]
+        Server[server<br/>main FastAPI + Vue 3 web]
+        Desktop[desktop<br/>desktop entry + local backend + UI]
+        CLI[cli<br/>sage command]
+        Ext[chrome-extension<br/>side panel]
+        Skills[skills<br/>built-in skill packs]
+        Wiki[wiki<br/>static site]
+    end
+
+    subgraph G_Ex ["Examples (examples/)"]
+        DemoCLI[sage_cli.py]
+        DemoUI[sage_demo.py · Streamlit]
+        DemoSrv[sage_server.py · FastAPI]
+    end
+
+    subgraph G_Sagents ["Core Runtime (sagents/)"]
+        Runtime[Session · Agent · Flow · Tool · Skill · Sandbox · Obs]
+    end
+
+    subgraph External
+        MCP[mcp_servers · built-in MCP]
+        Common[common · shared infra]
+        Docs[docs · this site]
+    end
+
+    Server --> Runtime
+    Desktop --> Runtime
+    CLI --> Runtime
+    DemoCLI --> Runtime
+    DemoUI --> Runtime
+    DemoSrv --> Runtime
+    Ext -->|HTTP| Server
+    Runtime --> MCP
+    Runtime -.shared.-> Common
+```
+
+
+
+## High-Level Data Flow of One Conversation
+
+```mermaid
+flowchart LR
+    UserIn((User input)) --> EntryApp[Some app entry]
+    EntryApp -->|run_stream call| SAgent[SAgent entry]
+    SAgent --> Sess[Session/SessionContext]
+    Sess --> Flow[FlowExecutor + AgentFlow]
+    Flow --> Agents[Specialized Agents]
+    Agents --> LLM[Model layer]
+    Agents --> Tools[Tool / Skill]
+    Tools --> Sandbox[Sandbox]
+    Sess --> Obs[Observability]
+    Agents -->|stream of MessageChunk| EntryApp
+    EntryApp -->|SSE/JSON| UserIn
+```
+
+
+
+## Sub-pages in this Chapter
+
+App architecture (different app entries):
+
+1. [Server & Web App Architecture](ARCHITECTURE_APP_SERVER.md)
+2. [Desktop App Architecture](ARCHITECTURE_APP_DESKTOP.md)
+3. [CLI, Examples & External Entries](ARCHITECTURE_APP_OTHERS.md)
+
+Core runtime `sagents/` architecture (the heart of this chapter):
+
+1. [sagents Overview](ARCHITECTURE_SAGENTS_OVERVIEW.md)
+2. [Agent & Flow Orchestration](ARCHITECTURE_SAGENTS_AGENT_FLOW.md)
+3. [Session & Context](ARCHITECTURE_SAGENTS_SESSION_CONTEXT.md)
+4. [Tool & Skill System](ARCHITECTURE_SAGENTS_TOOL_SKILL.md)
+5. [Sandbox, LLM Adapter & Observability](ARCHITECTURE_SAGENTS_SANDBOX_OBS.md)
+
+## Reading Tips
 
 ```mermaid
 flowchart TD
-    User[User Interfaces] --> Web[Web App]
-    User --> Desktop[Desktop App]
-    User --> Examples[Examples]
-    Web --> Server[app/server]
-    Desktop --> DesktopCore[app/desktop/core]
-    Server --> Runtime[sagents]
-    DesktopCore --> Runtime
-    Examples --> Runtime
-    Runtime --> Tools[Tool System]
-    Runtime --> Skills[Skill System]
-    Runtime --> Sandbox[Sandbox]
-    Runtime --> Obs[Observability]
-    Tools --> MCP[mcp_servers]
+    Want[What do you want to do]
+
+    Want --> A[Understand how a conversation runs]
+    A --> A1[sagents Overview] --> A2[Agent + Flow] --> A3[Session + Context]
+
+    Want --> B[Server integration / deployment]
+    B --> B1[Server & Web App Architecture] --> B2[Configuration + HTTP API Reference]
+
+    Want --> C[Extend with custom tool/MCP/skill/sub-agent]
+    C --> C1[Tool & Skill System] --> C2[Agent + Flow extension points]
+
+    Want --> D[Package the desktop app]
+    D --> D1[Desktop App Architecture] --> D2[app/desktop/scripts]
 ```
 
-## Core Runtime: `sagents/`
 
-- `sagents/sagents.py`: `SAgent` runtime entry and stream orchestration
-- `sagents/agent/`: agent implementations such as simple, planning, execution, routing, and fibre agents
-- `sagents/flow/`: flow schema, conditions, and executor
-- `sagents/tool/`: tool abstractions, built-ins, managers, and MCP support
-- `sagents/skill/`: skill management and proxies
-- `sagents/context/`: session and state handling
-- `sagents/utils/sandbox/`: sandbox configuration and providers
-- `sagents/observability/`: runtime tracing and telemetry hooks
 
-## Main Application: `app/server/`
-
-- `app/server/main.py`: primary FastAPI startup path
-- `app/server/routers/`: HTTP route registration
-- `app/server/services/`: business and integration services
-- `app/server/schemas/`: request and response models
-- `app/server/web/`: Vue 3 frontend
-
-This is the main multi-user application surface and the default place to understand the productized server behavior.
-
-## Desktop Application: `app/desktop/`
-
-- `app/desktop/entry.py`: desktop bootstrap
-- `app/desktop/core/main.py`: desktop-local FastAPI app
-- `app/desktop/ui/`: desktop frontend
-- `app/desktop/scripts/`: packaging and development scripts
-
-The desktop app reuses core platform concepts while packaging a local-first application flow.
-
-## Example Surfaces: `examples/`
-
-The `examples/` directory is intentionally lighter weight than `app/server/` and is useful for:
-
-- local experimentation
-- simple runtime validation
-- isolated demos
-- packaging experiments
-
-## MCP Servers: `mcp_servers/`
-
-Built-in MCP implementations are versioned in the repository and can be wired into the runtime through the tool layer.
-
-## Architectural Notes
-
-- `app/server/` is the primary application boundary.
-- `examples/` are useful, but they are not the canonical application stack.
-- `sagents/` is the runtime engine and extension substrate.
-- `mcp_servers/` and app-facing tool registration are separate concerns: implementation vs exposure.

--- a/docs/en/ARCHITECTURE_APP_DESKTOP.md
+++ b/docs/en/ARCHITECTURE_APP_DESKTOP.md
@@ -1,0 +1,158 @@
+---
+
+## layout: default
+
+title: Desktop App Architecture
+parent: Architecture
+nav_order: 2
+description: "app/desktop/ desktop architecture: local backend, UI, Tauri shell and how it consumes sagents"
+lang: en
+ref: architecture-app-desktop
+
+{% include lang_switcher.html %}
+
+# Desktop App Architecture
+
+`app/desktop/` is Sage's desktop shape, "local-first": an embedded local FastAPI backend plus an embedded UI, wrapped by Tauri / PyInstaller into a double-clickable desktop application.
+
+## Module Composition
+
+```mermaid
+flowchart TB
+    subgraph Entry
+        Entry[entry.py<br/>handle frozen / SSL certs]
+    end
+
+    subgraph LocalBackend ["Local backend (core/)"]
+        Main[main.py<br/>FastAPI app + uvicorn]
+        Boot[bootstrap.py · lifecycle.py]
+        DB[db_schema.py · migrations.py<br/>local SQLite]
+        Sync[skill_sync.py<br/>built-in skills → user dir]
+        UCtx[user_context.py<br/>single-user identity injection]
+        Routers[routers · desktop routes]
+        Services[services · desktop services]
+    end
+
+    subgraph Frontend
+        UI[ui/<br/>Vue 3 + Vite + Tailwind, separate build]
+        Tauri[tauri/<br/>Tauri shell · tray/menu/system integration]
+    end
+
+    subgraph Packaging
+        Spec[sage-desktop.spec<br/>PyInstaller spec]
+        Scripts[scripts/<br/>build/packaging scripts]
+        Out[build/ · dist/<br/>artifacts]
+    end
+
+    Entry --> Main
+    Main --> Boot
+    Main --> Routers --> Services
+    Boot --> DB
+    Boot --> Sync
+    Tauri --> UI
+    Tauri -.spawn.-> Entry
+    Spec -.drives.-> Out
+    Scripts -.drives.-> Out
+```
+
+
+
+## Startup Path
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Tauri as Tauri shell
+    participant UI as UI assets
+    participant Entry as entry.py
+    participant Main as core/main.py
+    participant Life as core/lifecycle.initialize_system
+    participant SAgent
+
+    User->>Tauri: Double-click
+    Tauri->>UI: Load ui/dist
+    Tauri->>Entry: Spawn backend process
+    Entry->>Entry: Fix SSL cert paths if frozen
+    Entry->>Main: call main()
+    Main->>Main: Force AGENT_BROWSER_HEADED=1
+    Main->>Main: Pre-import sagents.prompts
+    Main->>Life: lifespan: initialize_system()
+    Life-->>Life: local DB → Tool/Skill → SessionManager
+    UI->>Main: HTTP/SSE w/ X-Sage-Internal-UserId
+    Main->>Main: inject_desktop_user_context middleware
+    Main->>SAgent: SAgent.run_stream(...)
+    SAgent-->>UI: streaming MessageChunk
+```
+
+
+
+## Differences vs. Server
+
+
+| Aspect             | `app/server/`                    | `app/desktop/`                                                  |
+| ------------------ | -------------------------------- | --------------------------------------------------------------- |
+| Multi-user         | Yes, full auth                   | No, single user injected                                        |
+| Persistence        | Multi-tenant DB / object storage | Local SQLite + user-dir files                                   |
+| Deployment         | Container / server               | Desktop installer (PyInstaller + Tauri)                         |
+| Browser automation | Headless by default              | Headed by default (`AGENT_BROWSER_HEADED=1`)                    |
+| Skills             | Platform-managed                 | `skill_sync.py` syncs built-in skills to the user dir, editable |
+| Entry              | `app/server/main.py`             | `app/desktop/entry.py` → `app/desktop/core/main.py`             |
+| Auth middleware    | Full OAuth/JWT                   | `inject_desktop_user_context` single-user injection             |
+
+
+Both call the same `sagents/` runtime; the differences come from sandbox configuration (desktop prefers `local`), the registered tool/skill set, and where model config comes from (desktop typically reads user-provided API keys from local DB).
+
+## Desktop Runtime Dependencies
+
+```mermaid
+flowchart LR
+    User((User)) --> TauriShell[Tauri shell]
+    TauriShell --> UIRender[UI render]
+    UIRender -->|HTTP/SSE localhost| LocalAPI[Local FastAPI]
+    LocalAPI --> SAgent
+    LocalAPI --> LocalDB[(Local SQLite/<br/>user-dir files)]
+    SAgent --> Sandbox[Local sandbox]
+    SAgent --> Tools
+    LocalAPI -.static.-> UserSkills[(Synced skills dir)]
+    Sync[skill_sync] -. copy .-> UserSkills
+```
+
+
+
+## Tauri Shell Responsibilities
+
+```mermaid
+flowchart TB
+    Tauri[Tauri shell]
+    Tauri --> Window[Open window + load UI]
+    Tauri --> Process[Spawn / supervise<br/>PyInstaller backend]
+    Tauri --> Tray[System tray / menu / autostart]
+    Tauri --> Dialog[File dialogs / system notifications]
+```
+
+
+
+## Packaging Pipeline & Gotchas
+
+```mermaid
+flowchart LR
+    SrcPy[Python source + sagents/prompts/]
+    SrcUI[ui/ frontend]
+    SrcSkill[app/skills/ built-in skills]
+
+    SrcUI -->|npm build| UIDist[ui/dist]
+    SrcPy -->|PyInstaller<br/>sage-desktop.spec| Exec[sage-desktop binary]
+    SrcSkill -->|bundled + skill_sync| UserDir[user-dir skills]
+    UIDist --> Bundle[Final desktop installer]
+    Exec --> Bundle
+    UserDir -.runtime.-> Bundle
+```
+
+
+
+Packaging gotchas:
+
+- `sagents/prompts/` must be explicitly collected (the safety import in `main.py` covers this).
+- Built-in `app/skills/` need to be bundled and copied to the user dir via `skill_sync.py`.
+- Cert paths must work under the `_MEIPASS` temp dir (handled by `entry.py`).
+

--- a/docs/en/ARCHITECTURE_APP_OTHERS.md
+++ b/docs/en/ARCHITECTURE_APP_OTHERS.md
@@ -1,0 +1,132 @@
+---
+layout: default
+title: CLI, Examples & External Entries
+parent: Architecture
+nav_order: 3
+description: "app/cli/, examples/, app/chrome-extension/, app/wiki/ and other lightweight entries"
+lang: en
+ref: architecture-app-others
+---
+
+{% include lang_switcher.html %}
+
+# CLI, Examples & External Entries
+
+Beyond the two productized shapes (`app/server/` and `app/desktop/`), Sage ships several lighter entries for different scenarios: dev iteration, minimal demos, third-party integrations, docs/wiki.
+
+## Entry Map
+
+```mermaid
+flowchart TD
+    User((User)) --> CLI[app/cli<br/>sage command]
+    User --> Demo1[examples/sage_cli.py]
+    User --> Demo2[examples/sage_demo.py<br/>Streamlit]
+    User --> Demo3[examples/sage_server.py<br/>standalone FastAPI]
+    User --> Browser[(Browser)]
+    User --> Reader[Doc reader]
+
+    Browser --> Ext[app/chrome-extension<br/>side panel]
+    Browser --> Wiki[app/wiki<br/>static site]
+
+    CLI --> SAgent
+    Demo1 --> SAgent
+    Demo2 --> SAgent
+    Demo3 --> SAgent
+    Ext -->|HTTP/SSE| Server[app/server<br/>deployed]
+    Wiki -. static .-> Browser
+```
+
+## CLI: `app/cli/`
+
+```mermaid
+flowchart LR
+    User -->|sage run / chat / doctor| Argparse[main.py · argparse]
+    Argparse --> Service[service.py<br/>session orchestration]
+    Service --> SAgent[sagents runtime]
+    Service --> LocalFS[(local session files)]
+```
+
+Properties:
+
+- Reuses `sagents/` directly without `app/server/`.
+- Suitable for local dev, prompt iteration, runtime diagnostics.
+- `sage doctor` checks environment (deps, model connectivity, sandbox).
+
+See [CLI Guide](CLI.md) for commands.
+
+## Examples: `examples/`
+
+```mermaid
+flowchart TB
+    subgraph G_Ex ["examples/"]
+        SCli[sage_cli.py<br/>minimal CLI]
+        SDemo[sage_demo.py<br/>Streamlit demo]
+        SSrv[sage_server.py<br/>standalone FastAPI]
+        Helper[_example_support.py]
+        Mcp[mcp_setting.json<br/>MCP demo config]
+        Cfg1[preset_running_agent_config.json]
+        Cfg2[preset_running_config.json]
+        Build[build_exec/<br/>single-file build sample]
+    end
+
+    SCli --> SAgent
+    SDemo --> SAgent
+    SSrv --> SAgent
+    SCli -.read.-> Helper
+    SDemo -.read.-> Helper
+    SSrv -.read.-> Helper
+    SCli -.read.-> Mcp
+    SCli -.read.-> Cfg1
+    SCli -.read.-> Cfg2
+```
+
+When to use:
+
+- Validate the minimal arg set required to drive sagents.
+- Build a quick standalone demo without the full server.
+- Use as a baseline PyInstaller build sample.
+
+When not to use: anything requiring full product features (multi-user, KB, observability UI) — go with `app/server/`.
+
+## Chrome Extension: `app/chrome-extension/`
+
+```mermaid
+flowchart LR
+    Web[(Browsing pages)] --> ContentScript[content-script.js<br/>injected into page]
+    Web --> SidePanel[sidepanel.html<br/>side-panel UI]
+    SidePanel --> SidePanelJS[sidepanel.js]
+    ContentScript --> SW[service-worker.js<br/>background]
+    SidePanelJS --> SW
+    SW -->|HTTP/SSE| Server[app/server<br/>deployed]
+```
+
+It does not embed sagents; it is a browser-side UI client that talks to a deployed `app/server/` over HTTP/SSE — effectively a "web client living in the side panel".
+
+## Wiki / Static Docs: `app/wiki/`
+
+```mermaid
+flowchart LR
+    SrcMd[Markdown content] --> Gen[generate-docs.js]
+    Gen --> Site[Static site output]
+    Site --> ServeUser[(Browser readers)]
+```
+
+`app/wiki/` is an internal product/operations wiki site. It has a different purpose from this `docs/` set:
+
+- `docs/` (what you are reading): technical docs, bound to the current code.
+- `app/wiki/`: business / product / tutorial content, can be hosted independently.
+
+It is not part of the runtime, but it is one of the apps in the repo, so it lives in this chapter.
+
+## Picking the Right Entry
+
+```mermaid
+flowchart TD
+    Need[Need]
+    Need --> P1{Full multi-user<br/>web product?} -->|yes| Server[app/server + web]
+    Need --> P2{Single-machine /<br/>offline?} -->|yes| Desktop[app/desktop]
+    Need --> P3{CLI / scripts?} -->|yes| CLI[app/cli]
+    Need --> P4{Minimal demo /<br/>integration template?} -->|yes| Examples[examples/sage_*.py]
+    Need --> P5{Browser side entry?} -->|yes| Ext[app/chrome-extension]
+    Need --> P6{Product / tutorial<br/>content?} -->|yes| Wiki[app/wiki]
+```

--- a/docs/en/ARCHITECTURE_APP_SERVER.md
+++ b/docs/en/ARCHITECTURE_APP_SERVER.md
@@ -1,0 +1,207 @@
+---
+layout: default
+title: Server & Web App Architecture
+parent: Architecture
+nav_order: 1
+description: "FastAPI app and Vue 3 web client under app/server/"
+lang: en
+ref: architecture-app-server
+---
+
+{% include lang_switcher.html %}
+
+# Server & Web App Architecture
+
+`app/server/` is the main, productized entry of Sage. It owns multi-user, web, agent management, knowledge base, observability and the rest of the platform surface. It is not a demo.
+
+## Module Composition
+
+```mermaid
+flowchart TB
+    subgraph Entry
+        Main[main.py<br/>FastAPI app + uvicorn]
+        Boot[bootstrap.py<br/>subsystem init/teardown]
+        Life[lifecycle.py<br/>initialize_system orchestration]
+        Sched[scheduler.py<br/>scheduled jobs]
+    end
+
+    subgraph G_Core ["Cross-cutting (core/)"]
+        Auth[auth.py<br/>auth deps]
+        Mid[middleware.py<br/>CORS / logging / request id]
+        AdminBoot[bootstrap_admin.py<br/>built-in admin bootstrap]
+    end
+
+    subgraph G_Routers ["Routers (routers/)"]
+        RChat[chat]
+        RAgent[agent]
+        RConv[conversation]
+        RTask[task]
+        RTool[tool / mcp]
+        RSkill[skill]
+        RKdb[kdb]
+        RLLM[llm_provider]
+        RAuth[auth / oauth2 / user]
+        ROss[oss]
+        RObs[observability]
+        RSys[system / version]
+    end
+
+    subgraph G_Services ["Services (services/)"]
+        SChat[chat]
+        SAuth[auth]
+        SUser[user.py]
+        SAgent[agent_inherit.py]
+        SOss[oss.py]
+    end
+
+    subgraph G_Web ["Frontend (web/)"]
+        WebSrc[Vue 3 + Vite + Tailwind]
+    end
+
+    Main --> Mid
+    Main --> Life
+    Main --> RChat
+    RChat --> SChat
+    RAgent --> SAgent
+    RAuth --> SAuth
+    SChat --> SAgent
+    Life --> Boot
+    Boot --> AdminBoot
+```
+
+## Startup Path
+
+```mermaid
+sequenceDiagram
+    participant CLI as python -m app.server.main
+    participant Cfg as init_startup_config
+    participant App as create_fastapi_app
+    participant Life as lifecycle.initialize_system
+    participant Uvi as uvicorn.Server
+
+    CLI->>Cfg: read .env / startup config
+    CLI->>Uvi: start_server(cfg)
+    Uvi->>App: factory build FastAPI
+    App->>App: register_middlewares · exception · routes
+    Uvi->>Life: lifespan: initialize_system(cfg)
+    Life-->>Life: DB → Obs → Clients → Tool/Skill → Session → Scheduler
+    Uvi-->>CLI: listening on http://host:port
+```
+
+## Routers and Services
+
+```mermaid
+flowchart LR
+    HTTP((HTTP/SSE request)) --> Router[routers/* router]
+    Router -->|parse + auth| Service[services/* business orchestration]
+    Service -->|build SAgent args| RT[sagents runtime]
+    RT -->|MessageChunk stream| Service
+    Service -->|SSE / JSON| HTTP
+
+    Router -.read.-> Auth
+    Router -.errors.-> ExcHandler[common exception handler]
+```
+
+Each router maps to one HTTP resource group; services hold the business orchestration:
+
+| Router | Responsibility |
+| --- | --- |
+| `chat` | Streaming chat (SSE), the bridge from HTTP to `SAgent.run_stream` |
+| `agent` | Agent CRUD + configuration |
+| `conversation` | History, lists, favorites |
+| `task` | Long-running / async tasks |
+| `tool` / `mcp` | Tool and MCP server registration |
+| `skill` | Skill packages |
+| `kdb` | Knowledge base |
+| `llm_provider` | Model provider configuration |
+| `auth` / `oauth2` / `user` | Login, users, third-party OAuth2 (e.g. Lage) |
+| `oss` | Object storage |
+| `observability` | Observability data |
+| `system` / `version` | System info, version |
+
+## Boundary with sagents
+
+```mermaid
+flowchart TB
+    subgraph Startup
+        Init[lifecycle.initialize_system]
+        Init --> ToolMgr[global ToolManager]
+        Init --> SkillMgr[global SkillManager]
+        Init --> SessMgr[global SessionManager]
+        Init --> ObsMgr[ObservabilityManager]
+    end
+
+    subgraph Per Request
+        Req[Incoming request]
+        Req --> Pick[pick model + tool/skill subset + sandbox]
+        Pick --> Build[build ToolProxy / SkillProxy / system_prefix]
+        Build --> Call[SAgent.run_stream]
+        Call --> Sse[turn into SSE / JSON Lines]
+    end
+
+    ToolMgr -.reused.-> Build
+    SkillMgr -.reused.-> Build
+    SessMgr -.reused.-> Call
+```
+
+The server does not re-implement agent logic. It assembles HTTP/SSE protocol, auth, user/agent config and model providers into `SAgent.run_stream` arguments. See [sagents Overview](ARCHITECTURE_SAGENTS_OVERVIEW.md).
+
+## Web Client Structure
+
+```mermaid
+flowchart TB
+    subgraph G_Src ["app/server/web/src"]
+        Entry[main.js · App.vue]
+        Router[router · vue-router]
+        Stores[stores · Pinia]
+        Api[api · HTTP/SSE clients]
+        Comp[components · generic UI]
+        Compose[composables · chat/SSE hooks]
+        Views[views · page components]
+        I18n[locales · i18n]
+        Util[utils]
+    end
+
+    Entry --> Router --> Views
+    Views --> Comp
+    Views --> Compose
+    Compose --> Api
+    Stores -.state.-> Views
+    Stores -.state.-> Compose
+```
+
+The frontend subscribes to chunks via SSE and renders them based on `MessageChunk.role` / `message_type` (text, tool calls, token usage, etc.).
+
+## Deployment Shapes
+
+- `python -m app.server.main` for development.
+- `docker-compose.yml` / `docker/` images for production (recommended).
+
+See [Configuration](CONFIGURATION.md) and [Getting Started](GETTING_STARTED.md).
+
+## Extending: Add a New Router
+
+The most common server-side extension is "add a new HTTP resource". Template:
+
+```python
+# app/server/routers/my_module.py
+from fastapi import APIRouter, Depends
+from app.server.core.auth import current_user
+
+router = APIRouter(prefix="/api/my", tags=["my"])
+
+@router.get("/ping")
+async def ping(user=Depends(current_user)):
+    return {"ok": True, "user_id": user.id}
+```
+
+```python
+# Register in app/server/routers/__init__.py
+from . import my_module
+
+def register_routes(app):
+    ...
+    app.include_router(my_module.router)
+```
+
+Put business logic in `services/`. The router stays thin: parse, auth, format response.

--- a/docs/en/ARCHITECTURE_SAGENTS_AGENT_FLOW.md
+++ b/docs/en/ARCHITECTURE_SAGENTS_AGENT_FLOW.md
@@ -1,0 +1,326 @@
+---
+
+## layout: default
+title: Agent & Flow Orchestration
+parent: Architecture
+nav_order: 5
+description: "AgentBase, the specialized agents, AgentFlow / FlowExecutor and the three agent_modes"
+lang: en
+ref: architecture-sagents-agent-flow
+
+{% include lang_switcher.html %}
+
+# Agent & Flow Orchestration
+
+This page covers `sagents/agent/` and `sagents/flow/`. **An agent is the unit of work; a flow defines the relationships between agents.** They are decoupled: changing the flow does not change the agents, and vice versa.
+
+## 1. The Agent Layer
+
+### 1.1 What `AgentBase` Provides
+
+```mermaid
+flowchart LR
+    Base[AgentBase] --> RunStream[run_stream<br/>uniform async stream interface]
+    Base --> Model[holds model + model_config]
+    Base --> SafeCall[LLM call: retry + fallback + sanitize]
+    Base --> PromptCache[prompt cache control]
+    Base --> Schema[tool schema conversion]
+    Base --> Stream[streaming chunk assembly]
+    Base --> Live[read Session/SessionContext]
+```
+
+
+
+Agents own no per-conversation state — that lives in `SessionContext` — so agents can be reused concurrently.
+
+### 1.2 Specialized Agents
+
+```mermaid
+flowchart TB
+    subgraph Routing & analysis
+        Router[task_router]
+        Analysis[task_analysis]
+    end
+
+    subgraph Recall & suggestion
+        Recall[memory_recall]
+        ToolSug[tool_suggestion]
+        WfSel[workflow_select]
+        QSug[query_suggest]
+    end
+
+    subgraph Simple mode
+        Plan[plan]
+        Simple[simple]
+    end
+
+    subgraph Multi-agent mode
+        TPlan[task_planning]
+        TDecomp[task_decompose]
+        TExec[task_executor]
+        TObs[task_observation]
+        TJudge[task_completion_judge]
+        TSum[task_summary]
+    end
+
+    subgraph Fibre mode
+        Fibre[fibre]
+        SelfCheck[self_check]
+    end
+```
+
+
+
+Each agent's `agent_key` is how flow nodes reference it (e.g. `task_router`, `simple`, `task_planning`).
+
+### 1.3 `FibreAgent` and Sub-agent Orchestration
+
+```mermaid
+flowchart TB
+    Main[Main Session] --> FA[FibreAgent.run_stream]
+    FA --> Orch[FibreOrchestrator]
+    Orch --> Defs[(AgentDefinition registry<br/>sub-agent configs)]
+    Orch --> Backend[FibreBackendClient<br/>fetch/manage sub-agents)]
+    Orch --> SubMgr[shared SessionManager]
+    Orch -->|delegated tool call| Sub[Sub-session 1..N]
+    Sub -->|result| Orch
+    Orch -->|aggregate| FA
+```
+
+
+
+In short: **in fibre mode, the main agent delegates work to sub-agents via tool calls; each sub-agent runs in its own sub-session and the result flows back to the main session.**
+
+## 2. The Flow Layer
+
+### 2.1 Node Types
+
+```mermaid
+flowchart LR
+    Flow[AgentFlow.root] --> N1[AgentNode<br/>run a single agent]
+    Flow --> N2[SequenceNode<br/>run steps in order]
+    Flow --> N3[ParallelNode<br/>concurrent + max_concurrency]
+    Flow --> N4[LoopNode<br/>condition + max_loops circuit breaker]
+    Flow --> N5[IfNode<br/>true_body / false_body]
+    Flow --> N6[SwitchNode<br/>variable + cases + default]
+```
+
+
+
+The whole flow is wrapped by `AgentFlow(name, root)`. `run_stream` also accepts `custom_flow` to fully replace the default orchestration.
+
+### 2.2 Condition Registry `flow/conditions.py`
+
+```mermaid
+flowchart LR
+    Reg[ConditionRegistry] --> C1[is_deep_thinking]
+    Reg --> C2[enable_more_suggest]
+    Reg --> C3[enable_plan]
+    Reg --> C4[plan_should_start_execution]
+    Reg --> C5[task_not_completed]
+    Reg --> C6[self_check_should_retry]
+    Reg --> C7[need_summary]
+
+    Reg -.referenced by.-> If[IfNode.condition]
+    Reg -.referenced by.-> Loop[LoopNode.condition]
+```
+
+
+
+Callers can register custom conditions and reference them from `custom_flow` (see end of this page).
+
+### 2.3 Executor `flow/executor.py`
+
+```mermaid
+flowchart TB
+    Start([execute AgentFlow.root]) --> Dispatch{node type?}
+
+    Dispatch -->|AgentNode| Run[get agent → run_stream<br/>pass chunks through]
+    Dispatch -->|SequenceNode| Seq[run steps in order]
+    Dispatch -->|ParallelNode| Par[asyncio gather + semaphore]
+    Dispatch -->|LoopNode| L1[check condition + max_loops]
+    Dispatch -->|IfNode| If1[check condition]
+    Dispatch -->|SwitchNode| Sw1[read variable → cases]
+
+    Run --> Check{Session status?}
+    Seq --> Check
+    Par --> Check
+    L1 --> Check
+    If1 --> Check
+    Sw1 --> Check
+
+    Check -->|RUNNING| NextNode[next node]
+    Check -->|INTERRUPTED / ERROR| Stop([stop])
+
+    NextNode --> Dispatch
+```
+
+
+
+The executor only decides "how to walk the graph"; what happens inside an agent is the agent's own concern.
+
+## 3. Default Flow: simple / multi / fibre
+
+What `SAgent._build_default_flow(agent_mode, max_loop_count)` actually builds:
+
+```mermaid
+flowchart TB
+    Start([input messages]) --> R[task_router]
+    R --> DT{is_deep_thinking?}
+    DT -->|yes| Ana[task_analysis] --> Sw
+    DT -->|no| Sw
+    Sw{Switch agent_mode}
+    Sw -->|simple| SimpleBody
+    Sw -->|multi| MultiBody
+    Sw -->|fibre| FibreBody
+    SimpleBody --> More
+    MultiBody --> More
+    FibreBody --> More
+    More{enable_more_suggest?}
+    More -->|yes| QS[query_suggest]
+    More -->|no| End
+    QS --> End([done])
+```
+
+
+
+### simple_agent_body
+
+```mermaid
+flowchart TB
+    S0([enter simple]) --> Par1{parallel}
+    Par1 --> ToolSug1[tool_suggestion]
+    Par1 --> Recall1[memory_recall]
+    ToolSug1 --> If1
+    Recall1 --> If1
+    If1{enable_plan?}
+    If1 -->|yes| Plan1[plan]
+    Plan1 --> If2{plan_should_start_execution?}
+    If2 -->|yes| SimpleAgent1[simple]
+    If2 -->|no| Need
+    If1 -->|no| SimpleAgent2[simple]
+    SimpleAgent1 --> Need
+    SimpleAgent2 --> Need
+    Need{need_summary?}
+    Need -->|yes| Sum[task_summary] --> EndS
+    Need -->|no| EndS([end simple])
+```
+
+
+
+### multi_agent_full
+
+```mermaid
+flowchart TB
+    M0([enter multi]) --> Recall2[memory_recall]
+    Recall2 --> Loop[Loop: task_not_completed<br/>up to max_loop_count]
+    Loop --> P[task_planning]
+    P --> TS[tool_suggestion]
+    TS --> E[task_executor]
+    E --> O[task_observation]
+    O --> J[task_completion_judge]
+    J -.task_not_completed.-> Loop
+    J -->|done| Sum2[task_summary]
+    Sum2 --> EndM([end multi])
+```
+
+
+
+### fib_agent_body
+
+```mermaid
+flowchart TB
+    F0([enter fibre]) --> Loop2[Loop: self_check_should_retry<br/>up to 3]
+    Loop2 --> Core[fibre core]
+    Core --> Par2{parallel}
+    Par2 --> TS2[tool_suggestion]
+    Par2 --> R2[memory_recall]
+    TS2 --> If3
+    R2 --> If3
+    If3{enable_plan?}
+    If3 -->|yes| Plan2[plan] --> If4{plan_should_start_execution?}
+    If4 -->|yes| FibA[fibre]
+    If4 -->|no| SC
+    If3 -->|no| FibB[fibre]
+    FibA --> SC
+    FibB --> SC
+    SC[self_check]
+    SC -.should_retry.-> Loop2
+    SC -->|stop| EndF([end fibre])
+```
+
+
+
+## 4. Extending: Custom Flow & Sub-agents
+
+The runtime exposes three extension points that, combined, can build arbitrary orchestration **without touching sagents source**.
+
+### 4.1 Register a custom condition
+
+```python
+from sagents.flow.conditions import ConditionRegistry
+
+@ConditionRegistry.register("user_paid")
+def _user_paid(session_context, session=None) -> bool:
+    return session_context.system_context.get("plan") == "pro"
+```
+
+### 4.2 Custom Flow
+
+```python
+from sagents.flow.schema import (
+    AgentFlow, SequenceNode, AgentNode, IfNode, LoopNode,
+)
+
+custom_flow = AgentFlow(
+    name="My Pipeline",
+    root=SequenceNode(steps=[
+        AgentNode(agent_key="task_router"),
+        IfNode(
+            condition="user_paid",
+            true_body=LoopNode(
+                condition="task_not_completed",
+                max_loops=10,
+                body=SequenceNode(steps=[
+                    AgentNode(agent_key="task_planning"),
+                    AgentNode(agent_key="task_executor"),
+                    AgentNode(agent_key="task_completion_judge"),
+                ]),
+            ),
+            false_body=AgentNode(agent_key="simple"),
+        ),
+        AgentNode(agent_key="task_summary"),
+    ]),
+)
+
+async for chunks in agent.run_stream(
+    ...,
+    custom_flow=custom_flow,
+):
+    ...
+```
+
+When `custom_flow` is provided, `agent_mode` / `_build_default_flow` are bypassed.
+
+### 4.3 Custom sub-agents (fibre)
+
+`custom_sub_agents=[...]` injects extra sub-agent definitions without rewriting the flow, primarily for fibre orchestration:
+
+```python
+async for chunks in agent.run_stream(
+    ...,
+    agent_mode="fibre",
+    custom_sub_agents=[
+        {
+            "agent_key": "data_fetcher",
+            "description": "Pulls data from internal BI",
+            "system_prompt": "...",
+            "available_tools": ["http_fetcher", "sql_runner"],
+        },
+        # more sub-agent definitions...
+    ],
+):
+    ...
+```
+
+The main fibre agent recognizes these as valid delegation targets.

--- a/docs/en/ARCHITECTURE_SAGENTS_OVERVIEW.md
+++ b/docs/en/ARCHITECTURE_SAGENTS_OVERVIEW.md
@@ -1,0 +1,244 @@
+---
+
+## layout: default
+title: sagents Overview
+parent: Architecture
+nav_order: 4
+description: "Layering, module boundaries and the full path of one run_stream call inside sagents/"
+lang: en
+ref: architecture-sagents-overview
+
+{% include lang_switcher.html %}
+
+# sagents Overview
+
+`sagents/` is the core runtime of Sage. Every app shape (server, desktop, CLI, examples) ultimately runs a conversation through it. This page uses diagrams to lay out its layering, modules and the end-to-end path of one `run_stream` call.
+
+## Design Principles
+
+```mermaid
+flowchart LR
+    P1[Separation of concerns<br/>logic / state / capabilities / infra]
+    P2[Centralized state<br/>SessionContext blackboard]
+    P3[Observability first<br/>built-in event hooks]
+    P4[Protocol-driven<br/>MCP / OpenAI compatible]
+    P5[Sandbox abstraction<br/>local/remote/passthrough behind one interface]
+```
+
+
+
+## Layering and Modules
+
+```mermaid
+flowchart TB
+    subgraph Entry
+        SAgent[SAgent · runtime façade]
+        SessRT[Session / SessionManager]
+    end
+
+    subgraph G_Flow ["Orchestration (flow/)"]
+        Flow[AgentFlow + FlowExecutor + Conditions]
+    end
+
+    subgraph G_Agent ["Agents (agent/)"]
+        Agents[Specialized *Agents]
+        Fibre[fibre · sub-agent orchestration]
+        Agents -.fibre mode.-> Fibre
+    end
+
+    subgraph G_Ctx ["State (context/)"]
+        Ctx[SessionContext]
+        Msg[MessageManager + ContextBudget]
+        Mem[session_memory + user_memory]
+        Wf[workflows]
+    end
+
+    subgraph Capabilities
+        LLM[llm · SageOpenAI / capabilities]
+        Tools[tool · ToolManager + MCP]
+        Skills[skill · SkillManager]
+        Retr[retrieve_engine · RAG]
+    end
+
+    subgraph Infra
+        Sandbox[utils/sandbox · 3 sandbox kinds]
+        Obs[observability · OpenTelemetry]
+        Util[utils · logger/lock/prompt/...]
+    end
+
+    SAgent --> SessRT --> Flow --> Agents
+    Agents --> Ctx
+    Ctx --> Msg
+    Ctx --> Mem
+    Ctx --> Wf
+    Agents --> LLM
+    Agents --> Tools
+    Agents --> Skills
+    Agents --> Retr
+    SessRT --> Sandbox
+    SessRT --> Obs
+```
+
+
+
+## End-to-End: One `SAgent.run_stream`
+
+```mermaid
+sequenceDiagram
+    participant Caller as Caller<br/>(server/desktop/cli)
+    participant SAgent as SAgent.run_stream
+    participant SM as SessionManager
+    participant Sess as Session
+    participant Flow as FlowExecutor
+    participant Agent as Some Agent
+    participant LLM as SageAsyncOpenAI
+    participant Tool as ToolManager
+    participant Sandbox as Sandbox
+    participant Obs as Observability
+
+    Caller->>SAgent: run_stream(messages, model, ...)
+    SAgent->>SAgent: validate args / resolve sandbox_type
+    SAgent->>SM: get_or_create(session_id, sandbox_type)
+    SM-->>SAgent: Session
+    SAgent->>Sess: configure_runtime(model, sandbox, workspace, agent_id)
+    SAgent->>Obs: on_chain_start
+    SAgent->>SAgent: _build_default_flow(agent_mode) or custom_flow
+    SAgent->>Sess: run_stream_safe(messages, flow, tools, skills, ...)
+    Sess->>Flow: execute AgentFlow.root
+    loop each node
+        Flow->>Agent: instantiate + run_stream
+        Agent->>LLM: chat_completion(messages, tools)
+        LLM-->>Agent: streaming chunks (incl. tool_calls)
+        opt tool calls present
+            Agent->>Tool: run_tool(name, args)
+            Tool->>Sandbox: command/code/file ops
+            Sandbox-->>Tool: result
+            Tool-->>Agent: tool_message
+        end
+        Agent-->>Flow: yield MessageChunk(s)
+    end
+    Sess-->>SAgent: async generator keeps yielding
+    SAgent-->>Caller: yield [MessageChunk]
+    SAgent->>Obs: record TTFB / message timings
+    SAgent->>SM: close_session
+```
+
+
+
+## Key Parameters of `SAgent.run_stream`
+
+```mermaid
+flowchart TB
+    Caller[Caller] --> Args{run_stream args}
+
+    Args --> M[Model layer<br/>model + model_config + system_prefix]
+    Args --> SBX[Sandbox<br/>sandbox_type + sandbox_agent_workspace<br/>+ volume_mounts + sandbox_id]
+    Args --> CAP[Capabilities<br/>tool_manager + skill_manager]
+    Args --> ID[Identity<br/>session_id + user_id + agent_id]
+    Args --> MODE[Mode<br/>agent_mode: simple/multi/fibre<br/>+ max_loop_count]
+    Args --> EXT[Extension points<br/>custom_flow + custom_sub_agents<br/>+ available_workflows + system_context<br/>+ context_budget_config]
+```
+
+
+
+Constraints:
+
+- `model` and `model_config` are required.
+- `max_loop_count` is required as the final circuit breaker.
+- `sandbox_type` precedence: argument > `__init__` > `SAGE_SANDBOX_MODE` env > default `local`.
+- Sandbox modes have different `sandbox_agent_workspace` requirements (local/passthrough required; remote falls back to `/sage-workspace`).
+
+## Default Flow: the Three `agent_mode`s
+
+```mermaid
+flowchart TB
+    Start([input messages]) --> Router[task_router]
+    Router --> DT{is_deep_thinking?}
+    DT -->|yes| Analysis[task_analysis] --> Sw
+    DT -->|no| Sw
+    Sw{agent_mode}
+    Sw -->|simple| Simple[simple body<br/>tool_suggestion ∥ memory_recall<br/>→ plan? → simple → summary?]
+    Sw -->|multi| Multi[multi body<br/>memory_recall<br/>→ Loop plan/exec/observe/judge<br/>→ task_summary]
+    Sw -->|fibre| Fibre[fibre body<br/>Loop self_check_should_retry<br/>→ fibre core → self_check]
+    Simple --> More
+    Multi --> More
+    Fibre --> More
+    More{enable_more_suggest?}
+    More -->|yes| Sug[query_suggest] --> End([output])
+    More -->|no| End
+```
+
+
+
+`task_router` may rewrite `audit_status.agent_mode` at runtime, so even if `simple` is passed initially, the router may switch to `multi` or `fibre`. See [Agent & Flow Orchestration](ARCHITECTURE_SAGENTS_AGENT_FLOW.md) for node-by-node detail.
+
+## How the Modules Cooperate
+
+```mermaid
+flowchart LR
+    Sess[Session] -->|owns| Ctx[SessionContext]
+    Flow[FlowExecutor] -->|resolve agent per node| Agent
+    Agent -->|read/write| Ctx
+    Agent -->|call| LLM
+    Agent -->|call| ToolMgr
+    ToolMgr -->|local| Local[built-in tools]
+    ToolMgr -->|external| MCP
+    Local --> Sandbox
+    SkillMgr -->|project to sandbox| SandboxSkill[SandboxSkillManager]
+    SandboxSkill --> Sandbox
+    Obs[ObservabilityManager] -.events.-> Sess
+    Obs -.events.-> Agent
+    Obs -.events.-> ToolMgr
+    Obs -.events.-> LLM
+```
+
+
+
+Key points:
+
+- **Agents own no state**; everything goes through `SessionContext`, enabling reuse and concurrency.
+- **Tool execution lands on the Sandbox**; the tool layer never touches the host directly.
+- **Observability is cross-cutting**; every key event flows through `ObservabilityManager`.
+
+## What to Read Next
+
+```mermaid
+flowchart LR
+    Here[sagents Overview] --> A[Agent + Flow] --> B[Session + Context] --> C[Tool + Skill] --> D[Sandbox + LLM + Obs]
+```
+
+
+
+- [Agent & Flow](ARCHITECTURE_SAGENTS_AGENT_FLOW.md)
+- [Session & Context](ARCHITECTURE_SAGENTS_SESSION_CONTEXT.md)
+- [Tool & Skill](ARCHITECTURE_SAGENTS_TOOL_SKILL.md)
+- [Sandbox / LLM / Obs](ARCHITECTURE_SAGENTS_SANDBOX_OBS.md)
+
+## Extending: Minimal Caller Template
+
+The minimal way to use `SAgent.run_stream` as an SDK, useful for cross-checking parameters:
+
+```python
+import asyncio
+from openai import AsyncOpenAI
+from sagents.sagents import SAgent
+
+async def main():
+    agent = SAgent(session_root_space="/tmp/sage", sandbox_type="local")
+    model = AsyncOpenAI(api_key="...", base_url="...")
+    async for chunks in agent.run_stream(
+        input_messages=[{"role": "user", "content": "Hello"}],
+        model=model,
+        model_config={"model": "gpt-4o-mini"},
+        system_prefix="You are an assistant",
+        sandbox_agent_workspace="/tmp/sage/agents/demo",
+        max_loop_count=8,
+        agent_mode="simple",
+    ):
+        for c in chunks:
+            print(c.role, c.content)
+
+asyncio.run(main())
+```
+
+For more advanced extension points (custom flow, sub-agents, conditions), see the next page.

--- a/docs/en/ARCHITECTURE_SAGENTS_SANDBOX_OBS.md
+++ b/docs/en/ARCHITECTURE_SAGENTS_SANDBOX_OBS.md
@@ -1,0 +1,299 @@
+---
+layout: default
+title: Sandbox / LLM / Observability
+parent: Architecture
+nav_order: 8
+description: "Sandbox abstraction (Local / Remote / Passthrough), LLM client wrapper with capability probe, ObservabilityManager and OpenTelemetry"
+lang: en
+ref: architecture-sagents-sandbox-obs
+---
+
+{% include lang_switcher.html %}
+
+# Sandbox / LLM / Observability
+
+This chapter groups three cross-cutting concerns:
+
+- **Sandbox**: every entry point that "executes user/Agent code" goes through one unified interface.
+- **LLM layer**: model clients, capability probes, prompt cache and so on are wrapped in `SageAsyncOpenAI`.
+- **Observability**: a session's runtime trail is dispatched through `ObservabilityManager` to multiple handlers; OpenTelemetry is the default implementation.
+
+These don't show up in business flows directly, but if any of them breaks the whole runtime breaks – hence a dedicated chapter.
+
+## 1. Sandbox `sagents/utils/sandbox/`
+
+### 1.1 Module Composition
+
+```mermaid
+flowchart TB
+    Iface[interface.py · ISandboxHandle abstraction]
+    Cfg[config.py · SandboxConfig + VolumeMount]
+    Factory[factory.py · SandboxProviderFactory]
+
+    subgraph Providers ["providers/"]
+        Local[local · venv + bwrap/seatbelt isolation]
+        Remote[remote · OpenSandbox / K8s / Firecracker]
+        Pass[passthrough · no isolation, host execution]
+    end
+
+    Iface -.implemented by.-> Local
+    Iface -.implemented by.-> Remote
+    Iface -.implemented by.-> Pass
+    Cfg --> Factory
+    Factory -->|by mode| Local
+    Factory -->|by mode| Remote
+    Factory -->|by mode| Pass
+```
+
+`ISandboxHandle` is the **only** interface the tool layer sees – every implementation looks the same to a tool.
+
+### 1.2 Three Sandbox Modes
+
+```mermaid
+flowchart LR
+    Tool[tool/impl/* calls sandbox] --> SH{ISandboxHandle}
+    SH -->|LOCAL| L[Local venv + Linux bwrap / macOS seatbelt]
+    SH -->|REMOTE| R[Remote container / MicroVM]
+    SH -->|PASSTHROUGH| P[Run directly in current process cwd]
+    L --> Use1[default for desktop/server]
+    R --> Use2[shared / multi-tenant / restricted]
+    P --> Use3[examples / CLI debug]
+```
+
+- **LOCAL**: default. Each session gets its own `sandbox_agent_workspace`, plus resource limits (CPU time, memory, allowed paths).
+- **REMOTE**: outsource execution to OpenSandbox / Kubernetes / Firecracker; the factory selects the implementation by `remote_provider`.
+- **PASSTHROUGH**: no isolation at all, run on the host – mostly for local CLI and examples.
+
+### 1.3 Key Capabilities of ISandboxHandle
+
+```mermaid
+flowchart TB
+    H[ISandboxHandle] --> Meta[Metadata<br/>sandbox_type / sandbox_id / workspace_path]
+    H --> Cmd[execute_command<br/>workdir / timeout / env_vars]
+    H --> Py[execute_python<br/>requirements / workdir / timeout]
+    H --> FS[File I/O<br/>read_file / write_file / list_dir]
+    H --> Mounts[volume_mounts<br/>host/virtual path mapping]
+```
+
+The tool layer (`execute_command_tool`, `file_system_tool`, ...) only ever calls this surface; it has no idea whether the implementation is a venv or a remote container.
+
+### 1.4 One Tool Call End-to-End
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Agent
+    participant TM as ToolManager
+    participant Tool as execute_command_tool
+    participant Sandbox as ISandboxHandle
+    participant Provider as Local/Remote/Passthrough
+
+    Agent->>TM: run_tool("execute_command", args)
+    TM->>Tool: invoke implementation
+    Tool->>Sandbox: execute_command(cmd, ...)
+    Sandbox->>Provider: actually run (venv subprocess / remote RPC / host)
+    Provider-->>Sandbox: CommandResult
+    Sandbox-->>Tool: CommandResult
+    Tool-->>TM: truncated string output
+    TM-->>Agent: tool_message
+```
+
+### 1.5 Interaction with Skills
+
+```mermaid
+flowchart LR
+    Sess[Session] --> SC[SessionContext.init_more]
+    SC --> Sandbox[(sandbox instance)]
+    SC --> SSM[SandboxSkillManager]
+    SSM -->|copy/project| SkillDir[(fixed path inside sandbox)]
+    Tool -->|read/write| Sandbox
+    Tool -->|read skill assets| SkillDir
+```
+
+`SandboxSkillManager` bridges "skill → sandbox": once the sandbox is up, it places skill packages at conventional paths inside, so in-sandbox tool scripts can use them like local files.
+
+## 2. LLM Layer `sagents/llm/`
+
+### 2.1 Module Composition
+
+```mermaid
+flowchart TB
+    SAOAI[SageAsyncOpenAI · dual-client wrapper]
+    Chat[chat.py · stream + tool-call assembly]
+    Embed[embedding.py · embedding wrapper]
+    Cap[capabilities.py · sanitize_model_request_kwargs]
+    MCap[model_capabilities.py · startup capability probe]
+
+    SAOAI -->|standard / fast| Chat
+    SAOAI --> Embed
+    SAOAI -.uses.-> Cap
+    MCap -.injects after probing.-> SAOAI
+```
+
+### 2.2 SageAsyncOpenAI: Dual Clients
+
+```mermaid
+flowchart LR
+    Caller[Agent calls chat.completions.create] --> Sage[SageAsyncOpenAI]
+    Sage -->|model_type=standard| Std[Standard client<br/>main LLM]
+    Sage -->|model_type=fast| Fast[Fast client<br/>routers / classifiers]
+    Fast -.fallback when not configured.-> Std
+    Sage --> San[sanitize_model_request_kwargs<br/>scrub kwargs by capability]
+    San --> Std
+    San --> Fast
+```
+
+Highlights:
+
+- Interface is fully `AsyncOpenAI`-compatible, only adds a `model_type` parameter.
+- Capability flags (`supports_multimodal` / `supports_structured_output` / ...) are attached to the client object so call sites can read them directly without threading config through the stack.
+- `sanitize_model_request_kwargs` strips request fields that the underlying model does not support (e.g. drop `reasoning_effort` for non-reasoning models).
+
+### 2.3 Startup Capability Probe
+
+```mermaid
+flowchart TD
+    Boot[Startup: lifecycle.initialize_system] --> Probe[probe_connection / capabilities]
+    Probe --> P1[Send a minimal request<br/>verify connectivity + model name]
+    Probe --> P2[Send structured-output request<br/>infer supports_structured_output]
+    Probe --> P3[Send image input request<br/>infer supports_multimodal]
+    P1 --> Cap[(model_capabilities dict)]
+    P2 --> Cap
+    P3 --> Cap
+    Cap --> SAOAI[wrapped into SageAsyncOpenAI]
+```
+
+The probe runs once; its result lives with `SageAsyncOpenAI` for the entire lifetime so we don't reprobe per request.
+
+## 3. Observability `sagents/observability/`
+
+### 3.1 Module Composition
+
+```mermaid
+flowchart TB
+    Base[base.py · BaseTraceHandler abstract events]
+    Mgr[manager.py · ObservabilityManager multi-handler dispatcher]
+    Otel[opentelemetry_handler.py · default impl]
+    Runtime[agent_runtime.py · runtime-side helpers]
+
+    Base -.implemented by.-> Otel
+    Otel -->|registered into| Mgr
+    Mgr --> Runtime
+```
+
+### 3.2 Event Model
+
+```mermaid
+flowchart LR
+    Chain[on_chain_start/end/error<br/>whole session]
+    Agent[on_agent_start/end/error<br/>one Agent run]
+    LLM[on_llm_start/end/error<br/>one model call]
+    Tool[on_tool_start/end/error<br/>one tool call]
+    Msg[on_message_start/end<br/>one message]
+
+    Chain --> Agent --> LLM
+    Agent --> Tool
+    Agent --> Msg
+```
+
+`BaseTraceHandler` defines the **shape** of observability: chain / agent / llm / tool / message events, all paired (`start` / `end`, plus optional `error`).
+
+### 3.3 ObservabilityManager Dispatch
+
+```mermaid
+flowchart LR
+    Source[components emit events] --> Mgr[ObservabilityManager]
+    Mgr --> H1[OpenTelemetryTraceHandler]
+    Mgr --> H2[Custom handler 1]
+    Mgr --> H3[Custom handler N]
+    Mgr -.handler raises.-> Skip[only logged, others continue]
+```
+
+The dispatcher tolerates a single handler raising: the main flow is not interrupted and other handlers keep working.
+
+### 3.4 OpenTelemetry Implementation
+
+```mermaid
+flowchart TD
+    Start[on_*_start] --> NewSpan[create OTel Span]
+    NewSpan --> Attach[context.attach onto stack<br/>contextvars-safe across tasks]
+    Action[business runs] --> Anno[span.set_attribute / add_event]
+    End[on_*_end] --> Finalize[span.set_status OK<br/>span.end + pop]
+    Err[on_*_error] --> ErrSpan[span.record_exception<br/>set_status ERROR + pop]
+```
+
+Highlights:
+
+- Uses a `ContextVar` span stack so that nested async tasks don't tangle parent/child relationships.
+- Cross-context detach errors are explicitly swallowed (very common when an async generator is cancelled across boundaries).
+- This layer only **produces** OTel spans; where they are exported (Jaeger / Tempo / OTLP) is decided by the OpenTelemetry SDK config outside the runtime.
+
+## 4. How They Connect
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant SA as SAgent
+    participant Obs as ObservabilityManager
+    participant LLM as SageAsyncOpenAI
+    participant Tool as ToolProxy
+    participant SB as Sandbox
+
+    SA->>Obs: on_chain_start(session_id)
+    SA->>Obs: on_agent_start
+    SA->>LLM: chat.completions.create(...)
+    LLM-->>Obs: on_llm_start/end
+    LLM-->>SA: streaming response (with tool_call)
+    SA->>Tool: run_tool
+    Tool->>SB: execute_command / read_file
+    Tool-->>Obs: on_tool_start/end
+    SB-->>Tool: result
+    Tool-->>SA: tool_message
+    SA->>Obs: on_agent_end
+    SA->>Obs: on_chain_end
+```
+
+Within a single session: business logic moves through `SAgent`; everything "observable from the outside" is emitted via `ObservabilityManager`; everything that "executes across a process boundary" funnels into `SageAsyncOpenAI` and `ISandboxHandle`. That is how sagents decouples cross-cutting concerns.
+
+## 5. Extending: Custom Handler / Provider
+
+### 5.1 Custom Observability Handler
+
+```python
+from sagents.observability.base import BaseTraceHandler
+
+class MyHandler(BaseTraceHandler):
+    def on_llm_start(self, session_id, model_name, messages, step_name=None, **kwargs):
+        print(f"[LLM start] session={session_id} model={model_name} step={step_name}")
+
+    def on_llm_end(self, response, **kwargs):
+        print("[LLM end]", getattr(response, "usage", None))
+
+manager.add_handler(MyHandler())
+```
+
+- You only need to override the events you care about; the rest fall through to the no-op base impl.
+- Raising inside a handler will not break the main flow but **is** logged, which makes debugging easy.
+
+### 5.2 Custom Remote Sandbox
+
+```python
+from sagents.utils.sandbox.interface import ISandboxHandle, SandboxType, CommandResult
+from sagents.utils.sandbox.factory import SandboxProviderFactory
+
+class MyRemoteSandbox(ISandboxHandle):
+    @property
+    def sandbox_type(self): return SandboxType.REMOTE
+    @property
+    def sandbox_id(self): return self._id
+    # ... implement the rest of the interface ...
+
+    async def execute_command(self, command, workdir=None, timeout=30, env_vars=None):
+        # call your own RPC / HTTP / SSH
+        ...
+        return CommandResult(success=True, stdout="...", stderr="", return_code=0, execution_time=0.1)
+
+SandboxProviderFactory.register_remote_provider("my_remote", MyRemoteSandbox)
+```
+
+After that, `SandboxConfig(mode=SandboxType.REMOTE, remote_provider="my_remote", ...)` will route to your implementation.

--- a/docs/en/ARCHITECTURE_SAGENTS_SESSION_CONTEXT.md
+++ b/docs/en/ARCHITECTURE_SAGENTS_SESSION_CONTEXT.md
@@ -1,0 +1,235 @@
+---
+
+## layout: default
+title: Session & Context
+parent: Architecture
+nav_order: 6
+description: "Session, SessionContext, message manager, session/user memory and Workflow"
+lang: en
+ref: architecture-sagents-session-context
+
+{% include lang_switcher.html %}
+
+# Session & Context
+
+`sagents/session_runtime.py` and `sagents/context/` together form the "state layer". Agents are stateless processors; everything stateful lives here.
+
+## 1. Session Lifecycle: `Session` and `SessionManager`
+
+```mermaid
+flowchart LR
+    SAgent --> SM[SessionManager · process-wide singleton]
+    SM --> Map[(session_id → Session map)]
+    SM --> S1[Session]
+    SM --> S2[Session]
+    SM --> S3[...]
+    S1 --> Ctx1[SessionContext]
+    S2 --> Ctx2[SessionContext]
+    S1 --> Lock1[lock_manager cross-session locks]
+    SM --> CV[_session_id_var · ContextVar<br/>fetch current session_id anywhere]
+```
+
+
+
+`SessionManager` provides:
+
+- `get_or_create(session_id, sandbox_type)`
+- `save_session / interrupt_session / close_session`
+- `get_live_session(session_id)`: get a live Session reference from anywhere
+- Cooperates with `lock_manager` so one session is not driven concurrently
+
+### Session State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE
+    IDLE --> RUNNING: run_stream_safe acquires lock & starts
+    RUNNING --> COMPLETED: flow ended normally
+    RUNNING --> INTERRUPTED: user/system interrupt
+    RUNNING --> ERROR: exception
+    COMPLETED --> [*]
+    INTERRUPTED --> [*]
+    ERROR --> [*]
+```
+
+
+
+`FlowExecutor` checks the session status before/after every node and bails out on `INTERRUPTED` / `ERROR` to avoid burning tokens halfway.
+
+## 2. `SessionContext`: the Blackboard
+
+```mermaid
+flowchart TB
+    subgraph SessionContext
+        ID[Identity<br/>session_id · user_id · agent_id · parent_session_id]
+        Sys[system_context · extra info injected into prompt]
+        WS[Workspace<br/>session_root_space · sandbox_agent_workspace · volume_mounts]
+        SBX[sandbox · ISandboxHandle]
+        TM[tool_manager]
+        SM[skill_manager + sandbox_skill_manager]
+        ST[status · audit_status]
+        MM[MessageManager]
+        SMM[SessionMemoryManager]
+        UMM[UserMemoryManager]
+        WF[WorkflowManager]
+        CB[ContextBudgetManager]
+    end
+
+    Agents -->|read/write| SessionContext
+```
+
+
+
+It is a **Blackboard**: agents collaborate by reading/writing it, with no direct dependency on each other.
+
+### Two-step Explicit Init
+
+```mermaid
+sequenceDiagram
+    participant Sess as Session
+    participant Ctx as SessionContext
+    participant Sandbox
+    participant SkillProj as SandboxSkillManager
+
+    Sess->>Ctx: __init__(session_id, user_id, ...)
+    Note right of Ctx: placeholder, sandbox=None
+    Sess->>Ctx: configure_runtime(model, sandbox cfg, agent_id)
+    Sess->>Ctx: await init_more()
+    Ctx->>Sandbox: SandboxProviderFactory.create(...)
+    Sandbox-->>Ctx: ISandboxHandle
+    Ctx->>SkillProj: project visible skills into sandbox
+    Ctx-->>Sess: ready
+```
+
+
+
+`init_more()` moves heavy resources (sandbox boot, skill projection) out of the constructor so a half-initialized context cannot leak.
+
+## 3. Messages: `MessageChunk` + `MessageManager`
+
+### 3.1 The Chunk Unit
+
+```mermaid
+flowchart LR
+    Chunk[MessageChunk] --> ID[message_id · session_id]
+    Chunk --> Role[role · user/assistant/tool/system]
+    Chunk --> Type[message_type · text/tool_call/tool_result/token_usage/...]
+    Chunk --> Content[content · tool_calls · tool_call_id]
+    Chunk --> Meta[timing & extension metadata]
+```
+
+
+
+The whole runtime streams `List[MessageChunk]`.
+
+### 3.2 MessageManager: Source of Truth for History
+
+```mermaid
+flowchart TB
+    Inputs[chunks in] --> MM[MessageManager]
+    MM --> Merge[merge same message_id pieces]
+    MM --> Filter[filter system messages<br/>system is built per-call by agents]
+    MM --> Compress[compress / trim by token budget]
+    MM --> Estimate[token estimation<br/>global ratio sample pool]
+    MM --> Out1[agents fetch budget-fitting history before LLM call]
+    MM --> Out2[stream out to caller]
+    MM --> CB[ContextBudgetManager<br/>window / priority / buffer]
+    CB --> Compress
+```
+
+
+
+Highlights:
+
+- System messages do not enter history; agents assemble them at call time.
+- Context budgeting is centralized in `ContextBudgetManager`; all agents share the same rules.
+- Token estimation uses a global sampled ratio (heuristic) to avoid running the tokenizer per message.
+
+## 4. Memory: Session-level + User-level
+
+```mermaid
+flowchart LR
+    subgraph Short term
+        SMM[SessionMemoryManager<br/>valid for the session lifetime]
+    end
+
+    subgraph Long term
+        UMM[UserMemoryManager · indexed by user_id]
+        UMM --> Iface[IMemoryDriver abstraction]
+        Iface --> Drv[ToolMemoryDriver / others]
+        UMM --> Ext[Extractor · LLM extracts persistent entries]
+        UMM --> Path[(MEMORY_ROOT_PATH<br/>or workspace/user_memory)]
+    end
+
+    Recall[memory_recall agent] -->|recall| SMM
+    Recall -->|recall| UMM
+    Tool[memory_tool] -->|read/write| UMM
+    Obs -. events .-> UMM
+```
+
+
+
+Memory is optional for agents — invoked explicitly by `MemoryRecallAgent` and similar — not forced into every session.
+
+## 5. Workflow: `context/workflows/`
+
+```mermaid
+flowchart LR
+    AvailWF[run_stream available_workflows arg] --> WM[WorkflowManager]
+    WM --> WfList[(registered workflow templates)]
+    WfSel[workflow_select agent] -->|pick on demand| WM
+    WM -->|currently usable steps| Agent
+```
+
+
+
+A `Workflow` is a "reusable task template" — a predefined sequence of steps. Note the naming overlap but distinct purposes:
+
+- `flow/`: which agents to run (orchestration)
+- `workflows/`: fixed operational steps for a class of business tasks (business template)
+
+## 6. State Evolution During One Session
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant SAgent
+    participant SM as SessionManager
+    participant Sess as Session
+    participant Ctx as SessionContext
+    participant MM as MessageManager
+    participant Mem as Memory Managers
+
+    Caller->>SAgent: run_stream(messages, ...)
+    SAgent->>SM: get_or_create(session_id)
+    SM-->>SAgent: Session
+    SAgent->>Sess: configure_runtime(...)
+    Sess->>Ctx: build or reuse SessionContext
+    Ctx->>Ctx: init_more() boots sandbox/skill projection
+    Sess->>Ctx: write audit_status (agent_mode, deep_thinking ...)
+    Sess->>MM: ingest input messages
+    loop each FlowExecutor step
+        Sess->>MM: fetch budget-fitting history
+        Sess->>Mem: recall session/user memory
+        Sess-->>Caller: yield streaming chunks
+        Sess->>MM: append assistant/tool chunks
+    end
+    SAgent->>SM: close_session(session_id)
+    SM->>Mem: trigger user memory extraction (on demand)
+```
+
+
+
+## 7. Relation to External Storage
+
+```mermaid
+flowchart LR
+    Ctx[SessionContext · pure runtime memory] --> AppLayer[App layer]
+    AppLayer --> Server[(app/server: multi-tenant DB / object storage)]
+    AppLayer --> Desktop[(app/desktop: local SQLite / user dir)]
+    AppLayer --> CLI[(app/cli / examples: files or in-memory)]
+```
+
+
+
+`SessionContext` itself does not bind to any database. **"Pure in-memory runtime + persistence in the app layer"** is one of the reasons sagents can be reused across so many app shapes.

--- a/docs/en/ARCHITECTURE_SAGENTS_TOOL_SKILL.md
+++ b/docs/en/ARCHITECTURE_SAGENTS_TOOL_SKILL.md
@@ -1,0 +1,318 @@
+---
+
+## layout: default
+title: Tool & Skill System
+parent: Architecture
+nav_order: 7
+description: "ToolManager / ToolProxy, built-in tools, MCP proxy, SkillManager / SkillProxy and in-sandbox skills"
+lang: en
+ref: architecture-sagents-tool-skill
+
+{% include lang_switcher.html %}
+
+# Tool & Skill System
+
+`sagents/tool/` and `sagents/skill/` form the "capability layer": they decide what an Agent can call during a session and how skill packages are loaded and executed.
+
+## 1. Tool System `sagents/tool/`
+
+### 1.1 Module Composition
+
+```mermaid
+flowchart TB
+    subgraph Registration
+        TBase[tool_base · @tool decorator + _DISCOVERED_TOOLS]
+        MBase[mcp_tool_base · _DISCOVERED_MCP_TOOLS]
+        Schema[tool_schema · ToolSpec / OpenAI function-calling schema]
+    end
+
+    subgraph Runtime
+        TM[ToolManager · global tool registry]
+        TP[ToolProxy · session-level whitelist]
+        MP[mcp_proxy · proxy to MCP servers]
+        Impl[impl/ · built-in tool implementations]
+    end
+
+    TBase -.collected by.-> TM
+    MBase -.collected by.-> TM
+    TM --> Impl
+    TM --> MP
+    Schema -.converts to.-> TM
+    TP --> TM
+```
+
+
+
+### 1.2 Two Classes of Tool Sources
+
+```mermaid
+flowchart LR
+    Agent --> TP[ToolProxy]
+    TP --> TM[ToolManager]
+    TM -->|local| Impl[tool/impl/*]
+    TM -->|MCP| MCPProxy[mcp_proxy]
+    MCPProxy --> Stdio[stdio MCP server]
+    MCPProxy --> SSE[SSE MCP server]
+    MCPProxy --> HTTP[Streamable HTTP MCP]
+    Impl --> Sandbox
+```
+
+
+
+Whether a tool is local or comes from an MCP server, it looks the same to the Agent. `ToolManager` registers them uniformly and dispatches by call name.
+
+### 1.3 ToolManager Capabilities
+
+```mermaid
+flowchart TB
+    Start[Startup] --> Scan[Scan registered tools<br/>local @tool + MCP]
+    Run[Runtime] --> Call[run_tool name + args + SessionContext]
+    Call --> Exec[local impl / remote MCP]
+    Exec --> Trunc[Truncate result by token<br/>MAX_TOOL_RESULT_TOKENS=12000]
+    Trunc --> ToAgent[return tool_message]
+    Run --> Meta[list_all_tools_name / get_tool_spec]
+```
+
+
+
+`ToolManager` is normally a process-level singleton, initialized at startup by `app/server/lifecycle.py` (or its desktop equivalent).
+
+### 1.4 ToolProxy: Session-level Whitelist
+
+```mermaid
+flowchart LR
+    Caller[server-side request builder] --> Pick[pick available_tools by user/Agent permission]
+    Pick --> TP[ToolProxy<br/>tool_managers + available_tools]
+    TP --> Filter[whitelist filter + priority order]
+    TP --> Warn[warn on unknown whitelist entries]
+    TP --> SAgent[SAgent.run_stream tool_manager=TP]
+```
+
+
+
+`ToolProxy` accepts multiple `ToolManager` instances (priority decreases along the list) and is interface-compatible with `ToolManager`, so the Agent does not have to distinguish between them.
+
+### 1.5 Built-in Tools `tool/impl/`
+
+```mermaid
+flowchart TB
+    subgraph CmdFile ["Commands & files"]
+        Cmd[execute_command_tool]
+        FS[file_system_tool]
+    end
+    subgraph NetMM ["Network & multimodal"]
+        Web[web_fetcher_tool]
+        Img[image_understanding_tool]
+    end
+    subgraph CtxMgmt ["Context management"]
+        Compress[compress_history_tool]
+        TodoT[todo_tool · multi-agent task list]
+    end
+    subgraph UserInter ["User interaction"]
+        Quest[questionnaire_tool · structured questionnaire]
+    end
+    subgraph Memory
+        Mem[memory_tool]
+        MIdx[memory_index]
+    end
+
+    Cmd --> Sandbox
+    FS --> Sandbox
+    Web --> Sandbox
+```
+
+
+
+These are eventually executed against the `Sandbox` abstraction (see [Sandbox / LLM / Observability](ARCHITECTURE_SAGENTS_SANDBOX_OBS.md)).
+
+### 1.6 MCP Integration
+
+```mermaid
+flowchart LR
+    MCPServer[(any MCP server)] --> Conn{transport}
+    Conn -->|stdio| Stdio[StdioServerParameters]
+    Conn -->|HTTP+SSE| SSE[SseServerParameters]
+    Conn -->|Streamable HTTP| HTTP[StreamableHttpServerParameters]
+    Stdio --> MP[mcp_proxy]
+    SSE --> MP
+    HTTP --> MP
+    MP --> Convert[convert MCP tools to OpenAI function-calling schema]
+    Convert --> TM
+    MP --> Health[connection lifecycle / timeout / health-check]
+```
+
+
+
+The bundled `mcp_servers/` directory is integrated the same way.
+
+## 2. Skill System `sagents/skill/`
+
+A "tool" is a function-grained capability; a "skill" is a coarser-grained workflow: a directory, a description, optional scripts and asset files.
+
+### 2.1 Module Composition
+
+```mermaid
+flowchart TB
+    subgraph Host ["Host side"]
+        Schema[SkillSchema · metadata]
+        SM[SkillManager · scan/register/load]
+        SP[SkillProxy · session-level whitelist]
+    end
+
+    subgraph SBoxSide ["Sandbox side"]
+        SSM[SandboxSkillManager · copy/project into sandbox]
+    end
+
+    subgraph Exposed ["Exposed to Agent"]
+        STool[skill_tool · wrap a skill as a tool]
+    end
+
+    SM --> Schema
+    SM --> SP
+    SP --> SSM
+    SSM --> STool
+```
+
+
+
+### 2.2 Data Flow
+
+```mermaid
+flowchart LR
+    Disk[(skill directory)] --> SM
+    SM --> Reg[(SkillSchema registry)]
+    Caller[one request] --> Pick[pick available_skills by Agent permission]
+    Pick --> SP[SkillProxy]
+    SP --> SC[SessionContext.init_more]
+    SC --> SSM[SandboxSkillManager]
+    SSM --> Sandbox[(fixed path inside sandbox)]
+    Sandbox --> Use[in-sandbox tools/scripts read/write skill assets]
+```
+
+
+
+`SkillManager` is **not** responsible for copying skills into the sandbox – that is the job of `SandboxSkillManager`. This separation lets remote sandboxes use skills as well.
+
+### 2.3 Skill → Tool
+
+```mermaid
+flowchart LR
+    Skill[a skill package] --> MD[SKILL.md description]
+    Skill --> Assets[scripts / asset files]
+    MD -->|inject| SysPrompt[suitable position in system prompt]
+    Skill -->|optionally registered as| ST[skill_tool]
+    ST --> TM[ToolManager]
+    SysPrompt --> LLM
+    TM --> LLM
+```
+
+
+
+A skill can both shape model behavior via its description and be invoked by the LLM as a function call.
+
+## 3. Recommendation / Selection Strategy
+
+```mermaid
+flowchart LR
+    AllTools[(all tools)] --> ToolSug[tool_suggestion Agent]
+    AllWFs[(all workflows)] --> WfSel[workflow_select Agent]
+    ToolSug -->|"what to use this turn"| LLM
+    WfSel -->|"which workflow to take"| LLM
+```
+
+
+
+The tool/skill layer answers "what is available"; suggestion Agents answer "what should we use this turn", so we don't have to stuff every schema into the context.
+
+## 4. Startup vs Runtime
+
+```mermaid
+flowchart TD
+    Bootstrap[app start] --> ToolMgr[ToolManager singleton]
+    Bootstrap --> SkillMgr[SkillManager singleton]
+    Request[one request] --> Build[build ToolProxy + SkillProxy]
+    Build --> SAgent[SAgent.run_stream]
+    SAgent --> Sess[Session/SessionContext]
+    Sess --> SSM[SandboxSkillManager projects into sandbox]
+    Sess --> Agents
+    Agents --> Tools[ToolProxy.run_tool]
+```
+
+
+
+## 5. Extending: Custom Tool / MCP / Skill
+
+Most extension points of Sage live in these two layers. The three common ways to give an Agent more capabilities are independent of each other.
+
+### 5.1 Write a Local Tool
+
+```python
+# my_pkg/my_tools.py
+from sagents.tool.tool_base import tool
+
+@tool(
+    name="get_weather",
+    description="Look up the weather of a city",
+)
+async def get_weather(city: str) -> dict:
+    """Returning a dict is enough; the framework serializes it into a tool_message."""
+    return {"city": city, "temp_c": 23, "condition": "sunny"}
+```
+
+As long as this module is imported into the process (e.g. inside `app/server/bootstrap.py` during tool initialization), it will be auto-collected by `ToolManager`.
+
+### 5.2 Wire In an MCP Server
+
+```python
+from mcp import StdioServerParameters
+from sagents.tool.tool_schema import SseServerParameters, StreamableHttpServerParameters
+
+# Pick one of the three transports as needed:
+stdio_cfg = StdioServerParameters(command="my-mcp", args=["--stdio"])
+sse_cfg = SseServerParameters(url="https://mcp.example.com/sse")
+http_cfg = StreamableHttpServerParameters(url="https://mcp.example.com/mcp")
+
+# Register through whatever API tool_manager.py currently exposes
+tool_manager.register_mcp_server(name="my_mcp", params=stdio_cfg)
+```
+
+After registration, every tool exposed by that MCP server is auto-converted to OpenAI function-calling schema and is treated identically to local tools.
+
+### 5.3 Author a Skill Package
+
+A skill is a directory with a conventional layout:
+
+```text
+my_skill/
+├── SKILL.md          # required, human-readable "how to use", injected into the LLM
+├── skill.yaml        # optional metadata: id / name / description / activation scenarios
+├── scripts/          # optional scripts that may run inside the sandbox
+└── assets/           # optional static assets
+```
+
+`SKILL.md` typically starts with:
+
+```markdown
+# Skill: My Skill
+
+## Purpose
+What problem this skill solves, when to use it.
+
+## Steps
+1. ...
+2. ...
+
+## Notes
+- ...
+```
+
+Then register the parent directory with `SkillManager`:
+
+```python
+from sagents.skill import SkillManager
+
+skill_manager = SkillManager()
+skill_manager.add_skill_dir("/path/to/skills_root")
+```
+
+For a given session, scope the visible skills with `SkillProxy(skill_manager, available_skills=["my_skill"])` and pass it into `SAgent.run_stream`.

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -62,7 +62,9 @@ Read:
 - [Getting Started](GETTING_STARTED.md): install dependencies and run the CLI, server, web UI, or desktop build
 - [CLI Guide](CLI.md): command-line workflows, sessions, skills, workspaces, and structured output
 - [Core Concepts](CORE_CONCEPTS.md): sessions, agents, tools, skills, flows, and sandboxing
-- [Architecture](ARCHITECTURE.md): how the codebase is organized
+- [Architecture](ARCHITECTURE.md): how the codebase is organized (with sub-chapters)
+  - App layer: [Server](ARCHITECTURE_APP_SERVER.md) · [Desktop](ARCHITECTURE_APP_DESKTOP.md) · [Other entries](ARCHITECTURE_APP_OTHERS.md)
+  - sagents core: [Overview](ARCHITECTURE_SAGENTS_OVERVIEW.md) · [Agent / Flow](ARCHITECTURE_SAGENTS_AGENT_FLOW.md) · [Session / Context](ARCHITECTURE_SAGENTS_SESSION_CONTEXT.md) · [Tool / Skill](ARCHITECTURE_SAGENTS_TOOL_SKILL.md) · [Sandbox / LLM / Obs](ARCHITECTURE_SAGENTS_SANDBOX_OBS.md)
 - [Configuration](CONFIGURATION.md): runtime environment variables and storage settings
 - [Applications](APPLICATIONS.md): which app surface to use for which job
 - [MCP Servers](MCP_SERVERS.md): built-in MCP servers and how they fit into the platform

--- a/docs/zh/ARCHITECTURE.md
+++ b/docs/zh/ARCHITECTURE.md
@@ -1,63 +1,120 @@
 ---
-layout: default
+
+## layout: default
+
 title: 架构
 nav_order: 4
-description: "仓库与子系统架构"
+has_children: true
+description: "Sage 仓库与子系统架构总览，含应用与 sagents 核心运行时的二级文档"
 lang: zh
 ref: architecture
----
 
 {% include lang_switcher.html %}
 
 # 架构
 
-## 仓库总览
+Sage 不是一个单一二进制，而是一个分层的代码库。架构这一章被拆成两条主线：
 
-Sage 采用分层仓库结构，而不是单一二进制项目。主要顶层子系统包括：
+- **应用架构**：每一个面向使用者的入口（Web 服务端、桌面端、CLI、示例与浏览器扩展等）各自的形态、启动路径与边界。
+- **核心运行时 `sagents/` 架构**：所有应用都共享的会话与智能体引擎，是真正承载“跑一次对话/一次任务”的中枢。
 
-- `sagents/`：核心运行时与编排
-- `app/server/`：主 FastAPI 应用与 Web 客户端
-- `app/desktop/`：桌面本地应用栈
-- `examples/`：轻量可运行示例
-- `mcp_servers/`：内置 MCP Server 实现
-- `release_notes/`：主文档之外的版本说明
+这一章下面有多篇二级文档，分别拆开讲。本页只提供大图与索引，细节请进入对应子页。
 
-## 高层依赖关系
+## 仓库分层全景
+
+```mermaid
+flowchart TB
+    subgraph G_App ["应用层 app/"]
+        Server[server<br/>主 FastAPI + Vue 3 Web]
+        Desktop[desktop<br/>桌面入口 + 本地后端 + UI]
+        CLI[cli<br/>sage 命令]
+        Ext[chrome-extension<br/>侧边栏插件]
+        Skills[skills<br/>内置技能包]
+        Wiki[wiki<br/>静态站点]
+    end
+
+    subgraph G_Ex ["入口示例 examples/"]
+        DemoCLI[sage_cli.py]
+        DemoUI[sage_demo.py · Streamlit]
+        DemoSrv[sage_server.py · FastAPI]
+    end
+
+    subgraph G_Sagents ["核心运行时 sagents/"]
+        Runtime[Session · Agent · Flow · Tool · Skill · Sandbox · Obs]
+    end
+
+    subgraph 外部能力
+        MCP[mcp_servers · 内置 MCP]
+        Common[common · 共享基础设施]
+        Docs[docs · 当前文档]
+    end
+
+    Server --> Runtime
+    Desktop --> Runtime
+    CLI --> Runtime
+    DemoCLI --> Runtime
+    DemoUI --> Runtime
+    DemoSrv --> Runtime
+    Ext -->|HTTP| Server
+    Runtime --> MCP
+    Runtime -.基础.-> Common
+```
+
+
+
+## 一次会话的高层数据流
+
+```mermaid
+flowchart LR
+    UserIn((用户输入)) --> EntryApp[某个应用入口]
+    EntryApp -->|run_stream 调用| SAgent[SAgent 入口]
+    SAgent --> Sess[Session/SessionContext]
+    Sess --> Flow[FlowExecutor + AgentFlow]
+    Flow --> Agents[各类 Agent]
+    Agents --> LLM[模型层]
+    Agents --> Tools[工具/技能]
+    Tools --> Sandbox[沙箱]
+    Sess --> Obs[可观测性]
+    Agents -->|流式 MessageChunk| EntryApp
+    EntryApp -->|SSE/JSON| UserIn
+```
+
+
+
+## 这一章包含哪些二级文档
+
+应用架构（不同 app 的形态与边界）：
+
+1. [服务端与 Web 应用架构](ARCHITECTURE_APP_SERVER.md)：`app/server/` 的 FastAPI、路由、服务、启动与 Web 客户端结构
+2. [桌面应用架构](ARCHITECTURE_APP_DESKTOP.md)：`app/desktop/` 的本地后端、UI、Tauri 壳与与 sagents 的关系
+3. [CLI、示例与外部入口架构](ARCHITECTURE_APP_OTHERS.md)：`app/cli/`、`examples/`、`app/chrome-extension/`、`app/wiki/` 等轻量入口
+
+核心运行时 `sagents/` 架构（这一章的核心）：
+
+1. [sagents 总览](ARCHITECTURE_SAGENTS_OVERVIEW.md)：分层、模块边界与典型一次 `run_stream` 的全链路
+2. [智能体（Agent）与流程（Flow）编排](ARCHITECTURE_SAGENTS_AGENT_FLOW.md)：`AgentBase`、各专用 Agent、`AgentFlow` / `FlowExecutor`、三种 `agent_mode`
+3. [会话与上下文（Session & Context）](ARCHITECTURE_SAGENTS_SESSION_CONTEXT.md)：`Session`、`SessionContext`、消息管理、会话/用户记忆与 workflow
+4. [工具与技能（Tool & Skill）系统](ARCHITECTURE_SAGENTS_TOOL_SKILL.md)：`ToolManager` / `ToolProxy`、内置工具、MCP 代理、`SkillManager` / `SkillProxy`、沙箱内技能
+5. [沙箱、LLM 适配与可观测性](ARCHITECTURE_SAGENTS_SANDBOX_OBS.md)：`SandboxProviderFactory` 三种沙箱、`SageAsyncOpenAI` 模型层与 OpenTelemetry 链路
+
+## 阅读建议
 
 ```mermaid
 flowchart TD
-    User[用户界面] --> Web[Web App]
-    User --> Desktop[Desktop App]
-    User --> Examples[Examples]
-    Web --> Server[app/server]
-    Desktop --> DesktopCore[app/desktop/core]
-    Server --> Runtime[sagents]
-    DesktopCore --> Runtime
-    Examples --> Runtime
-    Runtime --> Tools[Tool System]
-    Runtime --> Skills[Skill System]
-    Runtime --> Sandbox[Sandbox]
-    Runtime --> Obs[Observability]
-    Tools --> MCP[mcp_servers]
+    Want[你想做什么]
+
+    Want --> A[理解一次对话怎么被驱动]
+    A --> A1[sagents 总览] --> A2[Agent + Flow] --> A3[Session + Context]
+
+    Want --> B[做服务端集成或部署]
+    B --> B1[服务端与 Web 应用架构] --> B2[配置 + HTTP API 参考]
+
+    Want --> C[做扩展<br/>自定义工具/MCP/技能/子智能体]
+    C --> C1[工具与技能系统] --> C2[Agent + Flow 的扩展点]
+
+    Want --> D[做桌面打包]
+    D --> D1[桌面应用架构] --> D2[app/desktop/scripts]
 ```
 
-## 核心运行时：`sagents/`
 
-这里包含会话运行时、智能体实现、工具系统、技能加载和沙箱抽象。无论你是从 CLI、Web 还是桌面端进入，最终都会依赖这一层。
 
-## 主服务端：`app/server/`
-
-这部分提供面向多用户和 Web 的主应用形态，包括：
-
-- FastAPI 入口
-- 路由与服务层
-- 配置与持久化接入
-- Web 前端源码
-
-## 桌面应用：`app/desktop/`
-
-桌面版包含桌面入口、桌面本地后端、UI 与构建脚本。它复用 Sage 的核心运行时，但在启动方式和本地资源组织上与服务端模式不同。
-
-## 示例与扩展
-
-`examples/` 提供最小化运行入口，适合验证链路或快速试验。`mcp_servers/` 则承载 Sage 的一类扩展能力，让运行时可以通过 MCP 暴露更多外部工具。

--- a/docs/zh/ARCHITECTURE_APP_DESKTOP.md
+++ b/docs/zh/ARCHITECTURE_APP_DESKTOP.md
@@ -1,0 +1,144 @@
+---
+layout: default
+title: 桌面应用架构
+parent: 架构
+nav_order: 2
+description: "app/desktop/ 桌面端架构：本地后端、UI、Tauri 壳与与 sagents 的关系"
+lang: zh
+ref: architecture-app-desktop
+---
+
+{% include lang_switcher.html %}
+
+# 桌面应用架构
+
+`app/desktop/` 是 Sage 的桌面形态，特点是“本地优先”：内嵌一个本地的 FastAPI 后端 + 内嵌的 UI，外面套一层 Tauri / PyInstaller 打包，对用户呈现为一个可双击的桌面应用。
+
+## 模块组成
+
+```mermaid
+flowchart TB
+    subgraph 入口
+        Entry[entry.py<br/>处理 frozen / SSL 证书]
+    end
+
+    subgraph G_Core ["本地后端 core/"]
+        Main[main.py<br/>FastAPI app + uvicorn]
+        Boot[bootstrap.py · lifecycle.py]
+        DB[db_schema.py · migrations.py<br/>本地 SQLite]
+        Sync[skill_sync.py<br/>内置技能 → 用户目录]
+        UCtx[user_context.py<br/>桌面单用户身份注入]
+        Routers[routers · 桌面路由]
+        Services[services · 桌面服务]
+    end
+
+    subgraph 前端
+        UI[ui/<br/>Vue 3 + Vite + Tailwind 独立工程]
+        Tauri[tauri/<br/>Tauri 壳 · 托盘/菜单/系统集成]
+    end
+
+    subgraph 打包
+        Spec[sage-desktop.spec<br/>PyInstaller 规格]
+        Scripts[scripts/<br/>构建/打包脚本]
+        Out[build/ · dist/<br/>构建产物]
+    end
+
+    Entry --> Main
+    Main --> Boot
+    Main --> Routers --> Services
+    Boot --> DB
+    Boot --> Sync
+    Tauri --> UI
+    Tauri -.启动.-> Entry
+    Spec -.驱动.-> Out
+    Scripts -.驱动.-> Out
+```
+
+## 启动链路
+
+```mermaid
+sequenceDiagram
+    participant User as 用户
+    participant Tauri as Tauri 壳
+    participant UI as UI 静态资源
+    participant Entry as entry.py
+    participant Main as core/main.py
+    participant Life as core/lifecycle.initialize_system
+    participant SAgent
+
+    User->>Tauri: 双击启动
+    Tauri->>UI: 加载 ui/dist
+    Tauri->>Entry: 启动桌面后端进程
+    Entry->>Entry: frozen 模式修复 SSL 证书路径
+    Entry->>Main: 调用 main()
+    Main->>Main: 强制 AGENT_BROWSER_HEADED=1
+    Main->>Main: 提前 import sagents.prompts
+    Main->>Life: lifespan: initialize_system()
+    Life-->>Life: 本地 DB → Tool/Skill → SessionManager
+    UI->>Main: HTTP/SSE 请求<br/>带 X-Sage-Internal-UserId
+    Main->>Main: inject_desktop_user_context 中间件
+    Main->>SAgent: SAgent.run_stream(...)
+    SAgent-->>UI: 流式 MessageChunk
+```
+
+## 与服务端架构的差异
+
+| 维度 | `app/server/` | `app/desktop/` |
+| --- | --- | --- |
+| 多用户 | 是，完整鉴权 | 否，单用户，注入身份 |
+| 持久化 | 多用户 DB / 对象存储 | 本地 SQLite + 用户目录文件 |
+| 部署 | 容器/服务器 | 桌面安装包（PyInstaller + Tauri） |
+| 浏览器自动化 | 默认 headless | 默认 headed（`AGENT_BROWSER_HEADED=1`） |
+| 技能 | 平台级管理 | `skill_sync.py` 把内置技能同步到用户目录，可被用户编辑 |
+| 启动入口 | `app/server/main.py` | `app/desktop/entry.py` → `app/desktop/core/main.py` |
+| 鉴权中间件 | 完整 OAuth/JWT | `inject_desktop_user_context` 单用户注入 |
+
+但两者最终都调用同一个 `sagents/` 运行时，行为差异主要来自：沙箱配置（桌面更倾向 `local`）、工具/技能注册集合不同、模型配置来源不同（桌面通常从本地 DB 读取用户填写的 API Key）。
+
+## 桌面运行态依赖关系
+
+```mermaid
+flowchart LR
+    User((用户)) --> TauriShell[Tauri 壳]
+    TauriShell --> UIRender[UI 渲染]
+    UIRender -->|HTTP/SSE localhost| LocalAPI[本地 FastAPI]
+    LocalAPI --> SAgent
+    LocalAPI --> LocalDB[(本地 SQLite/<br/>用户目录文件)]
+    SAgent --> Sandbox[本地沙箱]
+    SAgent --> Tools
+    LocalAPI -.静态.-> UserSkills[(同步出来的技能目录)]
+    Sync[skill_sync] -. 复制 .-> UserSkills
+```
+
+## Tauri 壳层职责
+
+```mermaid
+flowchart TB
+    Tauri[Tauri 壳]
+    Tauri --> Window[创建桌面窗口 + 加载 UI]
+    Tauri --> Process[启动 / 监督<br/>PyInstaller 后端进程]
+    Tauri --> Tray[系统托盘 / 菜单 / 自启动]
+    Tauri --> Dialog[文件对话框 / 系统通知]
+```
+
+## 打包链路与关注点
+
+```mermaid
+flowchart LR
+    SrcPy[Python 源码 + sagents/prompts/]
+    SrcUI[ui/ 前端工程]
+    SrcSkill[app/skills/ 内置技能]
+
+    SrcUI -->|npm build| UIDist[ui/dist]
+    SrcPy -->|PyInstaller<br/>sage-desktop.spec| Exec[sage-desktop 可执行]
+    SrcSkill -->|打入 + skill_sync| UserDir[用户目录技能]
+    UIDist --> Bundle[最终桌面安装包]
+    Exec --> Bundle
+    UserDir -.运行期.-> Bundle
+```
+
+打包的关键约束：
+
+- `sagents/prompts/` 必须被 PyInstaller 显式收集（`main.py` 里有兜底 import）。
+- 内置技能 `app/skills/` 需要被打入并通过 `skill_sync.py` 复制到用户目录。
+- 证书路径要兼容 `_MEIPASS` 临时目录（`entry.py` 已处理）。

--- a/docs/zh/ARCHITECTURE_APP_OTHERS.md
+++ b/docs/zh/ARCHITECTURE_APP_OTHERS.md
@@ -1,0 +1,132 @@
+---
+layout: default
+title: CLI、示例与外部入口架构
+parent: 架构
+nav_order: 3
+description: "app/cli/、examples/、app/chrome-extension/、app/wiki/ 等轻量入口"
+lang: zh
+ref: architecture-app-others
+---
+
+{% include lang_switcher.html %}
+
+# CLI、示例与外部入口架构
+
+除了 `app/server/` 和 `app/desktop/` 这两个完整产品形态外，Sage 还提供若干更轻量的入口，分别面向不同场景：开发调试、最小演示、第三方集成、文档/Wiki。
+
+## 入口全景
+
+```mermaid
+flowchart TD
+    User((用户)) --> CLI[app/cli<br/>sage 命令]
+    User --> Demo1[examples/sage_cli.py]
+    User --> Demo2[examples/sage_demo.py<br/>Streamlit]
+    User --> Demo3[examples/sage_server.py<br/>独立 FastAPI]
+    User --> Browser[(浏览器)]
+    User --> Reader[文档读者]
+
+    Browser --> Ext[app/chrome-extension<br/>侧边栏插件]
+    Browser --> Wiki[app/wiki<br/>静态站点]
+
+    CLI --> SAgent
+    Demo1 --> SAgent
+    Demo2 --> SAgent
+    Demo3 --> SAgent
+    Ext -->|HTTP/SSE| Server[app/server<br/>已部署]
+    Wiki -. 纯静态 .-> Browser
+```
+
+## CLI：`app/cli/`
+
+```mermaid
+flowchart LR
+    User -->|sage run / chat / doctor| Argparse[main.py · argparse]
+    Argparse --> Service[service.py<br/>会话调度]
+    Service --> SAgent[sagents 运行时]
+    Service --> LocalFS[(本地会话文件)]
+```
+
+特点：
+
+- 直接复用 `sagents/` 运行时，不依赖 `app/server/`。
+- 适合本地开发、提示词迭代、运行时诊断。
+- `sage doctor` 用于排查环境问题（依赖、模型连通性、沙箱）。
+
+详细命令请见 [CLI 使用指南](CLI.md)。
+
+## Examples：`examples/`
+
+```mermaid
+flowchart TB
+    subgraph G_Ex ["examples/"]
+        SCli[sage_cli.py<br/>极简 CLI]
+        SDemo[sage_demo.py<br/>Streamlit 演示]
+        SSrv[sage_server.py<br/>独立 FastAPI 示例]
+        Helper[_example_support.py]
+        Mcp[mcp_setting.json<br/>演示用 MCP 配置]
+        Cfg1[preset_running_agent_config.json]
+        Cfg2[preset_running_config.json]
+        Build[build_exec/<br/>单文件构建示例]
+    end
+
+    SCli --> SAgent
+    SDemo --> SAgent
+    SSrv --> SAgent
+    SCli -.读.-> Helper
+    SDemo -.读.-> Helper
+    SSrv -.读.-> Helper
+    SCli -.读.-> Mcp
+    SCli -.读.-> Cfg1
+    SCli -.读.-> Cfg2
+```
+
+什么时候用：
+
+- 验证“最少需要哪些参数才能跑通 sagents”。
+- 快速做一个不依赖完整服务端的演示。
+- 需要一个最小 PyInstaller 构建样本。
+
+什么时候不用：要做完整产品功能（多用户、知识库、可观测性 UI），请用 `app/server/` 而不是 `examples/`。
+
+## Chrome 扩展：`app/chrome-extension/`
+
+```mermaid
+flowchart LR
+    Web[(浏览网页)] --> ContentScript[content-script.js<br/>注入页面]
+    Web --> SidePanel[sidepanel.html<br/>侧边栏 UI]
+    SidePanel --> SidePanelJS[sidepanel.js]
+    ContentScript --> SW[service-worker.js<br/>后台]
+    SidePanelJS --> SW
+    SW -->|HTTP/SSE| Server[app/server<br/>已部署]
+```
+
+它本身不嵌入 sagents 运行时，而是作为浏览器侧的 UI 客户端，通过 HTTP/SSE 调用部署在某处的 `app/server/`。等价于一个“住在浏览器侧边栏里的 Web 客户端”。
+
+## Wiki / 静态文档：`app/wiki/`
+
+```mermaid
+flowchart LR
+    SrcMd[Markdown 业务内容] --> Gen[generate-docs.js]
+    Gen --> Site[静态站点产物]
+    Site --> ServeUser[(浏览器读者)]
+```
+
+`app/wiki/` 是面向产品/运营的内部 Wiki 站点，与本套 `docs/` 的定位不同：
+
+- `docs/`（你正在看的）：技术文档，绑定当前代码库。
+- `app/wiki/`：业务/产品/教程类内容，可独立出站。
+
+它不参与运行时，但属于仓库中的“应用”之一，所以放在这一章。
+
+## 总结：什么时候选哪种入口
+
+```mermaid
+flowchart TD
+    Need[需求]
+    Need --> P1{完整多用户<br/>Web 产品?} -->|是| Server[app/server + web]
+    Need --> P2{单机 / 离线?} -->|是| Desktop[app/desktop]
+    Need --> P3{命令行 / 脚本?} -->|是| CLI[app/cli]
+    Need --> P4{最小演示 / 集成模板?} -->|是| Examples[examples/sage_*.py]
+    Need --> P5{浏览器侧入口?} -->|是| Ext[app/chrome-extension]
+    Need --> P6{产品/教程内容?} -->|是| Wiki[app/wiki]
+```

--- a/docs/zh/ARCHITECTURE_APP_SERVER.md
+++ b/docs/zh/ARCHITECTURE_APP_SERVER.md
@@ -1,0 +1,207 @@
+---
+layout: default
+title: 服务端与 Web 应用架构
+parent: 架构
+nav_order: 1
+description: "app/server/ 主 FastAPI 应用与 Vue 3 Web 客户端的架构"
+lang: zh
+ref: architecture-app-server
+---
+
+{% include lang_switcher.html %}
+
+# 服务端与 Web 应用架构
+
+`app/server/` 是 Sage 的主应用入口，承载多用户、Web、智能体管理、知识库、可观测性等完整能力。它是真正“产品级”的入口，而不是演示。
+
+## 模块组成
+
+```mermaid
+flowchart TB
+    subgraph 入口
+        Main[main.py<br/>FastAPI app + uvicorn]
+        Boot[bootstrap.py<br/>子系统 init/teardown]
+        Life[lifecycle.py<br/>initialize_system 编排]
+        Sched[scheduler.py<br/>定时任务]
+    end
+
+    subgraph G_Core ["公共能力 core/"]
+        Auth[auth.py<br/>鉴权依赖]
+        Mid[middleware.py<br/>CORS / 日志 / 请求 ID]
+        AdminBoot[bootstrap_admin.py<br/>内置管理员初始化]
+    end
+
+    subgraph G_Routers ["路由 routers/"]
+        RChat[chat]
+        RAgent[agent]
+        RConv[conversation]
+        RTask[task]
+        RTool[tool / mcp]
+        RSkill[skill]
+        RKdb[kdb]
+        RLLM[llm_provider]
+        RAuth[auth / oauth2 / user]
+        ROss[oss]
+        RObs[observability]
+        RSys[system / version]
+    end
+
+    subgraph G_Services ["服务 services/"]
+        SChat[chat]
+        SAuth[auth]
+        SUser[user.py]
+        SAgent[agent_inherit.py]
+        SOss[oss.py]
+    end
+
+    subgraph G_Web ["前端 web/"]
+        WebSrc[Vue 3 + Vite + Tailwind]
+    end
+
+    Main --> Mid
+    Main --> Life
+    Main --> RChat
+    RChat --> SChat
+    RAgent --> SAgent
+    RAuth --> SAuth
+    SChat --> SAgent
+    Life --> Boot
+    Boot --> AdminBoot
+```
+
+## 启动链路
+
+```mermaid
+sequenceDiagram
+    participant CLI as python -m app.server.main
+    participant Cfg as init_startup_config
+    participant App as create_fastapi_app
+    participant Life as lifecycle.initialize_system
+    participant Uvi as uvicorn.Server
+
+    CLI->>Cfg: 读取 .env / 启动配置
+    CLI->>Uvi: start_server(cfg)
+    Uvi->>App: 工厂构造 FastAPI
+    App->>App: register_middlewares · exception · routes
+    Uvi->>Life: lifespan: initialize_system(cfg)
+    Life-->>Life: DB → Obs → Clients → Tool/Skill → Session → Scheduler
+    Uvi-->>CLI: 监听 http://host:port
+```
+
+## 路由与服务的协作
+
+```mermaid
+flowchart LR
+    HTTP((HTTP/SSE 请求)) --> Router[routers/* 路由]
+    Router -->|参数解析 + 鉴权| Service[services/* 服务编排]
+    Service -->|构造 SAgent 入参| RT[sagents 运行时]
+    RT -->|MessageChunk 流| Service
+    Service -->|SSE / JSON| HTTP
+
+    Router -.读.-> Auth
+    Router -.异常.-> ExcHandler[common 异常处理器]
+```
+
+每个路由模块对应一组 HTTP 资源；服务层把“业务编排”从路由里抽出来：
+
+| 路由模块 | 主要职责 |
+| --- | --- |
+| `chat` | 会话流式聊天接口（SSE），是 HTTP → `SAgent.run_stream` 的关键层 |
+| `agent` | 智能体的 CRUD 与配置管理 |
+| `conversation` | 会话历史、列表、收藏 |
+| `task` | 长任务/异步任务相关接口 |
+| `tool` / `mcp` | 工具与 MCP Server 注册管理 |
+| `skill` | 技能包管理 |
+| `kdb` | 知识库（Knowledge Base） |
+| `llm_provider` | 模型供应商配置 |
+| `auth` / `oauth2` / `user` | 登录、用户、第三方 OAuth2（如 Lage） |
+| `oss` | 对象存储 |
+| `observability` | 可观测性数据查询 |
+| `system` / `version` | 系统信息、版本 |
+
+## 与 sagents 的边界
+
+```mermaid
+flowchart TB
+    subgraph 启动期
+        Init[lifecycle.initialize_system]
+        Init --> ToolMgr[全局 ToolManager]
+        Init --> SkillMgr[全局 SkillManager]
+        Init --> SessMgr[全局 SessionManager]
+        Init --> ObsMgr[ObservabilityManager]
+    end
+
+    subgraph 请求期
+        Req[一次请求]
+        Req --> Pick[选模型 + 选工具/技能子集 + 选沙箱]
+        Pick --> Build[构造 ToolProxy / SkillProxy / system_prefix]
+        Build --> Call[SAgent.run_stream]
+        Call --> Sse[转 SSE / JSON Lines]
+    end
+
+    ToolMgr -.被复用.-> Build
+    SkillMgr -.被复用.-> Build
+    SessMgr -.被复用.-> Call
+```
+
+服务端不重新实现智能体逻辑，只负责把 HTTP/SSE 协议、鉴权、用户/Agent 配置、模型供应商等组装成 `SAgent.run_stream` 的入参。详见 [sagents 总览](ARCHITECTURE_SAGENTS_OVERVIEW.md)。
+
+## Web 客户端结构
+
+```mermaid
+flowchart TB
+    subgraph G_Src ["app/server/web/src"]
+        Entry[main.js<br/>App.vue]
+        Router[router · vue-router]
+        Stores[stores · Pinia]
+        Api[api · HTTP/SSE 客户端]
+        Comp[components · 通用组件]
+        Compose[composables · 聊天流/SSE 钩子]
+        Views[views · 页面级组件]
+        I18n[locales · i18n]
+        Util[utils]
+    end
+
+    Entry --> Router --> Views
+    Views --> Comp
+    Views --> Compose
+    Compose --> Api
+    Stores -.状态.-> Views
+    Stores -.状态.-> Compose
+```
+
+前端通过 SSE 实时订阅消息分片，并按 `MessageChunk.role` / `message_type` 决定如何渲染（普通消息、工具调用、token 用量等）。
+
+## 部署形态
+
+- 直接 `python -m app.server.main` 启动（开发态）。
+- 通过仓库提供的 `docker-compose.yml` / `docker/` 镜像启动（推荐生产）。
+
+详见 [配置](CONFIGURATION.md) 与 [快速开始](GETTING_STARTED.md)。
+
+## 二次开发：新增一个路由
+
+服务端最常见的扩展是“加一个新的 HTTP 资源”，模板如下：
+
+```python
+# app/server/routers/my_module.py
+from fastapi import APIRouter, Depends
+from app.server.core.auth import current_user
+
+router = APIRouter(prefix="/api/my", tags=["my"])
+
+@router.get("/ping")
+async def ping(user=Depends(current_user)):
+    return {"ok": True, "user_id": user.id}
+```
+
+```python
+# app/server/routers/__init__.py 中注册
+from . import my_module
+
+def register_routes(app):
+    ...
+    app.include_router(my_module.router)
+```
+
+业务逻辑放进 `services/`，路由层只做参数解析、鉴权与响应封装。

--- a/docs/zh/ARCHITECTURE_SAGENTS_AGENT_FLOW.md
+++ b/docs/zh/ARCHITECTURE_SAGENTS_AGENT_FLOW.md
@@ -1,0 +1,328 @@
+---
+
+## layout: default
+
+title: 智能体与流程编排
+parent: 架构
+nav_order: 5
+description: "AgentBase、各专用 Agent、AgentFlow / FlowExecutor、三种 agent_mode"
+lang: zh
+ref: architecture-sagents-agent-flow
+
+{% include lang_switcher.html %}
+
+# 智能体与流程编排
+
+这一篇覆盖 `sagents/agent/` 与 `sagents/flow/`。**Agent 是干活的单元，Flow 决定 Agent 之间的执行关系。** 两者解耦：换流程不改 Agent，换 Agent 也不改流程。
+
+## 1. Agent 层
+
+### 1.1 `AgentBase` 提供的能力
+
+```mermaid
+flowchart LR
+    Base[AgentBase] --> RunStream[run_stream<br/>统一异步流接口]
+    Base --> Model[持有 model + model_config]
+    Base --> SafeCall[LLM 调用：<br/>重试 + 降级 + sanitize]
+    Base --> PromptCache[prompt 缓存控制]
+    Base --> Schema[工具 schema 转换]
+    Base --> Stream[流式 chunk 拼装]
+    Base --> Live[读取 Session/SessionContext]
+```
+
+
+
+Agent 自身不持有“这次会话的状态”，状态都在 `SessionContext` 里——Agent 因此可以并发复用。
+
+### 1.2 已实现的专用 Agent
+
+```mermaid
+flowchart TB
+    subgraph 路由与分析
+        Router[task_router]
+        Analysis[task_analysis]
+    end
+
+    subgraph 召回与建议
+        Recall[memory_recall]
+        ToolSug[tool_suggestion]
+        WfSel[workflow_select]
+        QSug[query_suggest]
+    end
+
+    subgraph 简单模式
+        Plan[plan]
+        Simple[simple]
+    end
+
+    subgraph 多智能体模式
+        TPlan[task_planning]
+        TDecomp[task_decompose]
+        TExec[task_executor]
+        TObs[task_observation]
+        TJudge[task_completion_judge]
+        TSum[task_summary]
+    end
+
+    subgraph fibre 模式
+        Fibre[fibre]
+        SelfCheck[self_check]
+    end
+```
+
+
+
+各 Agent 的 `agent_key` 是流程中 `AgentNode` 引用它的标识，例如 `task_router`、`simple`、`task_planning` 等。
+
+### 1.3 `FibreAgent` 与子智能体编排
+
+```mermaid
+flowchart TB
+    Main[主 Session] --> FA[FibreAgent.run_stream]
+    FA --> Orch[FibreOrchestrator]
+    Orch --> Defs[(AgentDefinition 注册表<br/>子智能体配置)]
+    Orch --> Backend[FibreBackendClient<br/>从后端取/管理子智能体]
+    Orch --> SubMgr[SessionManager 复用]
+    Orch -->|委派工具调用| Sub[Sub-session 1..N]
+    Sub -->|结果| Orch
+    Orch -->|汇总| FA
+```
+
+
+
+简单理解：**fibre 模式下，主 Agent 通过工具调用把任务委派给子 Agent，每个子 Agent 在自己的 sub-session 里跑，结果再回流到主 session。**
+
+## 2. Flow 层
+
+### 2.1 节点类型
+
+```mermaid
+flowchart LR
+    Flow[AgentFlow.root] --> N1[AgentNode<br/>执行单个 Agent]
+    Flow --> N2[SequenceNode<br/>顺序执行 steps]
+    Flow --> N3[ParallelNode<br/>并行 + max_concurrency]
+    Flow --> N4[LoopNode<br/>condition + max_loops 熔断]
+    Flow --> N5[IfNode<br/>true_body / false_body]
+    Flow --> N6[SwitchNode<br/>variable + cases + default]
+```
+
+
+
+整个 Flow 由 `AgentFlow(name, root)` 包装根节点。`run_stream` 也接受 `custom_flow` 参数，调用方可以完全自定义编排。
+
+### 2.2 条件注册表 `flow/conditions.py`
+
+```mermaid
+flowchart LR
+    Reg[ConditionRegistry] --> C1[is_deep_thinking]
+    Reg --> C2[enable_more_suggest]
+    Reg --> C3[enable_plan]
+    Reg --> C4[plan_should_start_execution]
+    Reg --> C5[task_not_completed]
+    Reg --> C6[self_check_should_retry]
+    Reg --> C7[need_summary]
+
+    Reg -.被引用.-> If[IfNode.condition]
+    Reg -.被引用.-> Loop[LoopNode.condition]
+```
+
+
+
+业务方可以注册自己的条件函数，让 `custom_flow` 用上（见本页末尾）。
+
+### 2.3 执行器 `flow/executor.py`
+
+```mermaid
+flowchart TB
+    Start([开始执行 AgentFlow.root]) --> Dispatch{节点类型?}
+
+    Dispatch -->|AgentNode| Run[拿 Agent 实例 → run_stream<br/>透传 chunk]
+    Dispatch -->|SequenceNode| Seq[顺序执行 steps]
+    Dispatch -->|ParallelNode| Par[asyncio 并发 + 信号量]
+    Dispatch -->|LoopNode| L1[检查 condition + max_loops]
+    Dispatch -->|IfNode| If1[检查 condition]
+    Dispatch -->|SwitchNode| Sw1[读 variable → cases]
+
+    Run --> Check{Session 状态?}
+    Seq --> Check
+    Par --> Check
+    L1 --> Check
+    If1 --> Check
+    Sw1 --> Check
+
+    Check -->|RUNNING| NextNode[下一个节点]
+    Check -->|INTERRUPTED / ERROR| Stop([停止])
+
+    NextNode --> Dispatch
+```
+
+
+
+执行器只负责“怎么走”，不负责“走到 Agent 后做什么”——后者是 Agent 自己的责任。
+
+## 3. 默认流程：simple / multi / fibre
+
+`SAgent._build_default_flow(agent_mode, max_loop_count)` 拼出来的形状：
+
+```mermaid
+flowchart TB
+    Start([输入 messages]) --> R[task_router]
+    R --> DT{is_deep_thinking?}
+    DT -->|是| Ana[task_analysis] --> Sw
+    DT -->|否| Sw
+    Sw{Switch agent_mode}
+    Sw -->|simple| SimpleBody
+    Sw -->|multi| MultiBody
+    Sw -->|fibre| FibreBody
+    SimpleBody --> More
+    MultiBody --> More
+    FibreBody --> More
+    More{enable_more_suggest?}
+    More -->|是| QS[query_suggest]
+    More -->|否| End
+    QS --> End([结束])
+```
+
+
+
+### simple_agent_body
+
+```mermaid
+flowchart TB
+    S0([进入 simple]) --> Par1{并行}
+    Par1 --> ToolSug1[tool_suggestion]
+    Par1 --> Recall1[memory_recall]
+    ToolSug1 --> If1
+    Recall1 --> If1
+    If1{enable_plan?}
+    If1 -->|是| Plan1[plan]
+    Plan1 --> If2{plan_should_start_execution?}
+    If2 -->|是| SimpleAgent1[simple]
+    If2 -->|否| Need
+    If1 -->|否| SimpleAgent2[simple]
+    SimpleAgent1 --> Need
+    SimpleAgent2 --> Need
+    Need{need_summary?}
+    Need -->|是| Sum[task_summary] --> EndS
+    Need -->|否| EndS([结束 simple])
+```
+
+
+
+### multi_agent_full
+
+```mermaid
+flowchart TB
+    M0([进入 multi]) --> Recall2[memory_recall]
+    Recall2 --> Loop[Loop: task_not_completed<br/>最多 max_loop_count 次]
+    Loop --> P[task_planning]
+    P --> TS[tool_suggestion]
+    TS --> E[task_executor]
+    E --> O[task_observation]
+    O --> J[task_completion_judge]
+    J -.task_not_completed.-> Loop
+    J -->|完成| Sum2[task_summary]
+    Sum2 --> EndM([结束 multi])
+```
+
+
+
+### fib_agent_body
+
+```mermaid
+flowchart TB
+    F0([进入 fibre]) --> Loop2[Loop: self_check_should_retry<br/>最多 3 次]
+    Loop2 --> Core[fibre core]
+    Core --> Par2{并行}
+    Par2 --> TS2[tool_suggestion]
+    Par2 --> R2[memory_recall]
+    TS2 --> If3
+    R2 --> If3
+    If3{enable_plan?}
+    If3 -->|是| Plan2[plan] --> If4{plan_should_start_execution?}
+    If4 -->|是| FibA[fibre]
+    If4 -->|否| SC
+    If3 -->|否| FibB[fibre]
+    FibA --> SC
+    FibB --> SC
+    SC[self_check]
+    SC -.should_retry.-> Loop2
+    SC -->|不再重试| EndF([结束 fibre])
+```
+
+
+
+## 4. 二次开发：自定义流程与子智能体
+
+调用方有三个扩展点，组合起来几乎可以拼出任意复杂的 Agent 编排，而**完全不修改 sagents 源码**。
+
+### 4.1 注册自定义条件
+
+```python
+from sagents.flow.conditions import ConditionRegistry
+
+@ConditionRegistry.register("user_paid")
+def _user_paid(session_context, session=None) -> bool:
+    return session_context.system_context.get("plan") == "pro"
+```
+
+### 4.2 自定义 Flow
+
+```python
+from sagents.flow.schema import (
+    AgentFlow, SequenceNode, AgentNode, IfNode, LoopNode,
+)
+
+custom_flow = AgentFlow(
+    name="My Pipeline",
+    root=SequenceNode(steps=[
+        AgentNode(agent_key="task_router"),
+        IfNode(
+            condition="user_paid",
+            true_body=LoopNode(
+                condition="task_not_completed",
+                max_loops=10,
+                body=SequenceNode(steps=[
+                    AgentNode(agent_key="task_planning"),
+                    AgentNode(agent_key="task_executor"),
+                    AgentNode(agent_key="task_completion_judge"),
+                ]),
+            ),
+            false_body=AgentNode(agent_key="simple"),
+        ),
+        AgentNode(agent_key="task_summary"),
+    ]),
+)
+
+# 传给 SAgent.run_stream
+async for chunks in agent.run_stream(
+    ...,
+    custom_flow=custom_flow,
+):
+    ...
+```
+
+传了 `custom_flow` 之后，`agent_mode` / `_build_default_flow` 都会被绕过。
+
+### 4.3 自定义子智能体（fibre）
+
+`custom_sub_agents=[...]` 在不重写流程的前提下注入额外子智能体定义，主要服务 fibre 编排：
+
+```python
+async for chunks in agent.run_stream(
+    ...,
+    agent_mode="fibre",
+    custom_sub_agents=[
+        {
+            "agent_key": "data_fetcher",
+            "description": "负责从内部 BI 拉数据",
+            "system_prompt": "...",
+            "available_tools": ["http_fetcher", "sql_runner"],
+        },
+        # 更多子智能体定义...
+    ],
+):
+    ...
+```
+
+主 fibre Agent 会把这些子智能体识别成可委派的目标。

--- a/docs/zh/ARCHITECTURE_SAGENTS_OVERVIEW.md
+++ b/docs/zh/ARCHITECTURE_SAGENTS_OVERVIEW.md
@@ -1,0 +1,245 @@
+---
+
+## layout: default
+
+title: sagents 总览
+parent: 架构
+nav_order: 4
+description: "sagents/ 核心运行时的分层、模块边界与一次 run_stream 的全链路"
+lang: zh
+ref: architecture-sagents-overview
+
+{% include lang_switcher.html %}
+
+# sagents 总览
+
+`sagents/` 是 Sage 的核心运行时。所有应用形态（服务端、桌面、CLI、示例）最终都通过它来真正“跑一次会话”。这一节用图把 sagents 的分层、模块、以及一次 `run_stream` 的端到端调用关系讲清楚。
+
+## 设计原则
+
+```mermaid
+flowchart LR
+    P1[关注点分离<br/>逻辑/状态/能力/基础设施 分层]
+    P2[状态中心化<br/>SessionContext 黑板模式]
+    P3[可观测性优先<br/>事件钩子内建]
+    P4[协议驱动扩展<br/>MCP / OpenAI 兼容]
+    P5[沙箱抽象<br/>local/remote/passthrough 统一接口]
+```
+
+
+
+## 分层与模块
+
+```mermaid
+flowchart TB
+    subgraph 入口层
+        SAgent[SAgent · 运行时门面]
+        SessRT[Session / SessionManager]
+    end
+
+    subgraph G_Flow ["编排层 flow/"]
+        Flow[AgentFlow + FlowExecutor + Conditions]
+    end
+
+    subgraph G_Agent ["智能体层 agent/"]
+        Agents[各类 *Agent]
+        Fibre[fibre · 子智能体编排]
+        Agents -.fibre 模式.-> Fibre
+    end
+
+    subgraph G_Ctx ["状态层 context/"]
+        Ctx[SessionContext]
+        Msg[MessageManager + ContextBudget]
+        Mem[session_memory + user_memory]
+        Wf[workflows]
+    end
+
+    subgraph 能力层
+        LLM[llm · SageOpenAI / capabilities]
+        Tools[tool · ToolManager + MCP]
+        Skills[skill · SkillManager]
+        Retr[retrieve_engine · RAG]
+    end
+
+    subgraph 基础设施
+        Sandbox[utils/sandbox · 三种沙箱]
+        Obs[observability · OpenTelemetry]
+        Util[utils · logger/lock/prompt/...]
+    end
+
+    SAgent --> SessRT --> Flow --> Agents
+    Agents --> Ctx
+    Ctx --> Msg
+    Ctx --> Mem
+    Ctx --> Wf
+    Agents --> LLM
+    Agents --> Tools
+    Agents --> Skills
+    Agents --> Retr
+    SessRT --> Sandbox
+    SessRT --> Obs
+```
+
+
+
+## 一次 `SAgent.run_stream` 的全链路
+
+```mermaid
+sequenceDiagram
+    participant Caller as 调用方<br/>(server/desktop/cli)
+    participant SAgent as SAgent.run_stream
+    participant SM as SessionManager
+    participant Sess as Session
+    participant Flow as FlowExecutor
+    participant Agent as 某个 Agent
+    participant LLM as SageAsyncOpenAI
+    participant Tool as ToolManager
+    participant Sandbox as Sandbox
+    participant Obs as Observability
+
+    Caller->>SAgent: run_stream(messages, model, ...)
+    SAgent->>SAgent: 校验参数 / 推断 sandbox_type
+    SAgent->>SM: get_or_create(session_id, sandbox_type)
+    SM-->>SAgent: Session
+    SAgent->>Sess: configure_runtime(model, sandbox, workspace, agent_id)
+    SAgent->>Obs: on_chain_start
+    SAgent->>SAgent: _build_default_flow(agent_mode) 或 custom_flow
+    SAgent->>Sess: run_stream_safe(messages, flow, tools, skills, ...)
+    Sess->>Flow: 执行 AgentFlow.root
+    loop 每个节点
+        Flow->>Agent: 实例化 + run_stream
+        Agent->>LLM: chat_completion(messages, tools)
+        LLM-->>Agent: 流式 chunks（含 tool_calls）
+        opt 有工具调用
+            Agent->>Tool: run_tool(name, args)
+            Tool->>Sandbox: 命令/代码/文件操作
+            Sandbox-->>Tool: 结果
+            Tool-->>Agent: tool_message
+        end
+        Agent-->>Flow: yield MessageChunk(s)
+    end
+    Sess-->>SAgent: 异步生成器持续产出
+    SAgent-->>Caller: yield [MessageChunk]
+    SAgent->>Obs: 记录首屏耗时 / 消息时序
+    SAgent->>SM: close_session
+```
+
+
+
+## 入口 API：`SAgent.run_stream` 的关键参数
+
+```mermaid
+flowchart TB
+    Caller[调用方] --> Args{run_stream 入参}
+
+    Args --> M[模型层<br/>model + model_config + system_prefix]
+    Args --> SBX[沙箱<br/>sandbox_type + sandbox_agent_workspace<br/>+ volume_mounts + sandbox_id]
+    Args --> CAP[能力<br/>tool_manager + skill_manager]
+    Args --> ID[身份<br/>session_id + user_id + agent_id]
+    Args --> MODE[模式<br/>agent_mode: simple/multi/fibre<br/>+ max_loop_count]
+    Args --> EXT[扩展点<br/>custom_flow + custom_sub_agents<br/>+ available_workflows + system_context<br/>+ context_budget_config]
+```
+
+
+
+关键约束：
+
+- `model` 与 `model_config` 必须给。
+- `max_loop_count` 必须给，作为最终熔断。
+- `sandbox_type` 优先级：参数 > `__init__` > `SAGE_SANDBOX_MODE` 环境变量 > 默认 `local`。
+- 不同沙箱模式对 `sandbox_agent_workspace` 的要求不同（local/passthrough 必填，remote 可由默认 `/sage-workspace` 兜底）。
+
+## 默认流程：三种 `agent_mode`
+
+```mermaid
+flowchart TB
+    Start([输入 messages]) --> Router[task_router]
+    Router --> DT{is_deep_thinking?}
+    DT -->|是| Analysis[task_analysis] --> Sw
+    DT -->|否| Sw
+    Sw{agent_mode}
+    Sw -->|simple| Simple[simple body<br/>tool_suggestion ∥ memory_recall<br/>→ plan? → simple → summary?]
+    Sw -->|multi| Multi[multi body<br/>memory_recall<br/>→ Loop 规划/执行/观察/判定<br/>→ task_summary]
+    Sw -->|fibre| Fibre[fibre body<br/>Loop self_check_should_retry<br/>→ fibre 核心 → self_check]
+    Simple --> More
+    Multi --> More
+    Fibre --> More
+    More{enable_more_suggest?}
+    More -->|是| Sug[query_suggest] --> End([输出])
+    More -->|否| End
+```
+
+
+
+`task_router` 可以在运行期改写 `audit_status.agent_mode`，所以即使初始传 `simple`，路由后也可能切到 `multi` 或 `fibre`。逐节点细节见下一篇 [Agent 与 Flow 编排](ARCHITECTURE_SAGENTS_AGENT_FLOW.md)。
+
+## 模块之间是怎么协作的
+
+```mermaid
+flowchart LR
+    Sess[Session] -->|持有| Ctx[SessionContext]
+    Flow[FlowExecutor] -->|按节点找 Agent| Agent
+    Agent -->|读写状态| Ctx
+    Agent -->|调用| LLM
+    Agent -->|调用| ToolMgr
+    ToolMgr -->|本地| Local[内置工具]
+    ToolMgr -->|外部| MCP
+    Local --> Sandbox
+    SkillMgr -->|投影到沙箱| SandboxSkill[SandboxSkillManager]
+    SandboxSkill --> Sandbox
+    Obs[ObservabilityManager] -.事件.-> Sess
+    Obs -.事件.-> Agent
+    Obs -.事件.-> ToolMgr
+    Obs -.事件.-> LLM
+```
+
+
+
+要点：
+
+- **Agent 不持有状态**，状态全部走 `SessionContext`，方便复用与并发。
+- **工具的执行最终落到 Sandbox**，工具层不直接接触本机环境。
+- **可观测性是横向能力**，所有关键事件都通过 `ObservabilityManager` 分发。
+
+## 接下来读什么
+
+```mermaid
+flowchart LR
+    Here[sagents 总览] --> A[Agent + Flow] --> B[Session + Context] --> C[Tool + Skill] --> D[Sandbox + LLM + Obs]
+```
+
+
+
+- [Agent 与 Flow](ARCHITECTURE_SAGENTS_AGENT_FLOW.md)：智能体如何被定义和编排
+- [Session 与 Context](ARCHITECTURE_SAGENTS_SESSION_CONTEXT.md)：状态层的细节
+- [Tool 与 Skill](ARCHITECTURE_SAGENTS_TOOL_SKILL.md)：能力层
+- [Sandbox / LLM / Obs](ARCHITECTURE_SAGENTS_SANDBOX_OBS.md)：基础设施层
+
+## 二次开发：最小调用样板
+
+把 `SAgent.run_stream` 当 SDK 用的最简形式，方便对照参数：
+
+```python
+import asyncio
+from openai import AsyncOpenAI
+from sagents.sagents import SAgent
+
+async def main():
+    agent = SAgent(session_root_space="/tmp/sage", sandbox_type="local")
+    model = AsyncOpenAI(api_key="...", base_url="...")
+    async for chunks in agent.run_stream(
+        input_messages=[{"role": "user", "content": "你好"}],
+        model=model,
+        model_config={"model": "gpt-4o-mini"},
+        system_prefix="你是一个助手",
+        sandbox_agent_workspace="/tmp/sage/agents/demo",
+        max_loop_count=8,
+        agent_mode="simple",
+    ):
+        for c in chunks:
+            print(c.role, c.content)
+
+asyncio.run(main())
+```
+
+更复杂的扩展点（自定义 Flow、自定义子智能体、自定义条件）见下一篇。

--- a/docs/zh/ARCHITECTURE_SAGENTS_SANDBOX_OBS.md
+++ b/docs/zh/ARCHITECTURE_SAGENTS_SANDBOX_OBS.md
@@ -1,0 +1,326 @@
+---
+
+## layout: default
+title: 沙箱 / LLM / 可观测性
+parent: 架构
+nav_order: 8
+description: "Sandbox 抽象（Local / Remote / Passthrough）、LLM 客户端封装与能力探针、ObservabilityManager 与 OpenTelemetry"
+lang: zh
+ref: architecture-sagents-sandbox-obs
+
+{% include lang_switcher.html %}
+
+# 沙箱 / LLM / 可观测性
+
+这一章把三块“横切关注点”合在一起：
+
+- **Sandbox**：所有“执行用户/Agent 代码”的入口都通过统一接口经过它。
+- **LLM 层**：模型客户端、能力探针、prompt 缓存等都被封到 `SageAsyncOpenAI` 里。
+- **可观测性**：一次会话的运行链路通过 `ObservabilityManager` 派发到多个 handler，OpenTelemetry 是默认实现。
+
+它们不直接出现在“业务流程”里，但任何一个出问题都会让整个 runtime 出问题，所以单独一章。
+
+## 1. 沙箱 `sagents/utils/sandbox/`
+
+### 1.1 模块组成
+
+```mermaid
+flowchart TB
+    Iface[interface.py · ISandboxHandle 抽象]
+    Cfg[config.py · SandboxConfig + VolumeMount]
+    Factory[factory.py · SandboxProviderFactory]
+
+    subgraph Providers ["providers/"]
+        Local[local · venv + bwrap/seatbelt 隔离]
+        Remote[remote · OpenSandbox / K8s / Firecracker]
+        Pass[passthrough · 不隔离，宿主直跑]
+    end
+
+    Iface -.被实现.-> Local
+    Iface -.被实现.-> Remote
+    Iface -.被实现.-> Pass
+    Cfg --> Factory
+    Factory -->|按 mode 选择| Local
+    Factory -->|按 mode 选择| Remote
+    Factory -->|按 mode 选择| Pass
+```
+
+
+
+`ISandboxHandle` 是工具层看到的“唯一接口”——无论底下是哪种实现，工具调用都长一样。
+
+### 1.2 三种沙箱模式对比
+
+```mermaid
+flowchart LR
+    Tool[tool/impl/* 调用沙箱] --> SH{ISandboxHandle}
+    SH -->|LOCAL| L[本地 venv + Linux bwrap / macOS seatbelt]
+    SH -->|REMOTE| R[远端容器 / MicroVM]
+    SH -->|PASSTHROUGH| P[当前进程 cwd 内直接执行]
+    L --> Use1[默认桌面/服务端]
+    R --> Use2[共享/多租户/受限环境]
+    P --> Use3[examples / CLI 调试]
+```
+
+
+
+- **LOCAL**：默认模式。给每个会话一个独立目录作为 `sandbox_agent_workspace`，再加资源限制（CPU 时间、内存、可访问路径）。
+- **REMOTE**：把执行外包给 OpenSandbox / Kubernetes / Firecracker 等远端运行时，工厂根据 `remote_provider` 选择具体实现。
+- **PASSTHROUGH**：完全不隔离，直接在宿主机执行，多用于本地 CLI 与 examples。
+
+### 1.3 ISandboxHandle 关键能力
+
+```mermaid
+flowchart TB
+    H[ISandboxHandle] --> Meta[元数据<br/>sandbox_type / sandbox_id / workspace_path]
+    H --> Cmd[execute_command<br/>workdir / timeout / env_vars]
+    H --> Py[execute_python<br/>requirements / workdir / timeout]
+    H --> FS[文件读写<br/>read_file / write_file / list_dir]
+    H --> Mounts[volume_mounts<br/>主机/虚拟路径映射]
+```
+
+
+
+工具层（`execute_command_tool`、`file_system_tool` 等）只调这套接口，不关心具体实现是 venv 还是远端容器。
+
+### 1.4 一次工具调用的链路
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Agent
+    participant TM as ToolManager
+    participant Tool as execute_command_tool
+    participant Sandbox as ISandboxHandle
+    participant Provider as Local/Remote/Passthrough
+
+    Agent->>TM: run_tool("execute_command", args)
+    TM->>Tool: 调用工具实现
+    Tool->>Sandbox: execute_command(cmd, ...)
+    Sandbox->>Provider: 实际执行（venv subprocess / 远端 RPC / 直跑）
+    Provider-->>Sandbox: CommandResult
+    Sandbox-->>Tool: CommandResult
+    Tool-->>TM: 截断后的字符串结果
+    TM-->>Agent: tool_message
+```
+
+
+
+### 1.5 与 Skill 的协作
+
+```mermaid
+flowchart LR
+    Sess[Session] --> SC[SessionContext.init_more]
+    SC --> Sandbox[(沙箱实例)]
+    SC --> SSM[SandboxSkillManager]
+    SSM -->|拷贝/投影| SkillDir[(沙箱内固定路径)]
+    Tool -->|读写| Sandbox
+    Tool -->|读写技能资源| SkillDir
+```
+
+
+
+`SandboxSkillManager` 是“技能 → 沙箱”的桥梁：它在沙箱起来后把技能包按约定路径放进去，工具脚本就能像访问本地目录一样使用。
+
+## 2. LLM 层 `sagents/llm/`
+
+### 2.1 模块组成
+
+```mermaid
+flowchart TB
+    SAOAI[SageAsyncOpenAI · 双客户端封装]
+    Chat[chat.py · 流式调用 + 工具调用拼装]
+    Embed[embedding.py · 向量化封装]
+    Cap[capabilities.py · 请求净化 sanitize_model_request_kwargs]
+    MCap[model_capabilities.py · 启动期能力探针]
+
+    SAOAI -->|standard / fast| Chat
+    SAOAI --> Embed
+    SAOAI -.携带.-> Cap
+    MCap -.探测后注入.-> SAOAI
+```
+
+
+
+### 2.2 SageAsyncOpenAI：双客户端
+
+```mermaid
+flowchart LR
+    Caller[Agent 调 chat.completions.create] --> Sage[SageAsyncOpenAI]
+    Sage -->|model_type=standard| Std[标准模型客户端<br/>主力 LLM]
+    Sage -->|model_type=fast| Fast[快速模型客户端<br/>用于 Router/分类等小任务]
+    Fast -.未配置时回退.-> Std
+    Sage --> San[sanitize_model_request_kwargs<br/>按模型能力清洗参数]
+    San --> Std
+    San --> Fast
+```
+
+
+
+要点：
+
+- 接口完全兼容 `AsyncOpenAI`，只是多一个 `model_type` 参数；
+- 把模型能力位（`supports_multimodal` / `supports_structured_output` 等）挂到客户端对象上，调用点直接读，不必到处传配置；
+- `sanitize_model_request_kwargs` 会按模型能力裁剪请求体，避免“给不支持 reasoning 的模型传 `reasoning_effort`”这类问题。
+
+### 2.3 启动期能力探针
+
+```mermaid
+flowchart TD
+    Boot[启动: lifecycle.initialize_system] --> Probe[probe_connection / capabilities]
+    Probe --> P1[发一条最小请求<br/>验证连通性 + 模型名]
+    Probe --> P2[发结构化输出请求<br/>判断 supports_structured_output]
+    Probe --> P3[发图片输入请求<br/>判断 supports_multimodal]
+    P1 --> Cap[(model_capabilities 字典)]
+    P2 --> Cap
+    P3 --> Cap
+    Cap --> SAOAI[包进 SageAsyncOpenAI]
+```
+
+
+
+探针运行一次，结果会跟着 `SageAsyncOpenAI` 走完整个生命周期，避免每次请求都查能力。
+
+## 3. 可观测性 `sagents/observability/`
+
+### 3.1 模块组成
+
+```mermaid
+flowchart TB
+    Base[base.py · BaseTraceHandler 抽象事件]
+    Mgr[manager.py · ObservabilityManager 多 handler 派发]
+    Otel[opentelemetry_handler.py · 默认实现]
+    Runtime[agent_runtime.py · runtime 端便捷封装]
+
+    Base -.被实现.-> Otel
+    Otel -->|注册到| Mgr
+    Mgr --> Runtime
+```
+
+
+
+### 3.2 事件模型
+
+```mermaid
+flowchart LR
+    Chain[on_chain_start/end/error<br/>整次会话]
+    Agent[on_agent_start/end/error<br/>单个 Agent 一次执行]
+    LLM[on_llm_start/end/error<br/>一次模型调用]
+    Tool[on_tool_start/end/error<br/>一次工具调用]
+    Msg[on_message_start/end<br/>一条消息]
+
+    Chain --> Agent --> LLM
+    Agent --> Tool
+    Agent --> Msg
+```
+
+
+
+`BaseTraceHandler` 把可观测性的“形状”定下来：链路、Agent、LLM、工具、消息这五类事件，全都成对出现（start/end，加可选 error）。
+
+### 3.3 ObservabilityManager 派发
+
+```mermaid
+flowchart LR
+    Source[各组件触发事件] --> Mgr[ObservabilityManager]
+    Mgr --> H1[OpenTelemetryTraceHandler]
+    Mgr --> H2[自定义 Handler 1]
+    Mgr --> H3[自定义 Handler N]
+    Mgr -.单个 handler 抛错.-> Skip[只记 log，不影响其它 handler]
+```
+
+
+
+派发器对“一个 handler 抛异常”做了容错：不打断主流程，也不会污染别的 handler。
+
+### 3.4 OpenTelemetry 实现
+
+```mermaid
+flowchart TD
+    Start[on_*_start] --> NewSpan[创建 OTel Span]
+    NewSpan --> Attach[context.attach 入栈<br/>contextvars 安全跨 task]
+    Action[业务运行] --> Anno[span.set_attribute / add_event]
+    End[on_*_end] --> Finalize[span.set_status OK<br/>span.end + 出栈]
+    Err[on_*_error] --> ErrSpan[span.record_exception<br/>set_status ERROR + 出栈]
+```
+
+
+
+要点：
+
+- 用 `ContextVar` 维护 span 栈，保证异步任务嵌套时 span 关系不串。
+- 跨 context 的 detach 错误被显式忽略（async 任务跨边界很容易触发）。
+- 这一层只“产生”OTel span，至于导出到哪（Jaeger / Tempo / 自托管 OTLP），由进程外的 OpenTelemetry SDK 配置决定，runtime 不关心。
+
+## 4. 三者怎么串起来
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant SA as SAgent
+    participant Obs as ObservabilityManager
+    participant LLM as SageAsyncOpenAI
+    participant Tool as ToolProxy
+    participant SB as Sandbox
+
+    SA->>Obs: on_chain_start(session_id)
+    SA->>Obs: on_agent_start
+    SA->>LLM: chat.completions.create(...)
+    LLM-->>Obs: on_llm_start/end
+    LLM-->>SA: 流式响应（含 tool_call）
+    SA->>Tool: run_tool
+    Tool->>SB: execute_command / read_file
+    Tool-->>Obs: on_tool_start/end
+    SB-->>Tool: 结果
+    Tool-->>SA: tool_message
+    SA->>Obs: on_agent_end
+    SA->>Obs: on_chain_end
+```
+
+
+
+一次会话里：业务流程在 `SAgent` 推进，所有“被外部观测到的事情”都通过 `ObservabilityManager` 抛出来，所有“跨进程的执行”都收敛到 `SageAsyncOpenAI` 与 `ISandboxHandle`。这就是 sagents 把横切关注点解耦的方式。
+
+## 5. 二次开发：自定义 Handler / Provider
+
+### 5.1 自定义可观测性 Handler
+
+```python
+from sagents.observability.base import BaseTraceHandler
+
+class MyHandler(BaseTraceHandler):
+    def on_llm_start(self, session_id, model_name, messages, step_name=None, **kwargs):
+        print(f"[LLM start] session={session_id} model={model_name} step={step_name}")
+
+    def on_llm_end(self, response, **kwargs):
+        print("[LLM end]", getattr(response, "usage", None))
+
+# 注册
+manager.add_handler(MyHandler())
+```
+
+- 可以只实现关心的那几个 `on_*`，其它走父类的空实现；
+- 抛异常不会影响主流程，但会被 logger 记录，调试时方便定位。
+
+### 5.2 自定义远程沙箱
+
+```python
+from sagents.utils.sandbox.interface import ISandboxHandle, SandboxType, CommandResult
+from sagents.utils.sandbox.factory import SandboxProviderFactory
+
+class MyRemoteSandbox(ISandboxHandle):
+    @property
+    def sandbox_type(self): return SandboxType.REMOTE
+    @property
+    def sandbox_id(self): return self._id
+    # ... 其它属性按 interface 实现 ...
+
+    async def execute_command(self, command, workdir=None, timeout=30, env_vars=None):
+        # 调你自己的 RPC / HTTP / SSH
+        ...
+        return CommandResult(success=True, stdout="...", stderr="", return_code=0, execution_time=0.1)
+
+SandboxProviderFactory.register_remote_provider("my_remote", MyRemoteSandbox)
+```
+
+之后只要 `SandboxConfig(mode=SandboxType.REMOTE, remote_provider="my_remote", ...)`，工厂就会用你自己的实现。

--- a/docs/zh/ARCHITECTURE_SAGENTS_SESSION_CONTEXT.md
+++ b/docs/zh/ARCHITECTURE_SAGENTS_SESSION_CONTEXT.md
@@ -1,0 +1,215 @@
+---
+layout: default
+title: 会话与上下文
+parent: 架构
+nav_order: 6
+description: "Session、SessionContext、消息管理、会话/用户记忆与 Workflow"
+lang: zh
+ref: architecture-sagents-session-context
+---
+
+{% include lang_switcher.html %}
+
+# 会话与上下文
+
+`sagents/session_runtime.py` 与 `sagents/context/` 一起承担“状态层”。智能体本身是无状态的处理器，所有状态都集中在这里。
+
+## 1. 会话生命周期：`Session` 与 `SessionManager`
+
+```mermaid
+flowchart LR
+    SAgent --> SM[SessionManager · 进程级单例]
+    SM --> Map[(session_id → Session 映射)]
+    SM --> S1[Session]
+    SM --> S2[Session]
+    SM --> S3[...]
+    S1 --> Ctx1[SessionContext]
+    S2 --> Ctx2[SessionContext]
+    S1 --> Lock1[lock_manager 跨会话锁]
+    SM --> CV[_session_id_var · ContextVar<br/>任意位置拿当前 session_id]
+```
+
+`SessionManager` 提供：
+
+- `get_or_create(session_id, sandbox_type)`
+- `save_session / interrupt_session / close_session`
+- `get_live_session(session_id)`：跨模块拿到正在跑的 Session 引用
+- 与 `lock_manager` 协作，保证同一 session 不被并发跑两次
+
+### 会话状态机
+
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE
+    IDLE --> RUNNING: run_stream_safe 加锁后启动
+    RUNNING --> COMPLETED: 流程正常结束
+    RUNNING --> INTERRUPTED: 用户/系统主动中断
+    RUNNING --> ERROR: 异常
+    COMPLETED --> [*]
+    INTERRUPTED --> [*]
+    ERROR --> [*]
+```
+
+`FlowExecutor` 在每个节点前后都检查 Session 状态，进入 `INTERRUPTED` / `ERROR` 时立即退出循环，避免“跑一半还在烧 token”。
+
+## 2. `SessionContext`：黑板
+
+```mermaid
+flowchart TB
+    subgraph SessionContext
+        ID[身份<br/>session_id · user_id · agent_id · parent_session_id]
+        Sys[system_context · 注入到 Prompt 的额外信息]
+        WS[工作空间<br/>session_root_space · sandbox_agent_workspace · volume_mounts]
+        SBX[sandbox · ISandboxHandle]
+        TM[tool_manager]
+        SM[skill_manager + sandbox_skill_manager]
+        ST[status · audit_status]
+        MM[MessageManager]
+        SMM[SessionMemoryManager]
+        UMM[UserMemoryManager]
+        WF[WorkflowManager]
+        CB[ContextBudgetManager]
+    end
+
+    Agents -->|读写| SessionContext
+```
+
+它是一个**黑板（Blackboard）**：多个 Agent 通过读写它来协同，但互相之间没有直接依赖。
+
+### 显式两阶段初始化
+
+```mermaid
+sequenceDiagram
+    participant Sess as Session
+    participant Ctx as SessionContext
+    participant Sandbox
+    participant SkillProj as SandboxSkillManager
+
+    Sess->>Ctx: __init__(session_id, user_id, ...)
+    Note right of Ctx: 仅占位，sandbox=None
+    Sess->>Ctx: configure_runtime(model, sandbox cfg, agent_id)
+    Sess->>Ctx: await init_more()
+    Ctx->>Sandbox: SandboxProviderFactory.create(...)
+    Sandbox-->>Ctx: ISandboxHandle
+    Ctx->>SkillProj: 把可见技能投影进沙箱
+    Ctx-->>Sess: 就绪
+```
+
+`init_more()` 把耗时资源（沙箱启动、技能投影）从构造函数里挪出来，避免“半初始化”的上下文被误用。
+
+## 3. 消息：`MessageChunk` + `MessageManager`
+
+### 3.1 MessageChunk 单元
+
+```mermaid
+flowchart LR
+    Chunk[MessageChunk] --> ID[message_id · session_id]
+    Chunk --> Role[role · user/assistant/tool/system]
+    Chunk --> Type[message_type · text/tool_call/tool_result/token_usage/...]
+    Chunk --> Content[content · tool_calls · tool_call_id]
+    Chunk --> Meta[时序与扩展元数据]
+```
+
+整个运行时的流式输出都是 `List[MessageChunk]`。
+
+### 3.2 MessageManager：消息历史的真理之源
+
+```mermaid
+flowchart TB
+    Inputs[chunk 流入] --> MM[MessageManager]
+    MM --> Merge[合并同 message_id 的多段]
+    MM --> Filter[过滤 system 消息<br/>system 由 Agent 单独拼]
+    MM --> Compress[按 token 预算压缩 / 裁剪]
+    MM --> Estimate[token 估算<br/>全局比例采样池]
+    MM --> Out1[Agent 调 LLM 前取符合预算的历史]
+    MM --> Out2[流式输出给上游]
+    MM --> CB[ContextBudgetManager<br/>窗口/优先级/buffer]
+    CB --> Compress
+```
+
+要点：
+
+- system 消息不进历史，由 Agent 在调用时单独拼。
+- 上下文预算被收敛到 `ContextBudgetManager` 一处，所有 Agent 共用同一套规则。
+- token 估算用全局采样比例（启发式），避免每条都跑 tokenizer。
+
+## 4. 记忆：会话级 + 用户级
+
+```mermaid
+flowchart LR
+    subgraph 短期
+        SMM[SessionMemoryManager<br/>会话生命周期内有效]
+    end
+
+    subgraph 长期
+        UMM[UserMemoryManager · 以 user_id 索引]
+        UMM --> Iface[IMemoryDriver 抽象]
+        Iface --> Drv[ToolMemoryDriver / 其他]
+        UMM --> Ext[Extractor · 用 LLM 抽取持久条目]
+        UMM --> Path[(MEMORY_ROOT_PATH<br/>或 workspace/user_memory)]
+    end
+
+    Recall[memory_recall Agent] -->|召回| SMM
+    Recall -->|召回| UMM
+    Tool[memory_tool] -->|读写| UMM
+    Obs -. 事件 .-> UMM
+```
+
+记忆系统对 Agent 是“可有可无”的能力，由 `MemoryRecallAgent` 等显式调用，不强制塞进每一次会话。
+
+## 5. Workflow：`context/workflows/`
+
+```mermaid
+flowchart LR
+    AvailWF[run_stream 入参 available_workflows] --> WM[WorkflowManager]
+    WM --> WfList[(已注册 Workflow 模板)]
+    WfSel[workflow_select Agent] -->|按需挑选| WM
+    WM -->|当前可用步骤| Agent
+```
+
+`Workflow` 是“可重用任务模板”——一段预定义的步骤说明。注意它和 `flow/` 名字相近但定位完全不同：
+
+- `flow/`：跑哪些 Agent（编排）
+- `workflows/`：某一类业务任务的固定操作步骤说明（业务模板）
+
+## 6. 一次会话中状态如何演进
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant SAgent
+    participant SM as SessionManager
+    participant Sess as Session
+    participant Ctx as SessionContext
+    participant MM as MessageManager
+    participant Mem as Memory Managers
+
+    Caller->>SAgent: run_stream(messages, ...)
+    SAgent->>SM: get_or_create(session_id)
+    SM-->>SAgent: Session
+    SAgent->>Sess: configure_runtime(...)
+    Sess->>Ctx: 构造或复用 SessionContext
+    Ctx->>Ctx: init_more() 初始化沙箱/技能投影
+    Sess->>Ctx: 写入 audit_status (agent_mode, deep_thinking ...)
+    Sess->>MM: 写入输入 messages
+    loop FlowExecutor 每步
+        Sess->>MM: 读取符合预算的历史
+        Sess->>Mem: 召回会话/用户记忆
+        Sess-->>Caller: yield 流式 chunk
+        Sess->>MM: 增量写入 assistant/tool chunk
+    end
+    SAgent->>SM: close_session(session_id)
+    SM->>Mem: 触发用户记忆抽取（按需）
+```
+
+## 7. 与外部存储的关系
+
+```mermaid
+flowchart LR
+    Ctx[SessionContext · 纯运行时内存] --> AppLayer[应用层]
+    AppLayer --> Server[(app/server: 多租户 DB / 对象存储)]
+    AppLayer --> Desktop[(app/desktop: 本地 SQLite / 用户目录)]
+    AppLayer --> CLI[(app/cli / examples: 文件或纯内存)]
+```
+
+`SessionContext` 自身不直接绑定任何具体数据库。**“运行时纯内存 + 应用层负责持久化”**，正是 sagents 能被多种应用形态复用的关键之一。

--- a/docs/zh/ARCHITECTURE_SAGENTS_TOOL_SKILL.md
+++ b/docs/zh/ARCHITECTURE_SAGENTS_TOOL_SKILL.md
@@ -1,0 +1,296 @@
+---
+layout: default
+title: 工具与技能系统
+parent: 架构
+nav_order: 7
+description: "ToolManager / ToolProxy、内置工具、MCP 代理、SkillManager / SkillProxy 与沙箱内技能"
+lang: zh
+ref: architecture-sagents-tool-skill
+---
+
+{% include lang_switcher.html %}
+
+# 工具与技能系统
+
+`sagents/tool/` 与 `sagents/skill/` 是“能力层”：决定一次会话里 Agent 可以调用什么、技能包是怎么被加载和执行的。
+
+## 1. 工具系统 `sagents/tool/`
+
+### 1.1 模块组成
+
+```mermaid
+flowchart TB
+    subgraph 注册
+        TBase[tool_base · @tool 装饰器 + _DISCOVERED_TOOLS]
+        MBase[mcp_tool_base · _DISCOVERED_MCP_TOOLS]
+        Schema[tool_schema · ToolSpec / OpenAI 函数调用 schema]
+    end
+
+    subgraph 运行时
+        TM[ToolManager · 全局工具管理器]
+        TP[ToolProxy · 会话级白名单]
+        MP[mcp_proxy · 与 MCP Server 的代理]
+        Impl[impl/ · 内置工具实现]
+    end
+
+    TBase -.收集.-> TM
+    MBase -.收集.-> TM
+    TM --> Impl
+    TM --> MP
+    Schema -.转换.-> TM
+    TP --> TM
+```
+
+### 1.2 工具的两类来源
+
+```mermaid
+flowchart LR
+    Agent --> TP[ToolProxy]
+    TP --> TM[ToolManager]
+    TM -->|本地| Impl[tool/impl/*]
+    TM -->|MCP| MCPProxy[mcp_proxy]
+    MCPProxy --> Stdio[stdio MCP Server]
+    MCPProxy --> SSE[SSE MCP Server]
+    MCPProxy --> HTTP[Streamable HTTP MCP]
+    Impl --> Sandbox
+```
+
+无论本地工具还是 MCP 工具，对 Agent 都长得一样。`ToolManager` 把它们统一登记，再按调用名字派发。
+
+### 1.3 ToolManager 的关键能力
+
+```mermaid
+flowchart TB
+    Start[启动期] --> Scan[扫描已注册工具<br/>本地 @tool + MCP]
+    Run[运行期] --> Call[run_tool name + args + SessionContext]
+    Call --> Exec[本地实现 / MCP 远端]
+    Exec --> Trunc[结果按 token 截断<br/>MAX_TOOL_RESULT_TOKENS=12000]
+    Trunc --> ToAgent[返回 tool_message]
+    Run --> Meta[list_all_tools_name / get_tool_spec]
+```
+
+ToolManager 通常是进程级单例，由 `app/server/lifecycle.py`（或桌面端等价物）在启动期初始化。
+
+### 1.4 ToolProxy：会话级白名单
+
+```mermaid
+flowchart LR
+    Caller[服务端构造请求] --> Pick[按用户/Agent 权限选 available_tools]
+    Pick --> TP[ToolProxy<br/>tool_managers + available_tools]
+    TP --> Filter[白名单过滤 + 优先级排序]
+    TP --> Warn[白名单不存在的工具打 warning]
+    TP --> SAgent[SAgent.run_stream tool_manager=TP]
+```
+
+`ToolProxy` 接受多个 `ToolManager`（按列表顺序优先级递减），并兼容 `ToolManager` 的接口，所以 Agent 不需要区分。
+
+### 1.5 内置工具 `tool/impl/`
+
+```mermaid
+flowchart TB
+    subgraph 命令与文件
+        Cmd[execute_command_tool]
+        FS[file_system_tool]
+    end
+    subgraph 网络与多模态
+        Web[web_fetcher_tool]
+        Img[image_understanding_tool]
+    end
+    subgraph 上下文管理
+        Compress[compress_history_tool]
+        TodoT[todo_tool · 多智能体任务清单]
+    end
+    subgraph 用户交互
+        Quest[questionnaire_tool · 结构化问卷]
+    end
+    subgraph 记忆
+        Mem[memory_tool]
+        MIdx[memory_index]
+    end
+
+    Cmd --> Sandbox
+    FS --> Sandbox
+    Web --> Sandbox
+```
+
+它们的执行最终都要落到 `Sandbox` 抽象上（详见 [Sandbox/LLM/Obs](ARCHITECTURE_SAGENTS_SANDBOX_OBS.md)）。
+
+### 1.6 MCP 集成
+
+```mermaid
+flowchart LR
+    MCPServer[(任意 MCP Server)] --> Conn{连接方式}
+    Conn -->|stdio| Stdio[StdioServerParameters]
+    Conn -->|HTTP+SSE| SSE[SseServerParameters]
+    Conn -->|Streamable HTTP| HTTP[StreamableHttpServerParameters]
+    Stdio --> MP[mcp_proxy]
+    SSE --> MP
+    HTTP --> MP
+    MP --> Convert[把 MCP Tool 转成 OpenAI 函数调用 schema]
+    Convert --> TM
+    MP --> Health[连接生命周期 / 超时 / 健康检查]
+```
+
+仓库内置的 `mcp_servers/` 也是同样的方式接入。
+
+## 2. 技能系统 `sagents/skill/`
+
+“工具”是函数级能力，“技能”是更大粒度的工作流：一个目录、一份说明、可能配套脚本与示例资源。
+
+### 2.1 模块组成
+
+```mermaid
+flowchart TB
+    subgraph 宿主侧
+        Schema[SkillSchema · 元数据]
+        SM[SkillManager · 扫描/注册/加载]
+        SP[SkillProxy · 会话级白名单]
+    end
+
+    subgraph 沙箱侧
+        SSM[SandboxSkillManager · 复制/投影到沙箱]
+    end
+
+    subgraph 暴露给 Agent
+        STool[skill_tool · 把技能包装成工具]
+    end
+
+    SM --> Schema
+    SM --> SP
+    SP --> SSM
+    SSM --> STool
+```
+
+### 2.2 数据流
+
+```mermaid
+flowchart LR
+    Disk[(技能目录)] --> SM
+    SM --> Reg[(SkillSchema 注册表)]
+    Caller[一次请求] --> Pick[按 Agent 权限选 available_skills]
+    Pick --> SP[SkillProxy]
+    SP --> SC[SessionContext.init_more]
+    SC --> SSM[SandboxSkillManager]
+    SSM --> Sandbox[(沙箱内固定路径)]
+    Sandbox --> Use[沙箱里的工具/脚本读写技能资源]
+```
+
+`SkillManager` 不负责把技能拷贝到沙箱——那是 `SandboxSkillManager` 的职责。这种解耦让 remote 沙箱场景也能正常用技能。
+
+### 2.3 技能 → 工具
+
+```mermaid
+flowchart LR
+    Skill[一个技能包] --> MD[SKILL.md 说明]
+    Skill --> Assets[脚本 / 资源文件]
+    MD -->|注入| SysPrompt[system prompt 合适位置]
+    Skill -->|可注册| ST[skill_tool]
+    ST --> TM[ToolManager]
+    SysPrompt --> LLM
+    TM --> LLM
+```
+
+技能既能通过说明影响模型行为，也能直接以工具的形式被 LLM 通过 function call 调用。
+
+## 3. 推荐 / 选择策略
+
+```mermaid
+flowchart LR
+    AllTools[(全部工具)] --> ToolSug[tool_suggestion Agent]
+    AllWFs[(全部 workflow)] --> WfSel[workflow_select Agent]
+    ToolSug -->|本次该用什么| LLM
+    WfSel -->|本次该走哪条| LLM
+```
+
+工具/技能层负责“有什么”，建议 Agent 负责“这次用什么”。这样不用一次把全部 schema 塞进上下文。
+
+## 4. 启动期 vs 运行期
+
+```mermaid
+flowchart TD
+    Bootstrap[app 启动] --> ToolMgr[ToolManager 单例]
+    Bootstrap --> SkillMgr[SkillManager 单例]
+    Request[一次请求] --> Build[构造 ToolProxy + SkillProxy]
+    Build --> SAgent[SAgent.run_stream]
+    SAgent --> Sess[Session/SessionContext]
+    Sess --> SSM[SandboxSkillManager 投影到沙箱]
+    Sess --> Agents
+    Agents --> Tools[ToolProxy.run_tool]
+```
+
+## 5. 二次开发：自定义工具 / MCP / 技能
+
+Sage 的扩展点几乎都在这两层。三种最常用的“给 Agent 加能力”的方式互不冲突。
+
+### 5.1 写一个本地工具
+
+```python
+# my_pkg/my_tools.py
+from sagents.tool.tool_base import tool
+
+@tool(
+    name="get_weather",
+    description="按城市名查询天气",
+)
+async def get_weather(city: str) -> dict:
+    """返回 dict 即可，框架自动序列化为 tool_message。"""
+    return {"city": city, "temp_c": 23, "condition": "sunny"}
+```
+
+只要这个模块被 import 到进程里（例如在 `app/server/bootstrap.py` 的工具初始化阶段 import），它就会被 `ToolManager` 自动收集。
+
+### 5.2 接入一个 MCP Server
+
+```python
+from mcp import StdioServerParameters
+from sagents.tool.tool_schema import SseServerParameters, StreamableHttpServerParameters
+
+# 三种连接方式按需选一种：
+stdio_cfg = StdioServerParameters(command="my-mcp", args=["--stdio"])
+sse_cfg = SseServerParameters(url="https://mcp.example.com/sse")
+http_cfg = StreamableHttpServerParameters(url="https://mcp.example.com/mcp")
+
+# 通过 ToolManager 提供的注册接口加入（具体 API 看当前 tool_manager.py）
+tool_manager.register_mcp_server(name="my_mcp", params=stdio_cfg)
+```
+
+注册后，该 MCP Server 暴露的所有工具会被自动转成 OpenAI 函数调用 schema，并和本地工具同等对待。
+
+### 5.3 写一个技能包
+
+技能就是一个目录，按约定包含：
+
+```text
+my_skill/
+├── SKILL.md          # 必需，人类可读的“怎么用”说明，会注入 LLM
+├── skill.yaml        # 可选元数据：id / name / description / 激活场景
+├── scripts/          # 可选脚本，可在沙箱里执行
+└── assets/           # 可选静态资源
+```
+
+`SKILL.md` 的开头一般写：
+
+```markdown
+# Skill: My Skill
+
+## 用途
+描述这个技能解决什么问题，什么时候该用它。
+
+## 步骤
+1. ...
+2. ...
+
+## 注意事项
+- ...
+```
+
+把这个目录所在的根目录注册给 SkillManager 即可：
+
+```python
+from sagents.skill import SkillManager
+
+skill_manager = SkillManager()
+skill_manager.add_skill_dir("/path/to/skills_root")
+```
+
+之后通过 `SkillProxy(skill_manager, available_skills=["my_skill"])` 限定本次会话能看到的技能子集，再传给 `SAgent.run_stream`。

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -63,7 +63,9 @@ ref: home
 - [快速开始](GETTING_STARTED.md)：安装依赖并运行 CLI、服务端、Web UI 或桌面版
 - [CLI 使用指南](CLI.md)：命令行工作流、会话、技能、工作目录与结构化输出
 - [核心概念](CORE_CONCEPTS.md)：会话、智能体、工具、技能、流程和沙箱
-- [架构](ARCHITECTURE.md)：代码库整体组织方式
+- [架构](ARCHITECTURE.md)：代码库整体组织方式（含子章节）
+  - 应用层：[Server](ARCHITECTURE_APP_SERVER.md) · [Desktop](ARCHITECTURE_APP_DESKTOP.md) · [其它入口](ARCHITECTURE_APP_OTHERS.md)
+  - sagents 核心：[总览](ARCHITECTURE_SAGENTS_OVERVIEW.md) · [Agent / Flow](ARCHITECTURE_SAGENTS_AGENT_FLOW.md) · [Session / Context](ARCHITECTURE_SAGENTS_SESSION_CONTEXT.md) · [Tool / Skill](ARCHITECTURE_SAGENTS_TOOL_SKILL.md) · [Sandbox / LLM / Obs](ARCHITECTURE_SAGENTS_SANDBOX_OBS.md)
 - [配置](CONFIGURATION.md)：运行时环境变量与存储设置
 - [应用形态](APPLICATIONS.md)：不同入口分别适合什么场景
 - [MCP Servers](MCP_SERVERS.md)：内置 MCP Server 以及它们在平台中的角色

--- a/sagents/agent/agent_base.py
+++ b/sagents/agent/agent_base.py
@@ -5,7 +5,7 @@ import uuid
 import asyncio
 from sagents.utils.logger import logger
 from sagents.tool.tool_manager import ToolManager
-from sagents.context.session_context import SessionContext, SessionStatus
+from sagents.context.session_context import SessionContext
 from sagents.context.messages.message import MessageChunk, MessageRole, MessageType
 from sagents.utils.prompt_manager import prompt_manager
 from sagents.context.messages.message_manager import MessageManager
@@ -16,20 +16,28 @@ from sagents.utils.llm_request_utils import (
     format_api_error_details,
     is_unsupported_input_format_error,
 )
+from sagents.utils.multimodal_image import (
+    process_multimodal_content as _process_multimodal_content_util,
+    resolve_local_sage_url as _resolve_local_sage_url_util,
+    get_mime_type as _get_mime_type_util,
+)
+from sagents.utils.message_sanitizer import (
+    remove_orphan_tool_calls as _remove_orphan_tool_calls_util,
+    strip_content_when_tool_calls as _strip_content_when_tool_calls_util,
+)
+from sagents.utils.stream_merger import merge_chat_completion_chunks as _merge_chunks_util
+from sagents.utils.stream_tag_parser import judge_delta_content_type as _judge_delta_content_type_util
+from sagents.utils.agent_session_helper import (
+    get_live_session as _get_live_session_util,
+    get_live_session_context as _get_live_session_context_util,
+    should_abort_due_to_session as _should_abort_due_to_session_util,
+)
 import traceback
 import time
 import os
 from openai import AsyncOpenAI, APIError, RateLimitError, APIConnectionError
 import httpx
 from openai.types.chat import chat_completion_chunk
-from openai.types.chat import (
-    ChatCompletion,
-    ChatCompletionMessage,
-    ChatCompletionMessageToolCall,
-)
-from openai.types.chat.chat_completion import Choice
-from openai.types.chat.chat_completion_message_tool_call import Function
-from openai.types.completion_usage import CompletionUsage, PromptTokensDetails, CompletionTokensDetails
 
 
 class AgentBase(ABC):
@@ -64,22 +72,10 @@ class AgentBase(ABC):
         logger.debug(f"AgentBase: 初始化 {self.__class__.__name__}，模型配置: {model_config}, 最大输入长度（安全阈值）: {self.max_model_input_len}")
 
     def _get_live_session(self, session_id: Optional[str]):
-        if not session_id:
-            return None
-        try:
-            from sagents.session_runtime import get_global_session_manager
-
-            session_manager = get_global_session_manager()
-            if not session_manager:
-                return None
-            return session_manager.get_live_session(session_id)
-        except Exception as e:
-            logger.debug(f"{self.__class__.__name__}: 获取 live session 失败, session_id={session_id}: {e}")
-            return None
+        return _get_live_session_util(session_id, log_prefix=self.__class__.__name__)
 
     def _get_live_session_context(self, session_id: Optional[str]):
-        session = self._get_live_session(session_id)
-        return session.session_context if session else None
+        return _get_live_session_context_util(session_id, log_prefix=self.__class__.__name__)
 
     @abstractmethod
     async def run_stream(self,
@@ -100,258 +96,35 @@ class AgentBase(ABC):
             yield []
 
     def _remove_tool_call_without_id(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """移除 tool_calls 没有对应 tool 回复的 assistant 消息。详见
+        ``sagents.utils.message_sanitizer.remove_orphan_tool_calls``。
         """
-        移除assistant 是tool call 但是在messages中其他的role 为tool 的消息中没有对应的tool call id
-
-        Args:
-            messages: 输入消息列表
-
-        Returns:
-            List[Dict[str, Any]]: 移除了没有对应 tool_call_id 的tool call 消息
-        """
-        new_messages = []
-        all_tool_call_ids_from_tool = []
-        for msg in messages:
-            if msg.get('role') == MessageRole.TOOL.value and 'tool_call_id' in msg:
-                all_tool_call_ids_from_tool.append(msg['tool_call_id'])
-        for msg in messages:
-            if msg.get('role') == MessageRole.ASSISTANT.value and 'tool_calls' in msg:
-                tool_calls = msg['tool_calls'] or []
-                # 如果tool_calls 里面的id 没有在其他的role 为tool 的消息中出现，就移除这个消息
-                # 兼容 ChoiceDeltaToolCall 对象和字典形式
-                def get_tool_call_id(tool_call):
-                    if hasattr(tool_call, 'id'):
-                        return tool_call.id
-                    return tool_call.get('id')
-                if any(get_tool_call_id(tool_call) not in all_tool_call_ids_from_tool for tool_call in tool_calls):
-                    continue
-            new_messages.append(msg)
-        return new_messages
+        return _remove_orphan_tool_calls_util(messages)
 
     def _remove_content_if_tool_calls(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """assistant 消息带 tool_calls 时移除 content 字段。详见
+        ``sagents.utils.message_sanitizer.strip_content_when_tool_calls``。
         """
-        如果 assistant 消息包含 tool_calls，则移除 content 字段
-
-        Args:
-            messages: 消息列表
-
-        Returns:
-            List[Dict[str, Any]]: 处理后的消息列表
-        """
-        for msg in messages:
-            if msg.get('role') == MessageRole.ASSISTANT.value and msg.get('tool_calls'):
-                msg.pop('content', None)
-        return messages
+        return _strip_content_when_tool_calls_util(messages)
 
     async def _process_multimodal_content(self, msg: Dict[str, Any]) -> Dict[str, Any]:
+        """处理多模态消息内容（本地图片转 base64、压缩到最大 512x512）。详见
+        ``sagents.utils.multimodal_image.process_multimodal_content``。
         """
-        处理多模态消息内容，将本地图片路径转换为 base64
-        保持远程图片 URL 不变
-        图片会被压缩至最大 512x512 像素
-
-        Args:
-            msg: 消息字典
-
-        Returns:
-            Dict[str, Any]: 处理后的消息字典
-        """
-        import base64
-        from pathlib import Path
-        from PIL import Image
-        import io
-
-        content = msg.get('content')
-        if not isinstance(content, list):
-            return msg
-
-        new_content = []
-        for item in content:
-            if not isinstance(item, dict):
-                new_content.append(item)
-                continue
-
-            item_type = item.get('type')
-
-            if item_type == 'text':
-                # 文本内容保持不变
-                new_content.append(item)
-
-            elif item_type == 'image_url':
-                image_url_data = item.get('image_url', {})
-                url = image_url_data.get('url', '') if isinstance(image_url_data, dict) else str(image_url_data)
-
-                if not url:
-                    new_content.append(item)
-                    continue
-
-                # 检查是否已经是 base64 data URL
-                if url.startswith('data:image/'):
-                    # 已经是 base64 格式，需要解码、压缩后重新编码
-                    try:
-                        # 解析 data URL，格式: data:image/xxx;base64,xxxxx
-                        header, base64_str = url.split(',', 1)
-
-                        # 解码 base64 数据
-                        image_data = base64.b64decode(base64_str)
-
-                        # 打开图片并压缩
-                        buffer = io.BytesIO(image_data)
-                        with Image.open(buffer) as img:
-                            # 转换为 RGB 模式（处理 RGBA 等模式）
-                            if img.mode in ('RGBA', 'P'):
-                                img = img.convert('RGB')
-
-                            # 压缩图片至最大 512x512，保持原始比例
-                            img.thumbnail((512, 512), Image.Resampling.LANCZOS)
-
-                            # 保存到新的内存缓冲区
-                            output_buffer = io.BytesIO()
-                            img.save(output_buffer, format='JPEG', quality=85)
-                            compressed_data = output_buffer.getvalue()
-
-                        # 重新编码为 base64
-                        compressed_base64 = base64.b64encode(compressed_data).decode('utf-8')
-
-                        # 使用 JPEG MIME 类型（因为压缩后统一转为 JPEG）
-                        data_url = f"data:image/jpeg;base64,{compressed_base64}"
-
-                        new_content.append({
-                            'type': 'image_url',
-                            'image_url': {'url': data_url}
-                        })
-                        logger.debug(f"Compressed base64 image from {len(image_data)} to {len(compressed_data)} bytes")
-
-                    except Exception as e:
-                        logger.error(f"Failed to compress base64 image: {e}")
-                        # 压缩失败时保留原始数据，不进行截断
-                        new_content.append(item)
-                    continue
-
-                # 检查是否是本地文件路径
-                if url.startswith('file://'):
-                    # 移除 file:// 前缀
-                    file_path = url[7:]
-                elif url.startswith('http://') or url.startswith('https://'):
-                    # 桌面端 sidecar 暴露的"本地静态文件"也走 http URL，
-                    # 但远程 LLM 无法访问 127.0.0.1，需要在这里反解回本地路径再走 base64。
-                    local_path = self._maybe_resolve_local_sage_url(url)
-                    if local_path is None:
-                        new_content.append(item)
-                        continue
-                    file_path = local_path
-                else:
-                    file_path = url
-
-                # 检查文件是否存在
-                path_obj = Path(file_path)
-                if not path_obj.exists():
-                    logger.warning(f"Image file not found: {file_path}")
-                    new_content.append(item)
-                    continue
-
-                try:
-                    # 打开图片并压缩
-                    with Image.open(path_obj) as img:
-                        # 转换为 RGB 模式（处理 RGBA 等模式）
-                        if img.mode in ('RGBA', 'P'):
-                            img = img.convert('RGB')
-
-                        # 压缩图片至最大 512x512，保持原始比例
-                        img.thumbnail((512, 512), Image.Resampling.LANCZOS)
-
-                        # 保存到内存缓冲区
-                        buffer = io.BytesIO()
-                        img.save(buffer, format='JPEG', quality=85)
-                        image_data = buffer.getvalue()
-
-                    base64_data = base64.b64encode(image_data).decode('utf-8')
-
-                    # 使用 JPEG MIME 类型（因为压缩后统一转为 JPEG）
-                    mime_type = 'image/jpeg'
-
-                    # 构建 data URL
-                    data_url = f"data:{mime_type};base64,{base64_data}"
-
-                    new_content.append({
-                        'type': 'image_url',
-                        'image_url': {'url': data_url}
-                    })
-                    logger.debug(f"Converted and compressed local image to base64: {file_path}, size: {len(image_data)} bytes")
-
-                except Exception as e:
-                    logger.error(f"Failed to convert image to base64: {file_path}, error: {e}")
-                    new_content.append(item)
-
-            else:
-                # 其他类型保持不变
-                new_content.append(item)
-
-        msg['content'] = new_content
-        return msg
+        return await _process_multimodal_content_util(msg)
 
     @staticmethod
     def _maybe_resolve_local_sage_url(url: str) -> Optional[str]:
-        """把桌面端 sidecar 的本地 sage 文件 URL 反解为本地文件路径。
-
-        前端两端统一以 http(s) URL 渲染图片：
-        - server 端：是真正的远程 OSS URL，远程 LLM 可以直接访问；
-        - desktop 端：URL 形如 http://127.0.0.1:<port>/api/oss/file/<agent_id>/<filename>，
-          远程 LLM 访问不到 localhost，因此这里把它映射回 ~/.sage/agents/<agent_id>/upload_files/<filename>，
-          交由调用方走"本地图片 → base64"分支。
-
-        若不是本地 sage 文件 URL，返回 None。
+        """桌面端 sidecar 的 ``http://127.0.0.1/api/oss/file/...`` 反解为本地路径。详见
+        ``sagents.utils.multimodal_image.resolve_local_sage_url``。
         """
-        try:
-            from urllib.parse import urlparse, unquote
-
-            parsed = urlparse(url)
-            if parsed.hostname not in ("127.0.0.1", "localhost", "0.0.0.0"):
-                return None
-
-            from pathlib import Path
-
-            path = unquote(parsed.path or "")
-            # 形如 /api/oss/file/<agent_id>/<filename>
-            prefix = "/api/oss/file/"
-            if not path.startswith(prefix):
-                return None
-            rest = path[len(prefix):]
-            parts = rest.split("/", 1)
-            if len(parts) != 2:
-                return None
-            agent_id, filename = parts[0], parts[1]
-            if not agent_id or not filename or "/" in filename or "\\" in filename:
-                return None
-
-            user_home = Path.home()
-            if agent_id == "_default":
-                base_dir = user_home / ".sage" / "files"
-            else:
-                base_dir = user_home / ".sage" / "agents" / agent_id / "upload_files"
-            file_path = (base_dir / filename).resolve()
-            try:
-                file_path.relative_to(base_dir.resolve())
-            except ValueError:
-                return None
-            if not file_path.exists() or not file_path.is_file():
-                return None
-            return str(file_path)
-        except Exception as exc:
-            logger.warning(f"Failed to resolve local sage url: {url}, error: {exc}")
-            return None
+        return _resolve_local_sage_url_util(url)
 
     def _get_mime_type(self, file_extension: str) -> str:
-        """根据文件扩展名获取 MIME 类型"""
-        mime_types = {
-            '.jpg': 'image/jpeg',
-            '.jpeg': 'image/jpeg',
-            '.png': 'image/png',
-            '.gif': 'image/gif',
-            '.webp': 'image/webp',
-            '.bmp': 'image/bmp',
-            '.svg': 'image/svg+xml',
-        }
-        return mime_types.get(file_extension, 'image/jpeg')
+        """根据文件扩展名获取 MIME 类型。详见
+        ``sagents.utils.multimodal_image.get_mime_type``。
+        """
+        return _get_mime_type_util(file_extension)
 
     async def _call_llm_streaming(self, messages: List[Union[MessageChunk, Dict[str, Any]]], session_id: Optional[str] = None, step_name: str = "llm_call", model_config_override: Optional[Dict[str, Any]] = None, enable_thinking: Optional[bool] = None):
         """
@@ -1002,50 +775,10 @@ class AgentBase(ABC):
                                   delta_content: str,
                                   all_tokens_str: str,
                                   tag_type: Optional[List[str]] = None) -> str:
-        if tag_type is None:
-            tag_type = []
-
-        start_tag = [f"<{tag}>" for tag in tag_type]
-        end_tag = [f"</{tag}>" for tag in tag_type]
-
-        # 构造结束标签的所有可能前缀
-        end_tag_process_list = []
-        for tag in end_tag:
-            for i in range(len(tag)):
-                end_tag_process_list.append(tag[:i + 1])
-
-        last_tag = None
-        last_tag_index: Optional[int] = None
-
-        all_tokens_str = (all_tokens_str + delta_content).strip()
-
-        # 查找最后出现的标签
-        for tag in start_tag + end_tag:
-            index = all_tokens_str.rfind(tag)
-            if index != -1:
-                if last_tag_index is None or index > last_tag_index:
-                    last_tag = tag
-                    last_tag_index = index
-
-        if last_tag is None:
-            return "tag"
-
-        # Ensure last_tag_index is not None for mypy
-        if last_tag_index is None:
-            return "tag"
-
-        if last_tag in start_tag:
-            if last_tag_index + len(last_tag) == len(all_tokens_str):
-                return 'tag'
-            for end_tag_process in end_tag_process_list:
-                if all_tokens_str.endswith(end_tag_process):
-                    return 'unknown'
-            else:
-                return last_tag.replace("<", "").replace(">", "")
-        elif last_tag in end_tag:
-            return 'tag'
-
-        return "tag"
+        """根据已累积的输出，判断当前 delta 所属的 tag 类型。详见
+        ``sagents.utils.stream_tag_parser.judge_delta_content_type``。
+        """
+        return _judge_delta_content_type_util(delta_content, all_tokens_str, tag_type)
 
     def _handle_tool_calls_chunk(self,
                                  chunk,
@@ -1438,112 +1171,10 @@ class AgentBase(ABC):
         )]
 
     def merge_stream_response_to_non_stream_response(self, chunks):
+        """将流式的 chunk 合并成非流式的 response。详见
+        ``sagents.utils.stream_merger.merge_chat_completion_chunks``。
         """
-        将流式的chunk，进行合并成非流式的response
-        """
-        id_ = model_ = created_ = None
-        content = ""
-        tool_calls: dict[int, dict] = {}
-        finish_reason = None
-        usage = None
-
-        for chk in chunks:
-            if id_ is None:
-                id_, model_, created_ = chk.id, chk.model, chk.created
-
-            if chk.usage:  # 最后的 usage chunk
-                # 处理 prompt_tokens_details
-                prompt_tokens_details = None
-                if chk.usage.prompt_tokens_details:
-                    prompt_tokens_details = PromptTokensDetails(
-                        cached_tokens=chk.usage.prompt_tokens_details.cached_tokens,
-                        audio_tokens=chk.usage.prompt_tokens_details.audio_tokens,
-                    )
-                
-                # 处理 completion_tokens_details
-                completion_tokens_details = None
-                if chk.usage.completion_tokens_details:
-                    completion_tokens_details = CompletionTokensDetails(
-                        reasoning_tokens=chk.usage.completion_tokens_details.reasoning_tokens,
-                        audio_tokens=chk.usage.completion_tokens_details.audio_tokens,
-                        accepted_prediction_tokens=chk.usage.completion_tokens_details.accepted_prediction_tokens,
-                        rejected_prediction_tokens=chk.usage.completion_tokens_details.rejected_prediction_tokens,
-                    )
-                
-                usage = CompletionUsage(
-                    prompt_tokens=chk.usage.prompt_tokens,
-                    completion_tokens=chk.usage.completion_tokens,
-                    total_tokens=chk.usage.total_tokens,
-                    prompt_tokens_details=prompt_tokens_details,
-                    completion_tokens_details=completion_tokens_details,
-                )
-
-            if not chk.choices:
-                continue
-
-            delta = chk.choices[0].delta
-            finish_reason = chk.choices[0].finish_reason
-
-            if delta.content:
-                content += delta.content
-
-            for tc in delta.tool_calls or []:
-                idx = tc.index
-                if idx is None:
-                    continue
-                if idx not in tool_calls:
-                    tool_calls[idx] = {
-                        "id": tc.id or "",
-                        "type": tc.type or "function",
-                        "function": {"name": "", "arguments": ""},
-                    }
-                entry = tool_calls[idx]
-                if tc.id and not entry["id"]:
-                    entry["id"] = tc.id
-                if tc.function.name and not entry["function"]["name"]:
-                    entry["function"]["name"] = tc.function.name
-                if tc.function.arguments:
-                    entry["function"]["arguments"] += tc.function.arguments
-        if finish_reason is None:
-            finish_reason = "stop"
-        if id_ is None:
-            id_ = "stream-merge-empty"
-        if created_ is None:
-            created_ = 0
-        if model_ is None:
-            model_ = "unknown"
-        return ChatCompletion(
-            id=id_,
-            object="chat.completion",  # ← 关键修复
-            created=created_,
-            model=model_,
-            choices=[
-                Choice(
-                    index=0,
-                    message=ChatCompletionMessage(
-                        role="assistant",
-                        content=content or None,
-                        tool_calls=(
-                            [
-                                ChatCompletionMessageToolCall(
-                                    id=tc["id"],
-                                    type="function",
-                                    function=Function(
-                                        name=tc["function"]["name"],
-                                        arguments=tc["function"]["arguments"],
-                                    ),
-                                )
-                                for tc in tool_calls.values()
-                            ]
-                            if tool_calls
-                            else None
-                        ),
-                    ),
-                    finish_reason=finish_reason,
-                )
-            ],
-            usage=usage,
-        )
+        return _merge_chunks_util(chunks)
 
     async def _handle_tool_calls(self,
                                  tool_calls: Dict[str, Any],
@@ -1650,24 +1281,11 @@ class AgentBase(ABC):
             except (ValueError, SyntaxError, TypeError):
                 return None, False
 
-    def _should_abort_due_to_session(self, session_context: SessionContext,session_id: Optional[str] = None) -> bool:
-        session_id = session_context.session_id
-        session = self._get_live_session(session_id)
-        if session_id and session is None:
-            logger.info("SimpleAgent: 跳过执行，session上下文不存在或已中断")
-            return True
-        # 检查当前会话状态（中断、错误或已完成都应该停止）
-        if session and session.get_status() in [SessionStatus.INTERRUPTED, SessionStatus.ERROR, SessionStatus.COMPLETED]:
-            logger.info(f"SimpleAgent: 跳过执行，session状态为{session.get_status().value}")
-            return True
-        # 检查父会话状态（如果是子会话）
-        if hasattr(session_context, 'parent_session_id') and session_context.parent_session_id:
-            parent_session = self._get_live_session(session_context.parent_session_id)
-            if parent_session and parent_session.get_status() in [SessionStatus.INTERRUPTED, SessionStatus.ERROR, SessionStatus.COMPLETED]:
-                logger.info(f"SimpleAgent: 跳过执行，父会话 {session_context.parent_session_id} 状态为{parent_session.get_status().value}")
-                # 同时更新子会话状态
-                if session is None:
-                    return True
-                session.set_status(SessionStatus.INTERRUPTED, cascade=False)
-                return True
-        return False
+    def _should_abort_due_to_session(self, session_context: SessionContext, session_id: Optional[str] = None) -> bool:
+        """检查会话/父会话状态，命中即返回 True。详见
+        ``sagents.utils.agent_session_helper.should_abort_due_to_session``。
+        """
+        return _should_abort_due_to_session_util(
+            session_context,
+            log_prefix=self.__class__.__name__,
+        )

--- a/sagents/agent/fibre/tools.py
+++ b/sagents/agent/fibre/tools.py
@@ -28,9 +28,8 @@ class FibreTools:
         """
         logger.info(f"Tool Call: sys_spawn_agent(name={name}, description={description})")
 
-        from sagents.session_runtime import get_global_session_manager
-        session_manager = get_global_session_manager()
-        session = session_manager.get_live_session(session_id) if session_manager else None
+        from sagents.utils.agent_session_helper import get_live_session
+        session = get_live_session(session_id, log_prefix="FibreTools.sys_spawn_agent")
         if not session:
             return f"Error: Session not found for session_id: {session_id}"
         session_context = session.session_context
@@ -102,10 +101,9 @@ class FibreTools:
             session_id: The current session ID (auto-injected)
         """
         logger.info(f"Tool Call: sys_delegate_task(tasks_count={len(tasks)})")
-        
-        from sagents.session_runtime import get_global_session_manager
-        session_manager = get_global_session_manager()
-        session = session_manager.get_live_session(session_id) if session_manager else None
+
+        from sagents.utils.agent_session_helper import get_live_session
+        session = get_live_session(session_id, log_prefix="FibreTools.sys_delegate_task")
         if not session:
             return f"Error: Session not found for session_id: {session_id}"
         session_context = session.session_context

--- a/sagents/skill/skill_tool.py
+++ b/sagents/skill/skill_tool.py
@@ -35,10 +35,8 @@ class SkillTool:
         if not session_id:
             raise ValueError("session_id is required for load_skill")
 
-        # Use local import to avoid circular dependency
-        from sagents.session_runtime import get_global_session_manager
-        session_manager = get_global_session_manager()
-        session = session_manager.get_live_session(session_id) if session_manager else None
+        from sagents.utils.agent_session_helper import get_live_session
+        session = get_live_session(session_id, log_prefix="SkillTool")
         if not session or not session.session_context:
             raise ValueError(f"Invalid session_id: {session_id}")
 

--- a/sagents/tool/impl/compress_history_tool.py
+++ b/sagents/tool/impl/compress_history_tool.py
@@ -37,9 +37,8 @@ class CompressHistoryTool:
 
     def _get_session_context(self, session_id: str):
         """通过 session_id 获取会话上下文"""
-        from sagents.session_runtime import get_global_session_manager
-        session_manager = get_global_session_manager()
-        session = session_manager.get_live_session(session_id) if session_manager else None
+        from sagents.utils.agent_session_helper import get_live_session
+        session = get_live_session(session_id, log_prefix="CompressHistoryTool")
 
         if not session or not session.session_context:
             raise CompressHistoryError(f"无效的 session_id={session_id}")
@@ -76,10 +75,9 @@ class CompressHistoryTool:
 
         使用当前会话的模型配置
         """
-        from sagents.session_runtime import get_global_session_manager
+        from sagents.utils.agent_session_helper import get_live_session
 
-        session_manager = get_global_session_manager()
-        session = session_manager.get_live_session(session_id) if session_manager else None
+        session = get_live_session(session_id, log_prefix="CompressHistoryTool")
 
         if not session:
             raise CompressHistoryError(f"无法获取会话: {session_id}")

--- a/sagents/tool/impl/execute_command_tool.py
+++ b/sagents/tool/impl/execute_command_tool.py
@@ -9,6 +9,7 @@ from typing import Dict, Any, Optional
 from ..tool_base import tool
 from sagents.utils.logger import logger
 from sagents.utils.sandbox._stdout_echo import echo_header, echo_footer
+from sagents.utils.agent_session_helper import get_session_sandbox as _get_session_sandbox_util
 
 
 class SecurityManager:
@@ -44,18 +45,10 @@ class ExecuteCommandTool:
         self.security_manager = SecurityManager()
 
     def _get_sandbox(self, session_id: str):
-        """通过 session_id 获取沙箱"""
-        from sagents.session_runtime import get_global_session_manager
-        session_manager = get_global_session_manager()
-        session = session_manager.get_live_session(session_id) if session_manager else None
-        if not session or not session.session_context:
-            raise ValueError(f"ExecuteCommandTool: Invalid session_id={session_id}")
-
-        sandbox = session.session_context.sandbox
-        if not sandbox:
-            raise ValueError(f"ExecuteCommandTool: No sandbox available for session_id={session_id}")
-
-        return sandbox
+        """通过 session_id 获取沙箱。详见
+        ``sagents.utils.agent_session_helper.get_session_sandbox``。
+        """
+        return _get_session_sandbox_util(session_id, log_prefix="ExecuteCommandTool")
 
     @tool(
         description_i18n={

--- a/sagents/tool/impl/file_system_tool.py
+++ b/sagents/tool/impl/file_system_tool.py
@@ -5,6 +5,7 @@ from typing import Dict, Any, Optional, List
 from ..tool_base import tool
 from sagents.utils.file_content_validator import FileContentValidator
 from sagents.utils.logger import logger
+from sagents.utils.agent_session_helper import get_session_sandbox as _get_session_sandbox_util
 
 
 class FileSystemTool:
@@ -155,18 +156,10 @@ class FileSystemTool:
         }
 
     def _get_sandbox(self, session_id: str):
-        """通过 session_id 获取沙箱"""
-        from sagents.session_runtime import get_global_session_manager
-        session_manager = get_global_session_manager()
-        session = session_manager.get_live_session(session_id) if session_manager else None
-        if not session or not session.session_context:
-            raise ValueError(f"FileSystemTool: Invalid session_id={session_id}")
-
-        sandbox = session.session_context.sandbox
-        if not sandbox:
-            raise ValueError(f"FileSystemTool: No sandbox available for session_id={session_id}")
-
-        return sandbox
+        """通过 session_id 获取沙箱。详见
+        ``sagents.utils.agent_session_helper.get_session_sandbox``。
+        """
+        return _get_session_sandbox_util(session_id, log_prefix="FileSystemTool")
 
     @tool(
         description_i18n={

--- a/sagents/tool/impl/image_understanding_tool.py
+++ b/sagents/tool/impl/image_understanding_tool.py
@@ -13,6 +13,8 @@ import httpx
 
 from ..tool_base import tool
 from sagents.utils.logger import logger
+from sagents.utils.multimodal_image import get_mime_type as _get_mime_type_util
+from sagents.utils.agent_session_helper import get_session_sandbox as _get_session_sandbox_util
 
 # 尝试导入 PIL，如果不可用则给出警告
 try:
@@ -35,30 +37,20 @@ class ImageUnderstandingTool:
         self.supported_formats = {'.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp'}
 
     def _get_sandbox(self, session_id: str):
-        """通过 session_id 获取沙箱"""
-        from sagents.session_runtime import get_global_session_manager
-        session_manager = get_global_session_manager()
-        session = session_manager.get_live_session(session_id) if session_manager else None
-        if not session or not session.session_context:
-            raise ImageUnderstandingError(f"Invalid session_id={session_id}")
-
-        sandbox = session.session_context.sandbox
-        if not sandbox:
-            raise ImageUnderstandingError(f"No sandbox available for session_id={session_id}")
-
-        return sandbox
+        """通过 session_id 获取沙箱。详见
+        ``sagents.utils.agent_session_helper.get_session_sandbox``。
+        """
+        return _get_session_sandbox_util(
+            session_id,
+            log_prefix="ImageUnderstandingTool",
+            error_cls=ImageUnderstandingError,
+        )
 
     def _get_mime_type(self, file_extension: str) -> str:
-        """根据文件扩展名获取 MIME 类型"""
-        mime_types = {
-            '.jpg': 'image/jpeg',
-            '.jpeg': 'image/jpeg',
-            '.png': 'image/png',
-            '.gif': 'image/gif',
-            '.webp': 'image/webp',
-            '.bmp': 'image/bmp',
-        }
-        return mime_types.get(file_extension.lower(), 'image/jpeg')
+        """根据文件扩展名获取 MIME 类型。详见
+        ``sagents.utils.multimodal_image.get_mime_type``。
+        """
+        return _get_mime_type_util(file_extension.lower())
 
     async def _read_image_base64_from_sandbox(self, sandbox, image_path: str) -> str:
         """

--- a/sagents/tool/impl/memory_tool.py
+++ b/sagents/tool/impl/memory_tool.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Dict, Any, Optional, List
 from ..tool_base import tool
 from sagents.utils.logger import logger
+from sagents.utils.agent_session_helper import get_session_sandbox as _get_session_sandbox_util
 
 
 @dataclass
@@ -231,30 +232,21 @@ class MemoryTool:
         self.session_history_retriever = SessionHistoryRetriever(self)
 
     def _get_sandbox(self, session_id: str):
-        """通过 session_id 获取沙箱"""
-        from sagents.session_runtime import get_global_session_manager
-        session_manager = get_global_session_manager()
-        session = session_manager.get_live_session(session_id) if session_manager else None
-        if not session or not session.session_context:
-            raise ValueError(f"MemoryTool: Invalid session_id={session_id}")
-
-        sandbox = session.session_context.sandbox
-        if not sandbox:
-            raise ValueError(f"MemoryTool: No sandbox available for session_id={session_id}")
-
-        return sandbox
+        """通过 session_id 获取沙箱。详见
+        ``sagents.utils.agent_session_helper.get_session_sandbox``。
+        """
+        return _get_session_sandbox_util(session_id, log_prefix="MemoryTool")
 
     def _get_workspace_path(self, session_id: str) -> Optional[str]:
         """Get workspace virtual path from session"""
         try:
-            from sagents.session_runtime import get_global_session_manager
-            session_manager = get_global_session_manager()
-            session = session_manager.get_live_session(session_id) if session_manager else None
-            
+            from sagents.utils.agent_session_helper import get_live_session
+            session = get_live_session(session_id, log_prefix="MemoryTool")
+
             if not session:
                 logger.warning(f"MemoryTool: Session not found: {session_id}")
                 return None
-            
+
             session_context = session.session_context
             
             # Get sandbox_agent_workspace path
@@ -271,14 +263,13 @@ class MemoryTool:
     def _get_agent_id(self, session_id: str) -> Optional[str]:
         """Get agent_id from session"""
         try:
-            from sagents.session_runtime import get_global_session_manager
-            session_manager = get_global_session_manager()
-            session = session_manager.get_live_session(session_id) if session_manager else None
-            
+            from sagents.utils.agent_session_helper import get_live_session
+            session = get_live_session(session_id, log_prefix="MemoryTool")
+
             if not session:
                 logger.warning(f"MemoryTool: Session not found: {session_id}")
                 return None
-            
+
             session_context = session.session_context
             
             # Get agent_id from session_context
@@ -396,10 +387,9 @@ class MemoryTool:
     async def _search_file_memory(self, query: str, top_k: int, session_id: str) -> List[Dict[str, Any]]:
         """Search file memory using the scoped file-memory index through sandbox."""
         try:
-            from sagents.session_runtime import get_global_session_manager
+            from sagents.utils.agent_session_helper import get_live_session
 
-            session_manager = get_global_session_manager()
-            session = session_manager.get_live_session(session_id) if session_manager else None
+            session = get_live_session(session_id, log_prefix="MemoryTool")
             if not session or not session.session_context:
                 logger.warning(f"MemoryTool: Session not found for file memory search: {session_id}")
                 return []
@@ -417,11 +407,10 @@ class MemoryTool:
         流程：准备历史上下文 -> 使用 session_memory_manager 检索 -> 返回结果
         """
         try:
-            from sagents.session_runtime import get_global_session_manager
-            
-            session_manager = get_global_session_manager()
-            session = session_manager.get_live_session(session_id) if session_manager else None
-            
+            from sagents.utils.agent_session_helper import get_live_session
+
+            session = get_live_session(session_id, log_prefix="MemoryTool")
+
             if not session:
                 logger.warning(f"MemoryTool: Session not found: {session_id}")
                 return []

--- a/sagents/tool/impl/todo_tool.py
+++ b/sagents/tool/impl/todo_tool.py
@@ -15,11 +15,10 @@ class ToDoTool:
         if not session_id:
             return None
         try:
-            from sagents.session_runtime import get_global_session_manager
-            session_manager = get_global_session_manager()
-            session = session_manager.get_live_session(session_id) if session_manager else None
-            if session:
-                return session.session_context
+            from sagents.utils.agent_session_helper import get_live_session_context
+            ctx = get_live_session_context(session_id, log_prefix="ToDoTool")
+            if ctx:
+                return ctx
         except Exception as e:
             logger.warning(f"通过 session_id 获取 session_context 失败: {e}")
         return None

--- a/sagents/tool/impl/web_fetcher_tool.py
+++ b/sagents/tool/impl/web_fetcher_tool.py
@@ -182,11 +182,10 @@ class WebFetcherTool:
         if not session_id:
             return None
         try:
-            from sagents.session_runtime import get_global_session_manager
-            session_manager = get_global_session_manager()
-            session = session_manager.get_live_session(session_id) if session_manager else None
-            if session:
-                return session.session_context
+            from sagents.utils.agent_session_helper import get_live_session_context
+            ctx = get_live_session_context(session_id, log_prefix="WebFetcherTool")
+            if ctx:
+                return ctx
         except Exception as e:
             logger.warning(f"通过 session_id 获取 session_context 失败: {e}")
         return None

--- a/sagents/utils/agent_session_helper.py
+++ b/sagents/utils/agent_session_helper.py
@@ -1,0 +1,106 @@
+"""
+Agent 与全局 session 注册表交互的统一入口，避免在每个 Agent 中重复编写。
+
+- ``get_live_session(session_id)``：从全局 session manager 拿到 live session；
+- ``get_live_session_context(session_id)``：直接拿对应的 SessionContext；
+- ``should_abort_due_to_session(session_context, ...)``：聚合"会话中断/出错/已完成"以及
+  父会话状态的判断，命中即返回 True，调用方应直接 return。
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from sagents.context.session_context import SessionContext, SessionStatus
+from sagents.utils.logger import logger
+
+
+def get_live_session(session_id: Optional[str], log_prefix: str = "AgentBase") -> Optional[Any]:
+    """根据 session_id 获取 live session；任何异常都吞掉返回 None。"""
+    if not session_id:
+        return None
+    try:
+        # 延迟 import 避免循环依赖
+        from sagents.session_runtime import get_global_session_manager
+
+        session_manager = get_global_session_manager()
+        if not session_manager:
+            return None
+        return session_manager.get_live_session(session_id)
+    except Exception as exc:
+        logger.debug(f"{log_prefix}: 获取 live session 失败, session_id={session_id}: {exc}")
+        return None
+
+
+def get_live_session_context(
+    session_id: Optional[str], log_prefix: str = "AgentBase"
+) -> Optional[SessionContext]:
+    session = get_live_session(session_id, log_prefix=log_prefix)
+    return session.session_context if session else None
+
+
+def get_session_sandbox(
+    session_id: str,
+    *,
+    log_prefix: str = "Tool",
+    error_cls: type = ValueError,
+) -> Any:
+    """从指定 session 取出 sandbox，缺失或无效时按 ``error_cls`` 抛错。
+
+    被多个 tool 共用，避免每个工具都重写一遍
+    "拿 session manager → 拿 session → 校验 session_context → 校验 sandbox" 的样板代码。
+
+    Args:
+        session_id: 会话 ID。
+        log_prefix: 错误信息前缀（一般传工具名，如 ``"FileSystemTool"``）。
+        error_cls: 抛出的异常类型，默认 ``ValueError``；调用方有自定义异常的可传入。
+    """
+    session = get_live_session(session_id, log_prefix=log_prefix)
+    if not session or not getattr(session, 'session_context', None):
+        raise error_cls(f"{log_prefix}: Invalid session_id={session_id}")
+
+    sandbox = session.session_context.sandbox
+    if not sandbox:
+        raise error_cls(f"{log_prefix}: No sandbox available for session_id={session_id}")
+    return sandbox
+
+
+def should_abort_due_to_session(
+    session_context: SessionContext,
+    log_prefix: str = "Agent",
+) -> bool:
+    """检查会话与父会话状态，命中则应停止执行。
+
+    - session_context.session_id 已被中断/出错/已完成 → True；
+    - 父会话状态非运行中 → 同时把当前会话标为 INTERRUPTED 并返回 True。
+    """
+    session_id = session_context.session_id
+    session = get_live_session(session_id, log_prefix=log_prefix)
+    if session_id and session is None:
+        logger.info(f"{log_prefix}: 跳过执行，session上下文不存在或已中断")
+        return True
+
+    if session and session.get_status() in [
+        SessionStatus.INTERRUPTED,
+        SessionStatus.ERROR,
+        SessionStatus.COMPLETED,
+    ]:
+        logger.info(f"{log_prefix}: 跳过执行，session状态为{session.get_status().value}")
+        return True
+
+    parent_session_id = getattr(session_context, 'parent_session_id', None)
+    if parent_session_id:
+        parent_session = get_live_session(parent_session_id, log_prefix=log_prefix)
+        if parent_session and parent_session.get_status() in [
+            SessionStatus.INTERRUPTED,
+            SessionStatus.ERROR,
+            SessionStatus.COMPLETED,
+        ]:
+            logger.info(
+                f"{log_prefix}: 跳过执行，父会话 {parent_session_id} 状态为{parent_session.get_status().value}"
+            )
+            if session is None:
+                return True
+            session.set_status(SessionStatus.INTERRUPTED, cascade=False)
+            return True
+    return False

--- a/sagents/utils/content_saver.py
+++ b/sagents/utils/content_saver.py
@@ -18,10 +18,8 @@ def save_agent_response_content(content: str, session_id: str):
         return
 
     try:
-        # Import inside function to avoid circular import
-        from sagents.session_runtime import get_global_session_manager
-        session_manager = get_global_session_manager()
-        session = session_manager.get_live_session(session_id) if session_manager else None
+        from sagents.utils.agent_session_helper import get_live_session
+        session = get_live_session(session_id, log_prefix="ContentSaver")
         if not session or not session.session_context:
             logger.error(f"SaveContent: Session {session_id} not found or has no context")
             return

--- a/sagents/utils/message_sanitizer.py
+++ b/sagents/utils/message_sanitizer.py
@@ -1,0 +1,50 @@
+"""
+LLM 请求前的消息清洗工具，纯函数无状态。
+
+- ``remove_orphan_tool_calls``：去掉 tool_call_id 没有匹配 tool 消息回复的 assistant tool_calls 消息；
+- ``strip_content_when_tool_calls``：当 assistant 消息带有 tool_calls 时，去掉 content 字段。
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from sagents.context.messages.message import MessageRole
+
+
+def _get_tool_call_id(tool_call: Any) -> Any:
+    """兼容 ChoiceDeltaToolCall 对象与字典两种形式取出 id。"""
+    if hasattr(tool_call, 'id'):
+        return tool_call.id
+    if isinstance(tool_call, dict):
+        return tool_call.get('id')
+    return None
+
+
+def remove_orphan_tool_calls(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """移除 assistant 消息中的 tool_calls，但其后续没有对应 tool_call_id 的 tool 消息时丢弃整条。
+
+    保持原顺序与对象引用。
+    """
+    matched_tool_call_ids = [
+        msg['tool_call_id']
+        for msg in messages
+        if msg.get('role') == MessageRole.TOOL.value and 'tool_call_id' in msg
+    ]
+
+    new_messages: List[Dict[str, Any]] = []
+    for msg in messages:
+        if msg.get('role') == MessageRole.ASSISTANT.value and 'tool_calls' in msg:
+            tool_calls = msg['tool_calls'] or []
+            if any(_get_tool_call_id(tc) not in matched_tool_call_ids for tc in tool_calls):
+                continue
+        new_messages.append(msg)
+    return new_messages
+
+
+def strip_content_when_tool_calls(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """如果 assistant 消息包含 tool_calls，则就地移除 content 字段。返回同一个列表。"""
+    for msg in messages:
+        if msg.get('role') == MessageRole.ASSISTANT.value and msg.get('tool_calls'):
+            msg.pop('content', None)
+    return messages

--- a/sagents/utils/multimodal_image.py
+++ b/sagents/utils/multimodal_image.py
@@ -1,0 +1,193 @@
+"""
+多模态图片处理工具：将消息 content 中的本地/远端 image_url 统一压缩并转 base64。
+
+从 AgentBase 抽取，便于复用与单测。所有函数无状态，依赖只有 PIL 与项目内 logger。
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+from pathlib import Path
+from typing import Any, Dict, Optional
+from urllib.parse import unquote, urlparse
+
+from PIL import Image
+
+from sagents.utils.logger import logger
+
+
+_MIME_TYPES: Dict[str, str] = {
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.png': 'image/png',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp',
+    '.bmp': 'image/bmp',
+    '.svg': 'image/svg+xml',
+}
+
+# 压缩到的最大边长（保持比例）
+_MAX_IMAGE_EDGE = 512
+# JPEG 质量
+_JPEG_QUALITY = 85
+
+
+def get_mime_type(file_extension: str) -> str:
+    """根据文件扩展名获取 MIME 类型，未知类型回落到 image/jpeg。"""
+    return _MIME_TYPES.get(file_extension, 'image/jpeg')
+
+
+def resolve_local_sage_url(url: str) -> Optional[str]:
+    """把桌面端 sidecar 的本地 sage 文件 URL 反解为本地文件路径。
+
+    desktop 端图片 URL 形如 ``http://127.0.0.1:<port>/api/oss/file/<agent_id>/<filename>``，
+    远程 LLM 访问不到 localhost，因此映射回 ``~/.sage/agents/<agent_id>/upload_files/<filename>``，
+    交由调用方走"本地图片 → base64"分支。
+    若不是本地 sage 文件 URL，返回 None。
+    """
+    try:
+        parsed = urlparse(url)
+        if parsed.hostname not in ("127.0.0.1", "localhost", "0.0.0.0"):
+            return None
+
+        path = unquote(parsed.path or "")
+        prefix = "/api/oss/file/"
+        if not path.startswith(prefix):
+            return None
+        rest = path[len(prefix):]
+        parts = rest.split("/", 1)
+        if len(parts) != 2:
+            return None
+        agent_id, filename = parts[0], parts[1]
+        if not agent_id or not filename or "/" in filename or "\\" in filename:
+            return None
+
+        user_home = Path.home()
+        if agent_id == "_default":
+            base_dir = user_home / ".sage" / "files"
+        else:
+            base_dir = user_home / ".sage" / "agents" / agent_id / "upload_files"
+        file_path = (base_dir / filename).resolve()
+        try:
+            file_path.relative_to(base_dir.resolve())
+        except ValueError:
+            return None
+        if not file_path.exists() or not file_path.is_file():
+            return None
+        return str(file_path)
+    except Exception as exc:
+        logger.warning(f"Failed to resolve local sage url: {url}, error: {exc}")
+        return None
+
+
+def _compress_image_to_jpeg_bytes(img: Image.Image) -> bytes:
+    """RGB 化、缩放至最大边长、保存为 JPEG bytes。"""
+    if img.mode in ('RGBA', 'P'):
+        img = img.convert('RGB')
+    img.thumbnail((_MAX_IMAGE_EDGE, _MAX_IMAGE_EDGE), Image.Resampling.LANCZOS)
+    output = io.BytesIO()
+    img.save(output, format='JPEG', quality=_JPEG_QUALITY)
+    return output.getvalue()
+
+
+def _compress_base64_data_url(data_url: str) -> Optional[str]:
+    """对已是 base64 的 data URL 解码、压缩、再编码，失败返回 None。"""
+    try:
+        _, base64_str = data_url.split(',', 1)
+        raw = base64.b64decode(base64_str)
+        with Image.open(io.BytesIO(raw)) as img:
+            compressed = _compress_image_to_jpeg_bytes(img)
+        encoded = base64.b64encode(compressed).decode('utf-8')
+        logger.debug(f"Compressed base64 image from {len(raw)} to {len(compressed)} bytes")
+        return f"data:image/jpeg;base64,{encoded}"
+    except Exception as exc:
+        logger.error(f"Failed to compress base64 image: {exc}")
+        return None
+
+
+def _file_to_base64_data_url(file_path: Path) -> Optional[str]:
+    """把本地图片文件压缩并编码为 data URL。"""
+    try:
+        with Image.open(file_path) as img:
+            compressed = _compress_image_to_jpeg_bytes(img)
+        encoded = base64.b64encode(compressed).decode('utf-8')
+        logger.debug(
+            f"Converted and compressed local image to base64: {file_path}, size: {len(compressed)} bytes"
+        )
+        return f"data:image/jpeg;base64,{encoded}"
+    except Exception as exc:
+        logger.error(f"Failed to convert image to base64: {file_path}, error: {exc}")
+        return None
+
+
+async def process_multimodal_content(msg: Dict[str, Any]) -> Dict[str, Any]:
+    """处理多模态消息内容，将本地图片路径转换为 base64，远程 URL 保持不变。
+
+    - ``data:image/...`` 已是 base64 → 解码后压缩重编码；
+    - ``file://`` 与裸路径 → 读本地文件压缩后编码；
+    - ``http(s)://127.0.0.1...`` 桌面端 sidecar URL → 反解为本地路径再走本地分支；
+    - 其他 ``http(s)://`` → 视为远端，原样保留。
+
+    无 list content 的消息原样返回。
+    """
+    content = msg.get('content')
+    if not isinstance(content, list):
+        return msg
+
+    new_content = []
+    for item in content:
+        if not isinstance(item, dict):
+            new_content.append(item)
+            continue
+
+        item_type = item.get('type')
+        if item_type == 'text':
+            new_content.append(item)
+            continue
+        if item_type != 'image_url':
+            new_content.append(item)
+            continue
+
+        image_url_data = item.get('image_url', {})
+        url = image_url_data.get('url', '') if isinstance(image_url_data, dict) else str(image_url_data)
+        if not url:
+            new_content.append(item)
+            continue
+
+        # 已是 base64 data URL：解码-压缩-编码
+        if url.startswith('data:image/'):
+            compressed = _compress_base64_data_url(url)
+            if compressed is None:
+                new_content.append(item)
+            else:
+                new_content.append({'type': 'image_url', 'image_url': {'url': compressed}})
+            continue
+
+        # 解析为本地路径
+        if url.startswith('file://'):
+            file_path_str = url[7:]
+        elif url.startswith('http://') or url.startswith('https://'):
+            local_path = resolve_local_sage_url(url)
+            if local_path is None:
+                # 真正的远端 URL 原样保留
+                new_content.append(item)
+                continue
+            file_path_str = local_path
+        else:
+            file_path_str = url
+
+        path_obj = Path(file_path_str)
+        if not path_obj.exists():
+            logger.warning(f"Image file not found: {file_path_str}")
+            new_content.append(item)
+            continue
+
+        data_url = _file_to_base64_data_url(path_obj)
+        if data_url is None:
+            new_content.append(item)
+        else:
+            new_content.append({'type': 'image_url', 'image_url': {'url': data_url}})
+
+    msg['content'] = new_content
+    return msg

--- a/sagents/utils/stream_merger.py
+++ b/sagents/utils/stream_merger.py
@@ -1,0 +1,135 @@
+"""
+将 OpenAI ChatCompletionChunk 流合并为完整的 ChatCompletion 对象。
+
+从 AgentBase 抽取，便于复用与单测。
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from openai.types.chat import (
+    ChatCompletion,
+    ChatCompletionMessage,
+    ChatCompletionMessageToolCall,
+)
+from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_message_tool_call import Function
+from openai.types.completion_usage import (
+    CompletionTokensDetails,
+    CompletionUsage,
+    PromptTokensDetails,
+)
+
+
+def merge_chat_completion_chunks(chunks: Iterable) -> ChatCompletion:
+    """将流式的 ChatCompletionChunk 序列合并为一个非流式 ChatCompletion。
+
+    - 串接所有 ``delta.content`` 为最终 message 内容；
+    - 按 ``tool_call.index`` 聚合 tool_calls 名称与参数；
+    - 取最后一个携带 ``usage`` 的 chunk 作为 usage（含 prompt/completion 详情）；
+    - 缺失字段以稳健默认值兜底，保证产出可被下游消费。
+    """
+    id_ = model_ = created_ = None
+    content = ""
+    tool_calls: dict[int, dict] = {}
+    finish_reason = None
+    usage = None
+
+    for chk in chunks:
+        if id_ is None:
+            id_, model_, created_ = chk.id, chk.model, chk.created
+
+        if chk.usage:
+            prompt_tokens_details = None
+            if chk.usage.prompt_tokens_details:
+                prompt_tokens_details = PromptTokensDetails(
+                    cached_tokens=chk.usage.prompt_tokens_details.cached_tokens,
+                    audio_tokens=chk.usage.prompt_tokens_details.audio_tokens,
+                )
+
+            completion_tokens_details = None
+            if chk.usage.completion_tokens_details:
+                completion_tokens_details = CompletionTokensDetails(
+                    reasoning_tokens=chk.usage.completion_tokens_details.reasoning_tokens,
+                    audio_tokens=chk.usage.completion_tokens_details.audio_tokens,
+                    accepted_prediction_tokens=chk.usage.completion_tokens_details.accepted_prediction_tokens,
+                    rejected_prediction_tokens=chk.usage.completion_tokens_details.rejected_prediction_tokens,
+                )
+
+            usage = CompletionUsage(
+                prompt_tokens=chk.usage.prompt_tokens,
+                completion_tokens=chk.usage.completion_tokens,
+                total_tokens=chk.usage.total_tokens,
+                prompt_tokens_details=prompt_tokens_details,
+                completion_tokens_details=completion_tokens_details,
+            )
+
+        if not chk.choices:
+            continue
+
+        delta = chk.choices[0].delta
+        finish_reason = chk.choices[0].finish_reason
+
+        if delta.content:
+            content += delta.content
+
+        for tc in delta.tool_calls or []:
+            idx = tc.index
+            if idx is None:
+                continue
+            if idx not in tool_calls:
+                tool_calls[idx] = {
+                    "id": tc.id or "",
+                    "type": tc.type or "function",
+                    "function": {"name": "", "arguments": ""},
+                }
+            entry = tool_calls[idx]
+            if tc.id and not entry["id"]:
+                entry["id"] = tc.id
+            if tc.function.name and not entry["function"]["name"]:
+                entry["function"]["name"] = tc.function.name
+            if tc.function.arguments:
+                entry["function"]["arguments"] += tc.function.arguments
+
+    if finish_reason is None:
+        finish_reason = "stop"
+    if id_ is None:
+        id_ = "stream-merge-empty"
+    if created_ is None:
+        created_ = 0
+    if model_ is None:
+        model_ = "unknown"
+
+    return ChatCompletion(
+        id=id_,
+        object="chat.completion",
+        created=created_,
+        model=model_,
+        choices=[
+            Choice(
+                index=0,
+                message=ChatCompletionMessage(
+                    role="assistant",
+                    content=content or None,
+                    tool_calls=(
+                        [
+                            ChatCompletionMessageToolCall(
+                                id=tc["id"],
+                                type="function",
+                                function=Function(
+                                    name=tc["function"]["name"],
+                                    arguments=tc["function"]["arguments"],
+                                ),
+                            )
+                            for tc in tool_calls.values()
+                        ]
+                        if tool_calls
+                        else None
+                    ),
+                ),
+                finish_reason=finish_reason,
+            )
+        ],
+        usage=usage,
+    )

--- a/sagents/utils/stream_tag_parser.py
+++ b/sagents/utils/stream_tag_parser.py
@@ -1,0 +1,61 @@
+"""
+针对流式 LLM 输出的简单 XML 风格 tag 判别工具。
+
+仅用于 ``query_suggest_agent`` 这类需要在流式过程中区分"当前 token 属于哪个 tag 内"的场景。
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+
+def judge_delta_content_type(
+    delta_content: str,
+    all_tokens_str: str,
+    tag_type: Optional[List[str]] = None,
+) -> str:
+    """根据已累积的 token 串与新 delta，判断当前位置位于哪个 tag 内部。
+
+    返回值：
+    - ``"tag"``：当前刚好在标签边界上（开始/结束 tag 本身或 tag 之外）；
+    - ``"unknown"``：紧跟在某个开始 tag 后，但当前 buffer 末尾正在拼接潜在的结束 tag 前缀；
+    - 标签名（去掉尖括号）：当前位置位于该开始 tag 与对应结束 tag 之间。
+    """
+    if tag_type is None:
+        tag_type = []
+
+    start_tag = [f"<{tag}>" for tag in tag_type]
+    end_tag = [f"</{tag}>" for tag in tag_type]
+
+    # 结束标签的所有可能前缀（用于探测半截输出的结束 tag）
+    end_tag_process_list: List[str] = []
+    for tag in end_tag:
+        for i in range(len(tag)):
+            end_tag_process_list.append(tag[:i + 1])
+
+    last_tag = None
+    last_tag_index: Optional[int] = None
+
+    all_tokens_str = (all_tokens_str + delta_content).strip()
+
+    for tag in start_tag + end_tag:
+        index = all_tokens_str.rfind(tag)
+        if index != -1:
+            if last_tag_index is None or index > last_tag_index:
+                last_tag = tag
+                last_tag_index = index
+
+    if last_tag is None or last_tag_index is None:
+        return "tag"
+
+    if last_tag in start_tag:
+        if last_tag_index + len(last_tag) == len(all_tokens_str):
+            return 'tag'
+        for end_tag_process in end_tag_process_list:
+            if all_tokens_str.endswith(end_tag_process):
+                return 'unknown'
+        return last_tag.replace("<", "").replace(">", "")
+    elif last_tag in end_tag:
+        return 'tag'
+
+    return "tag"


### PR DESCRIPTION
## Summary
- Split `agent_base.py` (1673 → 1291 lines): extracted multimodal image handling, message sanitizer, stream merger, stream tag parser, and session helper into `sagents/utils/{multimodal_image,message_sanitizer,stream_merger,stream_tag_parser,agent_session_helper}.py`. Base class keeps thin wrappers so subclasses are unaffected.
- Added `agent_session_helper.get_session_sandbox()`; collapsed `_get_sandbox` in `file_system_tool` / `memory_tool` / `execute_command_tool` / `image_understanding_tool` to single-line calls.
- Replaced ~10 `get_global_session_manager()+get_live_session()` boilerplate sites in `compress_history_tool`, `web_fetcher_tool`, `todo_tool`, `skill_tool`, `content_saver`, `fibre/tools.py`, and `memory_tool` with the shared `get_live_session(_context)` helpers.
- `image_understanding_tool._get_mime_type` now reuses `multimodal_image.get_mime_type`.
- Plus prior chat UI polish (skill picker / message input / user bubble) and architecture docs split into per-area pages (zh + en).

## Test plan
- [x] `python3 -m py_compile` for all modified files
- [x] ReadLints clean on touched files
- [x] `rg` confirms remaining `get_live_session` boilerplate only lives in `logger.py` (kept to avoid circular import)
- [ ] Smoke-run an agent flow end-to-end after merge

Made with [Cursor](https://cursor.com)