### PR TITLE
Fix sage upload image flow: local path + base64 fallback

### DIFF
--- a/app/desktop/core/routers/oss.py
+++ b/app/desktop/core/routers/oss.py
@@ -22,11 +22,7 @@ def _resolve_upload_root(agent_id: Optional[str]) -> Path:
 
 
 def _build_public_url(request: Request, agent_id: Optional[str], filename: str) -> str:
-    """构建可被前端 <img src> / agent 后端拉取的 HTTP URL。
-
-    桌面端 sidecar 同时承担"上传/下载文件"的职责，前端拿到 URL 后即可与 web 端
-    完全一致地以 http(s) 形式直接渲染，不再需要 Tauri 的 convertFileSrc/readFile。
-    """
+    """构建可被前端 <img src> / agent 后端拉取的 HTTP URL（保留旧字段，仅作降级展示用）。"""
     base = str(request.base_url).rstrip("/")
     if agent_id:
         return f"{base}/api/oss/file/{agent_id}/{filename}"
@@ -163,10 +159,18 @@ async def upload_file(
             with open(file_path, "wb") as buffer:
                 shutil.copyfileobj(file.file, buffer)
 
-        # 统一返回 HTTP URL：前端 web/desktop 都直接以 <img src> 加载，
-        # agent_base 内部会把 127.0.0.1 的 sage 文件 URL 反解回本地路径再读为 base64。
+        # 桌面端 sidecar 与 agent 跑在同一台机器上，直接把"本地绝对路径"作为 url 返回：
+        # - markdown 引用 / image_url part 都用本地路径，agent 不再需要走 HTTP 抓回来或反解 localhost URL；
+        # - 前端 MarkdownRenderer 已有 `convertFileSrc / data-local-image` 分支，能直接渲染本地路径；
+        # - http_url 字段仍然保留（指向 sidecar 的 GET /api/oss/file/...），便于以后调试 / 在浏览器中打开。
+        local_path = str(file_path.resolve())
         public_url = _build_public_url(request, agent_id, final_filename)
-        payload = {"url": public_url, "filename": final_filename}
+        payload = {
+            "url": local_path,
+            "local_path": local_path,
+            "http_url": public_url,
+            "filename": final_filename,
+        }
         if agent_id:
             payload["agent_id"] = agent_id
         return payload

--- a/app/desktop/ui/src/api/oss.js
+++ b/app/desktop/ui/src/api/oss.js
@@ -5,7 +5,9 @@ import request from '../utils/request.js'
  * 通用文件上传
  * @param {File} file - 要上传的文件
  * @param {string} agentId - 可选的 Agent ID，如果提供，文件将保存到该 Agent 沙箱的 upload_files 文件夹
- * @returns {Promise<string>} - 返回拼接后的公网 URL
+ * @returns {Promise<{url: string, filename: string, local_path?: string, http_url?: string, agent_id?: string}>}
+ *   桌面端 sidecar 直接返回本地绝对路径作为 `url`（同时还有 `local_path`），让 markdown 引用 /
+ *   image_url 都使用本地路径，agent 与前端渲染都不必再绕 http://127.0.0.1。`http_url` 仅作降级展示。
  */
 async function uploadFile(file, agentId = null) {
     const formData = new FormData()
@@ -14,7 +16,7 @@ async function uploadFile(file, agentId = null) {
         formData.append('agent_id', agentId)
     }
     const res = await request.post('/api/oss/upload', formData)
-    return res.url
+    return res
 }
 
 export const ossApi = {

--- a/app/desktop/ui/src/components/chat/ChipInput.vue
+++ b/app/desktop/ui/src/components/chat/ChipInput.vue
@@ -388,6 +388,26 @@ const deleteCharsBeforeCaret = (n) => {
   handleInput()
 }
 
+/**
+ * 上传完成后用真实的服务端文件名刷新 chip：
+ * - 更新 dataset.attName / title / 文本节点，让 readText() 生成的占位符 alt 与 URL 末段一致；
+ * - 同步触发一次 update:modelValue，让父组件持有的 inputValue 跟着变。
+ */
+const updateChipName = (id, newName) => {
+  if (id == null || !newName) return false
+  const root = editorRef.value
+  if (!root) return false
+  const target = root.querySelector(`.chip-input__chip[data-att-id="${CSS.escape(String(id))}"]`)
+  if (!target) return false
+  target.dataset.attName = newName
+  target.setAttribute('title', newName)
+  const nameNode = target.querySelector('.chip-input__chip-name')
+  if (nameNode) nameNode.textContent = newName
+  // 触发一次同步：让 readText() 的输出立即写回 modelValue
+  handleInput()
+  return true
+}
+
 defineExpose({
   focus: focusEditor,
   insertPlaceholder,
@@ -396,7 +416,8 @@ defineExpose({
   getElement: () => editorRef.value,
   getTextBeforeCaret,
   getSkillQuery,
-  deleteCharsBeforeCaret
+  deleteCharsBeforeCaret,
+  updateChipName
 })
 </script>
 

--- a/app/desktop/ui/src/components/chat/MessageInput.vue
+++ b/app/desktop/ui/src/components/chat/MessageInput.vue
@@ -931,10 +931,19 @@ const processFile = async (file) => {
   try {
     // 调用OSS API上传，传递当前选中的 agent_id
     const agentId = props.selectedAgent?.id || props.selectedAgent?.agent_id
-    const url = await ossApi.uploadFile(file, agentId)
+    const result = await ossApi.uploadFile(file, agentId)
+    const url = typeof result === 'string' ? result : (result?.url || '')
+    const serverFilename = (typeof result === 'object' && result?.filename) ? result.filename : ''
 
-    // 更新文件URL
     fileItem.url = url
+    // 后端会追加时间戳 + 把图片压成 jpg，使用服务端文件名让 markdown alt 与真实 URL 文件名保持一致
+    if (serverFilename) {
+      fileItem.name = serverFilename
+      // 同步更新已插入的 chip 显示与 dataset，保证 readText() 输出的占位符 alt 与最终 URL 文件名一致
+      try {
+        editorRef.value?.updateChipName?.(fileItem.id, serverFilename)
+      } catch (_) { /* noop */ }
+    }
     fileItem.uploading = false
   } catch (error) {
 

--- a/app/desktop/ui/src/utils/multimodalContent.js
+++ b/app/desktop/ui/src/utils/multimodalContent.js
@@ -30,6 +30,20 @@ export const buildAttachmentPlaceholder = (file) => {
 /** 转义正则中的特殊字符。 */
 const escapeRegExp = (s) => String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
+/** 从一个完整 URL 中取出最后一段文件名（用作 markdown alt，确保与 URL 末段完全一致）。 */
+const extractUrlTailName = (url) => {
+  if (!url) return ''
+  try {
+    const u = new URL(url, 'http://localhost')
+    const last = decodeURIComponent(u.pathname.split('/').pop() || '')
+    return last || ''
+  } catch {
+    const s = String(url).split('?')[0].split('#')[0]
+    const last = s.split('/').pop() || ''
+    return last
+  }
+}
+
 /**
  * 从输入框文本中移除某个附件的占位符（一并清掉相邻的换行，避免留下空行）。
  */
@@ -98,7 +112,10 @@ export const buildOrderedMultimodalContent = (rawText, files = [], options = {})
     const file = filesById.get(String(id))
     if (file && file.url) {
       usedIds.add(String(id))
-      const cleanName = cleanupAttachmentName(filename || file.name)
+      // 让 markdown alt 与最终 URL 末段保持一致：优先用上传后服务端真实文件名（file.name 已在上传完成时刷新成 filename），
+      // 退化时再用占位符里的旧名字 / 清洗版本，避免后端 LLM 看到 alt 与链接不同导致疑惑。
+      const urlTailName = extractUrlTailName(file.url)
+      const cleanName = urlTailName || file.name || cleanupAttachmentName(filename || '') || '文件'
       const realImage = `![${cleanName}](${file.url})`
       const realLink = `[${cleanName}](${file.url})`
 
@@ -148,7 +165,7 @@ export const buildOrderedMultimodalContent = (rawText, files = [], options = {})
   if (orphans.length > 0) {
     const trailingTextPieces = []
     for (const f of orphans) {
-      const cleanName = cleanupAttachmentName(f.name)
+      const cleanName = extractUrlTailName(f.url) || f.name || cleanupAttachmentName(f.name)
       if (f.type === 'image') {
         if (multimodalEnabled) {
           items.push({ type: 'image_url', image_url: { url: f.url } })

--- a/app/server/web/src/components/chat/ChipInput.vue
+++ b/app/server/web/src/components/chat/ChipInput.vue
@@ -384,6 +384,25 @@ const deleteCharsBeforeCaret = (n) => {
   handleInput()
 }
 
+/**
+ * 上传完成后用真实的服务端文件名刷新 chip：
+ * - 更新 dataset.attName / title / 文本节点，让 readText() 生成的占位符 alt 与 URL 末段一致；
+ * - 同步触发一次 update:modelValue，让父组件持有的 inputValue 跟着变。
+ */
+const updateChipName = (id, newName) => {
+  if (id == null || !newName) return false
+  const root = editorRef.value
+  if (!root) return false
+  const target = root.querySelector(`.chip-input__chip[data-att-id="${CSS.escape(String(id))}"]`)
+  if (!target) return false
+  target.dataset.attName = newName
+  target.setAttribute('title', newName)
+  const nameNode = target.querySelector('.chip-input__chip-name')
+  if (nameNode) nameNode.textContent = newName
+  handleInput()
+  return true
+}
+
 defineExpose({
   focus: focusEditor,
   insertPlaceholder,
@@ -392,7 +411,8 @@ defineExpose({
   getElement: () => editorRef.value,
   getTextBeforeCaret,
   getSkillQuery,
-  deleteCharsBeforeCaret
+  deleteCharsBeforeCaret,
+  updateChipName
 })
 </script>
 

--- a/app/server/web/src/components/chat/MessageInput.vue
+++ b/app/server/web/src/components/chat/MessageInput.vue
@@ -766,7 +766,15 @@ const processFile = async (file) => {
 
   try {
     const response = await ossApi.uploadFile(file)
-    fileItem.url = response.data?.url || response.url || response
+    const payload = response?.data ?? response
+    fileItem.url = payload?.url || (typeof payload === 'string' ? payload : '')
+    const serverFilename = (payload && typeof payload === 'object') ? payload.filename : ''
+    if (serverFilename) {
+      fileItem.name = serverFilename
+      try {
+        editorRef.value?.updateChipName?.(fileItem.id, serverFilename)
+      } catch (_) { /* noop */ }
+    }
     fileItem.uploading = false
   } catch (error) {
     const index = uploadedFiles.value.indexOf(fileItem)

--- a/app/server/web/src/utils/multimodalContent.js
+++ b/app/server/web/src/utils/multimodalContent.js
@@ -30,6 +30,20 @@ export const buildAttachmentPlaceholder = (file) => {
 /** 转义正则中的特殊字符。 */
 const escapeRegExp = (s) => String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
+/** 从一个完整 URL 中取出最后一段文件名（用作 markdown alt，确保与 URL 末段完全一致）。 */
+const extractUrlTailName = (url) => {
+  if (!url) return ''
+  try {
+    const u = new URL(url, 'http://localhost')
+    const last = decodeURIComponent(u.pathname.split('/').pop() || '')
+    return last || ''
+  } catch {
+    const s = String(url).split('?')[0].split('#')[0]
+    const last = s.split('/').pop() || ''
+    return last
+  }
+}
+
 /**
  * 从输入框文本中移除某个附件的占位符（一并清掉相邻的换行，避免留下空行）。
  */
@@ -98,7 +112,10 @@ export const buildOrderedMultimodalContent = (rawText, files = [], options = {})
     const file = filesById.get(String(id))
     if (file && file.url) {
       usedIds.add(String(id))
-      const cleanName = cleanupAttachmentName(filename || file.name)
+      // 让 markdown alt 与最终 URL 末段保持一致：优先用上传后服务端真实文件名（file.name 已在上传完成时刷新成 filename），
+      // 退化时再用占位符里的旧名字 / 清洗版本，避免后端 LLM 看到 alt 与链接不同导致疑惑。
+      const urlTailName = extractUrlTailName(file.url)
+      const cleanName = urlTailName || file.name || cleanupAttachmentName(filename || '') || '文件'
       const realImage = `![${cleanName}](${file.url})`
       const realLink = `[${cleanName}](${file.url})`
 
@@ -148,7 +165,7 @@ export const buildOrderedMultimodalContent = (rawText, files = [], options = {})
   if (orphans.length > 0) {
     const trailingTextPieces = []
     for (const f of orphans) {
-      const cleanName = cleanupAttachmentName(f.name)
+      const cleanName = extractUrlTailName(f.url) || f.name || cleanupAttachmentName(f.name)
       if (f.type === 'image') {
         if (multimodalEnabled) {
           items.push({ type: 'image_url', image_url: { url: f.url } })

--- a/change_log.md
+++ b/change_log.md
@@ -1,7 +1,13 @@
 
+2026-04-21 22:55 桌面端上传图片改回"本地绝对路径"链路：sidecar `POST /api/oss/upload` 现在把 `file_path.resolve()` 直接作为 `url` 返回（保留 `local_path` 同值字段，外加 `http_url` 仅作降级展示）。前端 markdown 引用 / image_url part 都用本地路径，命中 MarkdownRenderer 既有的 `convertFileSrc / data-local-image` 分支，agent 端 `multimodal_image.process_multimodal_content` 直接走"裸路径→base64"分支，不再需要 `resolve_local_sage_url` 反解 localhost URL，也省掉一次 HTTP 抓取，文件类工具可直接消费该路径。22:30 加的 HTTP fallback 保留，给 server-web 那种 HOME 不一致场景兜底。
+
+2026-04-21 22:30 修复 sage 上传图片两个问题：1) 输入框 markdown alt 与最终 URL 文件名不一致（原 png/被压成 jpg + 时间戳后缀）——oss.uploadFile 改返回 {url, filename}，MessageInput/ChipInput 在上传完成后用服务端文件名刷新 chip 与 file.name，buildOrderedMultimodalContent 直接取 URL 末段作为 alt，desktop+server-web 同步；2) image_url 没转 base64 导致 dashscope 报 InvalidParameter——multimodal_image.process_multimodal_content 增加本机地址 HTTP 抓取兜底（httpx 已在 requirements），Path.home 反解失败时再走 GET URL→压缩→data:image/jpeg;base64 分支，加 warning/error 日志便于排查。
+
 2026-04-21 21:30 server 端登录页：当 allow_registration=false 时新增显眼提示——告知当前网页不允许创建新用户，推荐下载桌面版 https://zavixai.com/html/sage.html，或自行从 GitHub 部署 Web 版，并附微信联系方式 cfyz0814 / zhangzheng-thu。新增 zh/en 文案和 2 条 Login 单测，全部通过。
 
 2026-04-21 17:10 限制 Fibre 专属工具仅在 fibre 模式下可选：AgentEdit.vue 增加 isFibreOnlyToolUnavailable，非 fibre 模式下 sys_spawn_agent / sys_delegate_task / sys_finish_task 复选框禁用并打「仅 Fibre 模式」徽章 + 提示；模式切出 fibre 时自动从 availableTools 移除；后端 chat router 新增 _sync_fibre_only_tools 兜底，非 fibre 请求强制剔除这三个工具。
+
+2026-04-21 17:10 更新 docs/zh/DESIGN_AGENT_FLOW_PRODUCTIZATION.md：产品名定为「智能体画布」（内核仍叫 AgentFlow），重写 §9 IA 决策（智能体/智能体画布平级菜单、Router Agent 同列表加 tab、Chat 调用侧统一、旧「工作流」字段改名「任务步骤」），把 §11 替换为不带时间的 21 步递进式开发计划，附录 B 增加 UI 文案强约束表。
 
 2026-04-21 16:30 新增设计文档 docs/zh/DESIGN_AGENT_FLOW_PRODUCTIZATION.md：把 AgentFlow 升级为「真正的 Agent Flow」——所有 AI 节点都是 Agent，引入 Agent 模板体系（business/router 两种内置模板），分支判据收敛到 flow_state.{input,vars,steps} 命名空间（v1 寄存于 audit_status 子树），AgentFlow 改为可保存可重置的 DAG 静态图配置（flow_version.graph_json），含分阶段实施路线、API 草案、改动点速查与待决问题。
 

--- a/sagents/utils/multimodal_image.py
+++ b/sagents/utils/multimodal_image.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import io
 from pathlib import Path
@@ -121,6 +122,59 @@ def _file_to_base64_data_url(file_path: Path) -> Optional[str]:
         return None
 
 
+def _bytes_to_base64_data_url(raw: bytes) -> Optional[str]:
+    """把图片字节流压缩并编码为 data URL（用于 HTTP 抓取的兜底分支）。"""
+    try:
+        with Image.open(io.BytesIO(raw)) as img:
+            compressed = _compress_image_to_jpeg_bytes(img)
+        encoded = base64.b64encode(compressed).decode('utf-8')
+        logger.debug(f"Converted fetched image to base64: size={len(compressed)} bytes")
+        return f"data:image/jpeg;base64,{encoded}"
+    except Exception as exc:
+        logger.error(f"Failed to convert fetched bytes to base64: {exc}")
+        return None
+
+
+async def _fetch_url_to_base64(url: str, timeout: float = 10.0) -> Optional[str]:
+    """对 localhost 类 URL（或其他需要后端就近抓取的 URL）走 HTTP GET 拿字节流再转 base64。
+
+    远程 LLM（dashscope / openai）拉不到 ``http://127.0.0.1:<port>/...`` 这类
+    桌面/服务端本机地址，但 agent 进程自己一般是能访问的。如果通过 ``Path.home()``
+    无法把 URL 反解到本地文件（比如 agent 跑在容器里、HOME 不一致、或文件已被清理），
+    就退一步用 httpx 抓字节流再转成 ``data:image/...;base64`` 给 LLM。
+    """
+    try:
+        import httpx  # 局部导入，避免在不需要这条分支的环境里被强依赖
+    except ImportError:
+        logger.warning("httpx not installed, cannot fetch local image URL via HTTP fallback")
+        return None
+    try:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+            resp = await client.get(url)
+            if resp.status_code != 200:
+                logger.warning(f"HTTP fallback fetch non-200: url={url}, status={resp.status_code}")
+                return None
+            data = resp.content
+            if not data:
+                logger.warning(f"HTTP fallback fetch returned empty body: url={url}")
+                return None
+            return await asyncio.get_event_loop().run_in_executor(
+                None, _bytes_to_base64_data_url, data
+            )
+    except Exception as exc:
+        logger.warning(f"HTTP fallback fetch failed for url={url}, error: {exc}")
+        return None
+
+
+def _is_localhost_url(url: str) -> bool:
+    """简单判断一个 URL 是否指向本机地址（127.0.0.1 / localhost / 0.0.0.0）。"""
+    try:
+        parsed = urlparse(url)
+        return parsed.hostname in ("127.0.0.1", "localhost", "0.0.0.0")
+    except Exception:
+        return False
+
+
 async def process_multimodal_content(msg: Dict[str, Any]) -> Dict[str, Any]:
     """处理多模态消息内容，将本地图片路径转换为 base64，远程 URL 保持不变。
 
@@ -170,6 +224,23 @@ async def process_multimodal_content(msg: Dict[str, Any]) -> Dict[str, Any]:
         elif url.startswith('http://') or url.startswith('https://'):
             local_path = resolve_local_sage_url(url)
             if local_path is None:
+                if _is_localhost_url(url):
+                    # 是本机地址但反解失败（多半是 HOME 不一致 / 跑在容器里 / 自定义沙箱目录）。
+                    # 这种 URL 给远程 LLM 用不了，所以即使不能映射到本地文件，也尝试通过 HTTP 抓取再转 base64。
+                    logger.warning(
+                        f"Local sage url cannot be resolved to a file path, "
+                        f"falling back to HTTP fetch: {url}"
+                    )
+                    data_url = await _fetch_url_to_base64(url)
+                    if data_url is None:
+                        logger.error(
+                            f"Both local resolve and HTTP fallback failed for image_url: {url}; "
+                            f"keeping original URL but remote LLM may reject it."
+                        )
+                        new_content.append(item)
+                    else:
+                        new_content.append({'type': 'image_url', 'image_url': {'url': data_url}})
+                    continue
                 # 真正的远端 URL 原样保留
                 new_content.append(item)
                 continue
@@ -180,6 +251,7 @@ async def process_multimodal_content(msg: Dict[str, Any]) -> Dict[str, Any]:
         path_obj = Path(file_path_str)
         if not path_obj.exists():
             logger.warning(f"Image file not found: {file_path_str}")
+            # file:// 或裸路径找不到只能放弃；http(s) 已在上面分支处理
             new_content.append(item)
             continue
 


### PR DESCRIPTION
## Summary
- Desktop sidecar `POST /api/oss/upload` now returns the file's absolute local path as `url` (plus `local_path` and `http_url` for fallback display). Markdown image refs and `image_url` parts go through `MarkdownRenderer`'s existing `convertFileSrc / data-local-image` branch on the desktop bubble, and the agent reads the file directly via the bare-path branch in `multimodal_image.process_multimodal_content`, eliminating the extra "reverse-resolve localhost URL → read file" hop entirely. File-aware tools can also consume the path as-is.
- Frontend (desktop + server-web) refreshes chip name / `file.name` from the server-side filename when upload finishes (after timestamp suffix + PNG→JPG recompression), and `buildOrderedMultimodalContent` uses the URL tail as the markdown alt so alt and link always match.
- Add HTTP fetch fallback in `process_multimodal_content`: when a localhost URL cannot be reverse-resolved to a local file (HOME mismatch / containerised agent), GET it via httpx and convert the bytes to `data:image/jpeg;base64` before sending to the LLM. Adds warning/error logs for diagnosis.

## Test plan
- [ ] Desktop: paste / upload an image in chat input, verify chip name updates to the server filename and the submitted markdown looks like `![<filename>](/Users/.../upload_files/<filename>)`.
- [ ] Desktop: send the message to a remote LLM (qwen via dashscope); confirm the agent log shows base64 conversion (no more `InternalError.Algo.InvalidParameter`), and the bubble renders the image via `convertFileSrc`.
- [ ] Server-web: upload an image, verify markdown alt matches URL tail; agent receives it and (if URL is localhost-style with HOME mismatch) HTTP fallback fires and base64 is sent to LLM.

Made with [Cursor](https://cursor.com)