### PR TITLE
fix(docs): restore nested sidebar nav (lang + theme pages.html)

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -1,4 +1,6 @@
 
+2026-04-21 文档站侧边栏真正根因：`docs/_includes/components/sidebar.html` 自定义实现里对 `nav_pages` 单层 for 循环输出链接，未调用主题自带的 `components/nav/pages.html`（parent 分组 + 递归子菜单），故无论 front matter 是否正确，左侧始终为扁平列表；已改为 `where` 过滤语言后 `include components/nav/pages.html`，恢复「架构」下二级菜单。
+
 2026-04-21 00:02 修复架构子页 YAML front matter 被破坏导致侧边栏丢失「架构」父级、子页全部提升为顶级项的问题：10 个文件（zh+en 各 5 份：ARCHITECTURE / ARCHITECTURE_SAGENTS_OVERVIEW / AGENT_FLOW / SESSION_CONTEXT / TOOL_SKILL / SANDBOX_OBS 与 ARCHITECTURE_APP_DESKTOP）第二行被换成了「## layout: default」且缺失结束的「---」，重建为标准 Jekyll front matter，恢复 has_children/parent 层级。
 
 2026-04-20 23:51 复用样板：agent_session_helper 增 get_session_sandbox()；file_system/memory/execute_command/image_understanding 4 个 tool 的 _get_sandbox 改为单行调用；compress_history、web_fetcher、todo、skill、content_saver、fibre/tools 共 8 处 get_global_session_manager+get_live_session 模板替换为 get_live_session/get_live_session_context helper；image_understanding._get_mime_type 改用 multimodal_image.get_mime_type。

--- a/docs/_includes/components/sidebar.html
+++ b/docs/_includes/components/sidebar.html
@@ -1,9 +1,12 @@
+{%- comment -%}
+  Sage 多语言：只展示当前语言下的页面，但必须沿用 Just the Docs 的层级导航逻辑
+  （group_by parent + components/nav/pages.html）。切勿对 nav_pages 做单层 for 循环，
+  否则 parent/has_children 全部失效，侧边栏会变成「扁平长列表」。
+{%- endcomment -%}
 {% assign current_lang = page.lang | default: site.lang %}
 {% assign nav_pages = site.html_pages
   | where_exp: "item", "item.nav_exclude != true"
-  | where: "lang", current_lang
-  | sort: "title"
-  | sort: "nav_order" %}
+  | where: "lang", current_lang %}
 
 <header class="side-bar">
   <div class="site-header">
@@ -20,16 +23,7 @@
   </div>
 
   <nav aria-label="Main" id="site-nav" class="site-nav">
-    <ul class="nav-list">
-      {% for nav_page in nav_pages %}
-        {% assign is_active = page.url == nav_page.url %}
-        <li class="nav-list-item{% if is_active %} active{% endif %}">
-          <a href="{{ nav_page.url | relative_url }}" class="nav-list-link{% if is_active %} active{% endif %}">
-            {{ nav_page.title }}
-          </a>
-        </li>
-      {% endfor %}
-    </ul>
+    {% include components/nav/pages.html pages=nav_pages all=false %}
   </nav>
 
   <footer class="site-footer">


### PR DESCRIPTION
## Summary
- Root cause of flat sidebar: custom `docs/_includes/components/sidebar.html` looped all `nav_pages` in one `<ul>` and never called Just the Docs `components/nav/pages.html`, so `parent` / `has_children` were ignored.
- Fix: after filtering `site.html_pages` by `lang`, delegate to `{% include components/nav/pages.html pages=nav_pages all=false %}` so hierarchy and expanders match the theme.

## Test plan
- [ ] `bundle exec jekyll serve` in `docs/` and confirm Architecture (架构) shows nested children and chevron expanders for zh and en.

Made with [Cursor](https://cursor.com)