### PR TITLE
docs(architecture): fix broken YAML front matter for nav nesting

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -1,4 +1,6 @@
 
+2026-04-21 00:02 修复架构子页 YAML front matter 被破坏导致侧边栏丢失「架构」父级、子页全部提升为顶级项的问题：10 个文件（zh+en 各 5 份：ARCHITECTURE / ARCHITECTURE_SAGENTS_OVERVIEW / AGENT_FLOW / SESSION_CONTEXT / TOOL_SKILL / SANDBOX_OBS 与 ARCHITECTURE_APP_DESKTOP）第二行被换成了「## layout: default」且缺失结束的「---」，重建为标准 Jekyll front matter，恢复 has_children/parent 层级。
+
 2026-04-20 23:51 复用样板：agent_session_helper 增 get_session_sandbox()；file_system/memory/execute_command/image_understanding 4 个 tool 的 _get_sandbox 改为单行调用；compress_history、web_fetcher、todo、skill、content_saver、fibre/tools 共 8 处 get_global_session_manager+get_live_session 模板替换为 get_live_session/get_live_session_context helper；image_understanding._get_mime_type 改用 multimodal_image.get_mime_type。
 
 2026-04-20 架构文档拆分为多二级章节（zh+en）：父页 ARCHITECTURE 重写为流程图导览，新增 app/server、app/desktop、app/others 三篇，sagents 拆为 overview / agent-flow / session-context / tool-skill / sandbox-obs 五篇；以 mermaid 图为主，仅保留二开示例代码；修复带 () 与 / 的 subgraph 标题语法；docs/README 索引同步更新。

--- a/docs/en/ARCHITECTURE.md
+++ b/docs/en/ARCHITECTURE.md
@@ -1,12 +1,12 @@
 ---
-
-## layout: default
+layout: default
 title: Architecture
 nav_order: 4
 has_children: true
 description: "Repository and subsystem architecture overview, with sub-pages for apps and the sagents core runtime"
 lang: en
 ref: architecture
+---
 
 {% include lang_switcher.html %}
 

--- a/docs/en/ARCHITECTURE_APP_DESKTOP.md
+++ b/docs/en/ARCHITECTURE_APP_DESKTOP.md
@@ -1,13 +1,12 @@
 ---
-
-## layout: default
-
+layout: default
 title: Desktop App Architecture
 parent: Architecture
 nav_order: 2
 description: "app/desktop/ desktop architecture: local backend, UI, Tauri shell and how it consumes sagents"
 lang: en
 ref: architecture-app-desktop
+---
 
 {% include lang_switcher.html %}
 

--- a/docs/en/ARCHITECTURE_SAGENTS_AGENT_FLOW.md
+++ b/docs/en/ARCHITECTURE_SAGENTS_AGENT_FLOW.md
@@ -1,12 +1,12 @@
 ---
-
-## layout: default
+layout: default
 title: Agent & Flow Orchestration
 parent: Architecture
 nav_order: 5
 description: "AgentBase, the specialized agents, AgentFlow / FlowExecutor and the three agent_modes"
 lang: en
 ref: architecture-sagents-agent-flow
+---
 
 {% include lang_switcher.html %}
 

--- a/docs/en/ARCHITECTURE_SAGENTS_OVERVIEW.md
+++ b/docs/en/ARCHITECTURE_SAGENTS_OVERVIEW.md
@@ -1,12 +1,12 @@
 ---
-
-## layout: default
+layout: default
 title: sagents Overview
 parent: Architecture
 nav_order: 4
 description: "Layering, module boundaries and the full path of one run_stream call inside sagents/"
 lang: en
 ref: architecture-sagents-overview
+---
 
 {% include lang_switcher.html %}
 

--- a/docs/en/ARCHITECTURE_SAGENTS_SESSION_CONTEXT.md
+++ b/docs/en/ARCHITECTURE_SAGENTS_SESSION_CONTEXT.md
@@ -1,12 +1,12 @@
 ---
-
-## layout: default
+layout: default
 title: Session & Context
 parent: Architecture
 nav_order: 6
 description: "Session, SessionContext, message manager, session/user memory and Workflow"
 lang: en
 ref: architecture-sagents-session-context
+---
 
 {% include lang_switcher.html %}
 

--- a/docs/en/ARCHITECTURE_SAGENTS_TOOL_SKILL.md
+++ b/docs/en/ARCHITECTURE_SAGENTS_TOOL_SKILL.md
@@ -1,12 +1,12 @@
 ---
-
-## layout: default
+layout: default
 title: Tool & Skill System
 parent: Architecture
 nav_order: 7
 description: "ToolManager / ToolProxy, built-in tools, MCP proxy, SkillManager / SkillProxy and in-sandbox skills"
 lang: en
 ref: architecture-sagents-tool-skill
+---
 
 {% include lang_switcher.html %}
 

--- a/docs/zh/ARCHITECTURE.md
+++ b/docs/zh/ARCHITECTURE.md
@@ -1,13 +1,12 @@
 ---
-
-## layout: default
-
+layout: default
 title: 架构
 nav_order: 4
 has_children: true
 description: "Sage 仓库与子系统架构总览，含应用与 sagents 核心运行时的二级文档"
 lang: zh
 ref: architecture
+---
 
 {% include lang_switcher.html %}
 

--- a/docs/zh/ARCHITECTURE_SAGENTS_AGENT_FLOW.md
+++ b/docs/zh/ARCHITECTURE_SAGENTS_AGENT_FLOW.md
@@ -1,13 +1,12 @@
 ---
-
-## layout: default
-
+layout: default
 title: 智能体与流程编排
 parent: 架构
 nav_order: 5
 description: "AgentBase、各专用 Agent、AgentFlow / FlowExecutor、三种 agent_mode"
 lang: zh
 ref: architecture-sagents-agent-flow
+---
 
 {% include lang_switcher.html %}
 

--- a/docs/zh/ARCHITECTURE_SAGENTS_OVERVIEW.md
+++ b/docs/zh/ARCHITECTURE_SAGENTS_OVERVIEW.md
@@ -1,13 +1,12 @@
 ---
-
-## layout: default
-
+layout: default
 title: sagents 总览
 parent: 架构
 nav_order: 4
 description: "sagents/ 核心运行时的分层、模块边界与一次 run_stream 的全链路"
 lang: zh
 ref: architecture-sagents-overview
+---
 
 {% include lang_switcher.html %}
 

--- a/docs/zh/ARCHITECTURE_SAGENTS_SANDBOX_OBS.md
+++ b/docs/zh/ARCHITECTURE_SAGENTS_SANDBOX_OBS.md
@@ -1,12 +1,12 @@
 ---
-
-## layout: default
+layout: default
 title: 沙箱 / LLM / 可观测性
 parent: 架构
 nav_order: 8
 description: "Sandbox 抽象（Local / Remote / Passthrough）、LLM 客户端封装与能力探针、ObservabilityManager 与 OpenTelemetry"
 lang: zh
 ref: architecture-sagents-sandbox-obs
+---
 
 {% include lang_switcher.html %}
 


### PR DESCRIPTION
## Summary
- 10 zh/en architecture sub-pages had `## layout: default` instead of `layout: default` and were missing the closing `---`, so Jekyll/just-the-docs lost their `has_children` / `parent` metadata.
- Symptom: Architecture chapter disappeared from the sidebar; child pages (Server / Desktop / Others / sagents Overview / Agent & Flow / Session & Context / Tool & Skill / Sandbox-Obs) were promoted to top-level items, mixed in with Quick Start / Core Concepts / Configuration etc.
- Fix: rebuild the front matter to standard form (`---` … `---`) on all 10 pages so the Architecture parent and its sub-tree render correctly.

## Test plan
- [ ] Build the docs site (Jekyll / GitHub Pages) and verify the sidebar shows `Architecture` as a parent with the 8 sub-pages nested under it (zh + en).

Made with [Cursor](https://cursor.com)