### PR TITLE
fix(chat): plain-text paste in ChipInput; add tests

### DIFF
--- a/app/desktop/ui/src/components/chat/ChipInput.vue
+++ b/app/desktop/ui/src/components/chat/ChipInput.vue
@@ -13,7 +13,7 @@
     @keydown="forward('keydown', $event)"
     @keyup="onCaretActivity('keyup', $event)"
     @click="onCaretActivity('click', $event)"
-    @paste="forward('paste', $event)"
+    @paste="handlePaste"
     @focus="onCaretActivity('focus', $event)"
     @blur="forward('blur', $event)"
     @compositionstart="onCompositionStart"
@@ -326,6 +326,36 @@ const insertText = (text) => {
     }
   }
   handleInput()
+}
+
+const clipboardPlainText = (cd) => {
+  if (!cd) return ''
+  const plain = cd.getData('text/plain')
+  if (plain) return plain
+  const html = cd.getData('text/html')
+  if (!html) return ''
+  const div = document.createElement('div')
+  div.innerHTML = html
+  return div.innerText || div.textContent || ''
+}
+
+const clipboardHasFileItems = (cd) => {
+  const items = cd?.items
+  if (!items?.length) return false
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+    if (item.type.startsWith('image/') || item.kind === 'file') return true
+  }
+  return false
+}
+
+const handlePaste = (e) => {
+  if (props.disabled) return
+  const cd = e.clipboardData
+  emit('paste', e)
+  if (clipboardHasFileItems(cd)) return
+  e.preventDefault()
+  insertText(clipboardPlainText(cd))
 }
 
 const setText = (text) => {

--- a/app/server/web/src/components/chat/ChipInput.vue
+++ b/app/server/web/src/components/chat/ChipInput.vue
@@ -13,7 +13,7 @@
     @keydown="forward('keydown', $event)"
     @keyup="onCaretActivity('keyup', $event)"
     @click="onCaretActivity('click', $event)"
-    @paste="forward('paste', $event)"
+    @paste="handlePaste"
     @focus="onCaretActivity('focus', $event)"
     @blur="forward('blur', $event)"
     @compositionstart="onCompositionStart"
@@ -325,6 +325,36 @@ const insertText = (text) => {
     }
   }
   handleInput()
+}
+
+const clipboardPlainText = (cd) => {
+  if (!cd) return ''
+  const plain = cd.getData('text/plain')
+  if (plain) return plain
+  const html = cd.getData('text/html')
+  if (!html) return ''
+  const div = document.createElement('div')
+  div.innerHTML = html
+  return div.innerText || div.textContent || ''
+}
+
+const clipboardHasFileItems = (cd) => {
+  const items = cd?.items
+  if (!items?.length) return false
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+    if (item.type.startsWith('image/') || item.kind === 'file') return true
+  }
+  return false
+}
+
+const handlePaste = (e) => {
+  if (props.disabled) return
+  const cd = e.clipboardData
+  emit('paste', e)
+  if (clipboardHasFileItems(cd)) return
+  e.preventDefault()
+  insertText(clipboardPlainText(cd))
 }
 
 const setText = (text) => {

--- a/change_log.md
+++ b/change_log.md
@@ -1,4 +1,6 @@
 
+2026-04-21 23:40 ChipInput 粘贴：非文件时阻止默认富文本插入，仅写入纯文本（优先 clipboard text/plain，否则从 text/html 取文本），避免保留来源页字体颜色等在深色输入框中对比度过低；仍先 emit paste 供 MessageInput 处理剪贴板图片/文件。desktop/ui 与 server/web 已同步。
+
 2026-04-21 22:55 桌面端上传图片改回"本地绝对路径"链路：sidecar `POST /api/oss/upload` 现在把 `file_path.resolve()` 直接作为 `url` 返回（保留 `local_path` 同值字段，外加 `http_url` 仅作降级展示）。前端 markdown 引用 / image_url part 都用本地路径，命中 MarkdownRenderer 既有的 `convertFileSrc / data-local-image` 分支，agent 端 `multimodal_image.process_multimodal_content` 直接走"裸路径→base64"分支，不再需要 `resolve_local_sage_url` 反解 localhost URL，也省掉一次 HTTP 抓取，文件类工具可直接消费该路径。22:30 加的 HTTP fallback 保留，给 server-web 那种 HOME 不一致场景兜底。
 
 2026-04-21 22:30 修复 sage 上传图片两个问题：1) 输入框 markdown alt 与最终 URL 文件名不一致（原 png/被压成 jpg + 时间戳后缀）——oss.uploadFile 改返回 {url, filename}，MessageInput/ChipInput 在上传完成后用服务端文件名刷新 chip 与 file.name，buildOrderedMultimodalContent 直接取 URL 末段作为 alt，desktop+server-web 同步；2) image_url 没转 base64 导致 dashscope 报 InvalidParameter——multimodal_image.process_multimodal_content 增加本机地址 HTTP 抓取兜底（httpx 已在 requirements），Path.home 反解失败时再走 GET URL→压缩→data:image/jpeg;base64 分支，加 warning/error 日志便于排查。

--- a/tests/common/services/test_agent_service_workspace_delete.py
+++ b/tests/common/services/test_agent_service_workspace_delete.py
@@ -1,0 +1,74 @@
+import asyncio
+from pathlib import Path
+
+from common.core import config
+from common.services import agent_service
+
+
+def _build_cfg(tmp_path: Path) -> config.StartupConfig:
+    root = tmp_path / "sage"
+    cfg = config.StartupConfig(
+        app_mode="server",
+        logs_dir=str(root / "logs"),
+        session_dir=str(root / "sessions"),
+        agents_dir=str(root / "agents"),
+        skill_dir=str(root / "skills"),
+        user_dir=str(root / "users"),
+    )
+    Path(cfg.agents_dir).mkdir(parents=True, exist_ok=True)
+    return cfg
+
+
+def test_delete_server_agent_workspace_deletes_existing_workspace(tmp_path, monkeypatch):
+    cfg = _build_cfg(tmp_path)
+    monkeypatch.setattr(config, "_GLOBAL_STARTUP_CONFIG", cfg, raising=False)
+
+    workspace = Path(cfg.agents_dir) / "user_a" / "agent_demo"
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / "artifact.txt").write_text("hello", encoding="utf-8")
+
+    result = asyncio.run(
+        agent_service.delete_server_agent_workspace("agent_demo", "user_a")
+    )
+
+    assert result["deleted"] is True
+    assert result["agent_id"] == "agent_demo"
+    assert result["user_id"] == "user_a"
+    assert not workspace.exists()
+
+
+def test_delete_server_agent_workspace_returns_false_when_missing(tmp_path, monkeypatch):
+    cfg = _build_cfg(tmp_path)
+    monkeypatch.setattr(config, "_GLOBAL_STARTUP_CONFIG", cfg, raising=False)
+
+    result = asyncio.run(
+        agent_service.delete_server_agent_workspace("agent_demo", "user_a")
+    )
+
+    assert result["deleted"] is False
+    assert result["agent_id"] == "agent_demo"
+    assert result["user_id"] == "user_a"
+
+
+def test_delete_agent_workspace_on_host_desktop_removes_tree(tmp_path, monkeypatch):
+    agents_root = tmp_path / "agents_mount"
+    agents_root.mkdir()
+    monkeypatch.setenv("SAGE_AGENTS_PATH", str(agents_root))
+    cfg = config.StartupConfig(
+        app_mode="desktop",
+        logs_dir=str(tmp_path / "logs"),
+        session_dir=str(tmp_path / "sessions"),
+        agents_dir=str(tmp_path / "agents_unused"),
+        skill_dir=str(tmp_path / "skills"),
+        user_dir=str(tmp_path / "users"),
+    )
+    monkeypatch.setattr(config, "_GLOBAL_STARTUP_CONFIG", cfg, raising=False)
+
+    ws = agents_root / "agent_desktop"
+    ws.mkdir()
+    (ws / "x.txt").write_text("z", encoding="utf-8")
+
+    result = agent_service.delete_agent_workspace_on_host("agent_desktop", "")
+
+    assert result["deleted"] is True
+    assert not ws.exists()

--- a/tests/sagents/test_self_check_agent_paths.py
+++ b/tests/sagents/test_self_check_agent_paths.py
@@ -1,0 +1,163 @@
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_self_check_agent(monkeypatch):
+    def ensure_package(name: str) -> types.ModuleType:
+        module = types.ModuleType(name)
+        module.__path__ = []
+        monkeypatch.setitem(sys.modules, name, module)
+        return module
+
+    ensure_package("sagents")
+    ensure_package("sagents.agent")
+    ensure_package("sagents.context")
+    ensure_package("sagents.context.messages")
+    ensure_package("sagents.utils")
+
+    message_module = types.ModuleType("sagents.context.messages.message")
+
+    class _EnumValue:
+        def __init__(self, value):
+            self.value = value
+
+    class MessageRole:
+        ASSISTANT = _EnumValue("assistant")
+
+    class MessageType:
+        OBSERVATION = _EnumValue("observation")
+
+    class MessageChunk:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    message_module.MessageChunk = MessageChunk
+    message_module.MessageRole = MessageRole
+    message_module.MessageType = MessageType
+    monkeypatch.setitem(sys.modules, "sagents.context.messages.message", message_module)
+
+    session_context_module = types.ModuleType("sagents.context.session_context")
+    session_context_module.SessionContext = object
+    monkeypatch.setitem(sys.modules, "sagents.context.session_context", session_context_module)
+
+    logger_module = types.ModuleType("sagents.utils.logger")
+    logger_module.logger = SimpleNamespace(info=lambda *args, **kwargs: None, warning=lambda *args, **kwargs: None)
+    monkeypatch.setitem(sys.modules, "sagents.utils.logger", logger_module)
+
+    agent_base_module = types.ModuleType("sagents.agent.agent_base")
+
+    class AgentBase:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def _should_abort_due_to_session(self, session_context):
+            return False
+
+    agent_base_module.AgentBase = AgentBase
+    monkeypatch.setitem(sys.modules, "sagents.agent.agent_base", agent_base_module)
+
+    module_path = Path("/Users/zhangzheng/workspace/Sage/sagents/agent/self_check_agent.py")
+    spec = importlib.util.spec_from_file_location("sagents.agent.self_check_agent", module_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "sagents.agent.self_check_agent", module)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.SelfCheckAgent
+
+
+def _make_message(role, content):
+    return SimpleNamespace(
+        role=role,
+        content=content,
+        tool_calls=[],
+        is_user_input_message=lambda: role == "user",
+    )
+
+
+def test_only_latest_assistant_message_is_checked(monkeypatch):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+
+    session_context = SimpleNamespace(
+        message_manager=SimpleNamespace(
+            messages=[
+                _make_message("user", "请继续"),
+                _make_message("assistant", "[old](file:///tmp/old.md)"),
+                _make_message("assistant", "[new](file:///tmp/new.md)"),
+            ]
+        )
+    )
+
+    referenced = agent._collect_recent_referenced_files(session_context)
+
+    assert referenced == {"/tmp/new.md"}
+
+
+def test_non_absolute_markdown_link_returns_guidance(monkeypatch):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+
+    class DummySandbox:
+        async def file_exists(self, path):
+            return True
+
+        async def read_file(self, path, encoding="utf-8"):
+            return ""
+
+    session_context = SimpleNamespace(
+        audit_status={},
+        sandbox=DummySandbox(),
+        message_manager=SimpleNamespace(
+            messages=[
+                _make_message("user", "请生成结果"),
+                _make_message("assistant", "[README.md](README.md)"),
+            ]
+        ),
+    )
+
+    async def collect():
+        chunks = []
+        async for batch in agent.run_stream(session_context):
+            chunks.extend(batch)
+        return chunks
+
+    chunks = asyncio.run(collect())
+
+    assert session_context.audit_status["self_check_passed"] is False
+    assert "必须使用绝对路径 Markdown 链接" in chunks[0].content
+    assert "`README.md`" in chunks[0].content
+
+
+def test_absolute_markdown_link_checks_file_existence(monkeypatch):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+
+    class MissingSandbox:
+        async def file_exists(self, path):
+            return False
+
+    session_context = SimpleNamespace(
+        audit_status={},
+        sandbox=MissingSandbox(),
+        message_manager=SimpleNamespace(
+            messages=[
+                _make_message("user", "请生成结果"),
+                _make_message("assistant", "[README.md](file:///tmp/project/README.md)"),
+            ]
+        ),
+    )
+
+    async def collect():
+        chunks = []
+        async for batch in agent.run_stream(session_context):
+            chunks.extend(batch)
+        return chunks
+
+    chunks = asyncio.run(collect())
+
+    assert session_context.audit_status["self_check_passed"] is False
+    assert "文件不存在: /tmp/project/README.md" in chunks[0].content

--- a/tests/sagents/tool/impl/test_file_system_tool.py
+++ b/tests/sagents/tool/impl/test_file_system_tool.py
@@ -1,0 +1,83 @@
+from sagents.tool.impl.file_system_tool import FileSystemTool
+
+
+def test_normalize_update_operation_accepts_explicit_search_replace():
+    result = FileSystemTool._normalize_update_operation(
+        {
+            "update_mode": "search_replace",
+            "search_pattern": "hello",
+            "replacement": "world",
+        }
+    )
+
+    assert result["status"] == "success"
+    assert result["update_mode"] == "search_replace"
+
+
+def test_normalize_update_operation_requires_both_line_bounds():
+    result = FileSystemTool._normalize_update_operation(
+        {
+            "update_mode": "line_range",
+            "start_line": 2,
+            "replacement": "x",
+        }
+    )
+
+    assert result["status"] == "error"
+    assert "start_line 和 end_line" in result["message"]
+
+
+def test_normalize_update_operation_rejects_mixed_modes():
+    result = FileSystemTool._normalize_update_operation(
+        {
+            "update_mode": "line_range",
+            "start_line": 2,
+            "end_line": 3,
+            "search_pattern": "hello",
+            "replacement": "x",
+        }
+    )
+
+    assert result["status"] == "error"
+    assert "不要同时提供 search_pattern" in result["message"]
+
+
+def test_apply_line_range_update_uses_inclusive_bounds():
+    result = FileSystemTool._apply_line_range_update(
+        "line1\nline2\nline3\n",
+        replacement="middle",
+        start_line=1,
+        end_line=1,
+    )
+
+    assert result["status"] == "success"
+    assert result["content"] == "line1\nmiddle\nline3\n"
+    assert result["lines_replaced"] == 1
+    assert result["start_line"] == 1
+    assert result["end_line"] == 1
+
+
+def test_apply_search_update_prefers_literal_match_before_regex():
+    result = FileSystemTool._apply_search_update(
+        "foo.*bar foo.*bar",
+        search_pattern="foo.*bar",
+        replacement="baz",
+    )
+
+    assert result["status"] == "success"
+    assert result["match_mode"] == "text"
+    assert result["content"] == "baz baz"
+    assert result["replacements"] == 2
+
+
+def test_apply_search_update_falls_back_to_regex():
+    result = FileSystemTool._apply_search_update(
+        "foo1 foo2",
+        search_pattern=r"foo\d",
+        replacement="x",
+    )
+
+    assert result["status"] == "success"
+    assert result["match_mode"] == "regex"
+    assert result["content"] == "x x"
+    assert result["replacements"] == 2

--- a/tests/sagents/utils/sandbox/providers/passthrough/test_passthrough_provider.py
+++ b/tests/sagents/utils/sandbox/providers/passthrough/test_passthrough_provider.py
@@ -1,0 +1,115 @@
+import asyncio
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from sagents.utils.sandbox.providers.passthrough.passthrough import (
+    PassthroughSandboxProvider,
+)
+
+
+@pytest.fixture
+def provider(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    return PassthroughSandboxProvider(
+        sandbox_id="test-sandbox",
+        sandbox_agent_workspace=str(workspace),
+    )
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_execute_command_accepts_workdir_and_env_vars(provider):
+    result = await provider.execute_command(
+        command=f'{sys.executable} -c "import os; print(os.getenv(\'TEST_KEY\', \'\'))"',
+        workdir=provider.workspace_path,
+        env_vars={"TEST_KEY": "hello"},
+        timeout=10,
+    )
+
+    assert result.success is True
+    assert result.stdout.strip() == "hello"
+
+
+@pytest.mark.anyio
+async def test_write_file_supports_overwrite_and_append(provider):
+    target = os.path.join(provider.workspace_path, "notes.txt")
+
+    await provider.write_file(target, "first", mode="overwrite")
+    await provider.write_file(target, "\nsecond", mode="append")
+
+    content = await provider.read_file(target)
+    assert content == "first\nsecond"
+
+
+@pytest.mark.anyio
+async def test_list_directory_respects_include_hidden(provider):
+    await provider.write_file(os.path.join(provider.workspace_path, "visible.txt"), "ok")
+    await provider.write_file(os.path.join(provider.workspace_path, ".hidden.txt"), "secret")
+
+    visible_entries = await provider.list_directory(provider.workspace_path)
+    all_entries = await provider.list_directory(provider.workspace_path, include_hidden=True)
+
+    visible_paths = {os.path.basename(entry.path) for entry in visible_entries}
+    all_paths = {os.path.basename(entry.path) for entry in all_entries}
+
+    assert "visible.txt" in visible_paths
+    assert ".hidden.txt" not in visible_paths
+    assert ".hidden.txt" in all_paths
+    assert all(entry.path.startswith(provider.workspace_path) for entry in all_entries)
+
+
+@pytest.mark.anyio
+async def test_execute_python_returns_unified_execution_result(provider):
+    result = await provider.execute_python(
+        code="print('py-ok')",
+        workdir=provider.workspace_path,
+        timeout=10,
+    )
+
+    assert result.success is True
+    assert result.output.strip() == "py-ok"
+    assert result.error is None
+    assert result.installed_packages == []
+
+
+@pytest.mark.anyio
+async def test_execute_javascript_returns_clean_error_when_node_missing(provider):
+    original = asyncio.create_subprocess_exec
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        if args and args[0] == "node":
+            raise FileNotFoundError("node not found")
+        return await original(*args, **kwargs)
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_create_subprocess_exec):
+        result = await provider.execute_javascript(
+            code="console.log('js-ok')",
+            workdir=provider.workspace_path,
+            timeout=10,
+        )
+
+    assert result.success is False
+    assert result.output == ""
+    assert "Node.js not found" in (result.error or "")
+    assert result.installed_packages == []
+
+
+@pytest.mark.anyio
+async def test_file_info_paths_are_usable_for_matching_and_deletion(provider):
+    target = os.path.join(provider.workspace_path, "delete-me.txt")
+    await provider.write_file(target, "bye")
+
+    entries = await provider.list_directory(provider.workspace_path)
+    matching = next(entry for entry in entries if os.path.basename(entry.path) == "delete-me.txt")
+
+    assert matching.is_file is True
+    await provider.delete_file(matching.path)
+    assert await provider.file_exists(target) is False

--- a/tests/sagents/utils/sandbox/test_stdout_echo.py
+++ b/tests/sagents/utils/sandbox/test_stdout_echo.py
@@ -1,0 +1,345 @@
+"""
+Unit tests for sagents.utils.sandbox._stdout_echo.
+
+覆盖范围：
+- echo_enabled 各种 env var 取值组合
+- echo_chunk / echo_header / echo_footer 的输出格式与开关行为
+- _safe_write 的异常吞咽
+- run_with_streaming_stdout：基本成功 / 非零 rc / stderr 隔离 / 超时 partial output
+  / cwd / env / echo 开关 / 大输出（多 chunk）/ 二进制非 UTF-8 字节兜底
+"""
+import os
+import subprocess
+import sys
+import time
+from typing import List
+
+import pytest
+
+from sagents.utils.sandbox import _stdout_echo
+from sagents.utils.sandbox._stdout_echo import (
+    echo_chunk,
+    echo_enabled,
+    echo_footer,
+    echo_header,
+    run_with_streaming_stdout,
+)
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_echo_env(monkeypatch):
+    """每个用例开始前，清空 SAGE_ECHO_SHELL_OUTPUT，避免被外部环境污染。"""
+    monkeypatch.delenv("SAGE_ECHO_SHELL_OUTPUT", raising=False)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ---------------------------------------------------------------------------
+# echo_enabled
+# ---------------------------------------------------------------------------
+
+class TestEchoEnabled:
+    def test_default_when_unset_is_enabled(self, monkeypatch):
+        monkeypatch.delenv("SAGE_ECHO_SHELL_OUTPUT", raising=False)
+        assert echo_enabled() is True
+
+    @pytest.mark.parametrize(
+        "value",
+        ["1", "true", "TRUE", "True", "yes", "YES", "on", "ON", " 1 ", "anything-else"],
+    )
+    def test_enabled_values(self, monkeypatch, value):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", value)
+        assert echo_enabled() is True, f"value={value!r} 应被视为开启"
+
+    @pytest.mark.parametrize(
+        "value",
+        ["0", "false", "FALSE", "False", "no", "NO", "off", "OFF", "", "  "],
+    )
+    def test_disabled_values(self, monkeypatch, value):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", value)
+        assert echo_enabled() is False, f"value={value!r} 应被视为关闭"
+
+
+# ---------------------------------------------------------------------------
+# echo_chunk / echo_header / echo_footer
+# ---------------------------------------------------------------------------
+
+class TestEchoChunk:
+    def test_writes_to_stdout_when_enabled(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        echo_chunk("hello world\n")
+        out = capsys.readouterr().out
+        assert out == "hello world\n"
+
+    def test_silent_when_disabled(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "0")
+        echo_chunk("must not appear")
+        assert capsys.readouterr().out == ""
+
+    def test_empty_string_is_noop(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        echo_chunk("")
+        assert capsys.readouterr().out == ""
+
+    def test_none_is_noop(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        # 类型注解是 str，但代码用 `if not text` 兜底；显式传 None 不应抛
+        echo_chunk(None)  # type: ignore[arg-type]
+        assert capsys.readouterr().out == ""
+
+    def test_swallows_stdout_write_exception(self, monkeypatch):
+        """sys.stdout.write 抛异常时，echo_chunk 必须静默吞掉，不能影响主流程。"""
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+
+        class _BrokenStdout:
+            def write(self, _):
+                raise RuntimeError("disk full")
+
+            def flush(self):
+                raise RuntimeError("disk full")
+
+        monkeypatch.setattr(sys, "stdout", _BrokenStdout())
+        # 不应抛
+        echo_chunk("payload")
+
+    def test_unicode_passthrough(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        echo_chunk("中文 🚀 emoji\n")
+        assert capsys.readouterr().out == "中文 🚀 emoji\n"
+
+
+class TestEchoHeader:
+    def test_default_format(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        echo_header("ls -la")
+        assert capsys.readouterr().out == "\n$ ls -la\n"
+
+    def test_silent_when_disabled(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "0")
+        echo_header("ls -la")
+        assert capsys.readouterr().out == ""
+
+    def test_truncates_long_command(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        long_cmd = "x" * 800
+        echo_header(long_cmd)
+        out = capsys.readouterr().out
+        # 头/尾各一个 \n + "$ " 前缀 + 500 个字符 + " …"
+        assert out.startswith("\n$ ") and out.endswith(" …\n")
+        body = out[len("\n$ "):-len(" …\n")]
+        assert body == "x" * 500
+
+    def test_empty_command_still_emits_marker(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        echo_header("")
+        assert capsys.readouterr().out == "\n$ \n"
+
+    def test_custom_tag(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        echo_header("pwd", tag=">>>")
+        assert capsys.readouterr().out == "\n>>> pwd\n"
+
+
+class TestEchoFooter:
+    def test_with_int_rc(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        echo_footer(0)
+        assert capsys.readouterr().out == "↪ rc=0\n"
+
+    def test_with_nonzero_rc(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        echo_footer(137)
+        assert capsys.readouterr().out == "↪ rc=137\n"
+
+    def test_with_none_rc(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        echo_footer(None)
+        assert capsys.readouterr().out == "↪ rc=?\n"
+
+    def test_silent_when_disabled(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "0")
+        echo_footer(0)
+        assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# run_with_streaming_stdout
+# ---------------------------------------------------------------------------
+
+class TestRunWithStreamingStdout:
+    def test_simple_success_returns_rc_stdout(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        rc, out, err = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "echo hello"], timeout=5
+        )
+        assert rc == 0
+        assert out == "hello\n"
+        assert err == ""
+        # 同时也实时回显到 stdout
+        captured = capsys.readouterr().out
+        assert "hello\n" in captured
+
+    def test_nonzero_returncode_does_not_raise(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "0")
+        rc, out, err = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "echo bye; exit 7"], timeout=5
+        )
+        assert rc == 7
+        assert out == "bye\n"
+        assert err == ""
+
+    def test_stderr_captured_separately_and_not_echoed(self, monkeypatch, capsys):
+        """stderr 必须独立捕获，且不会被 echo 到本进程 stdout。"""
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        rc, out, err = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "echo on-out; echo on-err 1>&2; exit 0"],
+            timeout=5,
+        )
+        assert rc == 0
+        assert out == "on-out\n"
+        assert err == "on-err\n"
+        echoed = capsys.readouterr().out
+        # 只有 stdout 被回显
+        assert "on-out\n" in echoed
+        assert "on-err" not in echoed
+
+    def test_echo_disabled_does_not_write_to_stdout(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "0")
+        rc, out, _ = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "echo silent"], timeout=5
+        )
+        assert rc == 0
+        assert out == "silent\n"
+        # 关闭后不应往 stdout 回显
+        assert capsys.readouterr().out == ""
+
+    def test_cwd_takes_effect(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "0")
+        target = tmp_path / "subdir"
+        target.mkdir()
+        rc, out, _ = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "pwd"], cwd=str(target), timeout=5
+        )
+        assert rc == 0
+        # macOS 下 /tmp 会被解析成 /private/tmp，做 realpath 比较
+        assert os.path.realpath(out.strip()) == os.path.realpath(str(target))
+
+    def test_env_takes_effect(self, monkeypatch, capsys):
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "0")
+        rc, out, _ = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "echo $MY_TEST_VAR"],
+            env={"MY_TEST_VAR": "abc123", "PATH": os.environ.get("PATH", "")},
+            timeout=5,
+        )
+        assert rc == 0
+        assert out == "abc123\n"
+
+    def test_timeout_raises_with_partial_output(self, monkeypatch, capsys):
+        """超时必须抛 TimeoutExpired，且把已收集到的 stdout 带回来。"""
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        start = time.monotonic()
+        with pytest.raises(subprocess.TimeoutExpired) as exc_info:
+            run_with_streaming_stdout(
+                ["/bin/sh", "-c", "echo before; sleep 5; echo after"],
+                timeout=0.5,
+            )
+        elapsed = time.monotonic() - start
+        # 应该在 ~0.5s 杀掉，绝不该跑满 5s
+        assert elapsed < 3.0, f"超时未生效，跑了 {elapsed:.2f}s"
+        te = exc_info.value
+        # partial output 已经包含 before
+        partial = te.output or ""
+        assert "before" in partial
+        assert "after" not in partial
+
+    def test_large_output_streams_in_chunks(self, monkeypatch, capsys):
+        """跨多个 4KB chunk 的大输出，应该完整捕获且实时回显。"""
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        # 生成 ~30KB 输出
+        rc, out, err = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "yes 'line' 2>/dev/null | head -n 5000"],
+            timeout=10,
+        )
+        assert rc == 0
+        lines = out.splitlines()
+        assert len(lines) == 5000
+        assert all(line == "line" for line in lines)
+        # echo 也覆盖完整
+        echoed = capsys.readouterr().out
+        assert echoed.count("line\n") == 5000
+
+    def test_invalid_utf8_does_not_crash(self, monkeypatch, capsys):
+        """非 UTF-8 字节应被 errors='replace' 兜底，不抛异常。"""
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        # printf '\xff\xfe\xfd' → 3 个非法 UTF-8 字节
+        rc, out, err = run_with_streaming_stdout(
+            ["/bin/sh", "-c", r"printf '\xff\xfe\xfd'"],
+            timeout=5,
+        )
+        assert rc == 0
+        # 三个字节都被替换为 U+FFFD（一个或多个）
+        assert "\ufffd" in out
+
+    def test_ordering_preserves_command_output_then_echo(self, monkeypatch, capsys):
+        """同一行命令输出，echo 顺序应当与捕获顺序一致（按到达顺序流式）。"""
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        rc, out, _ = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "echo A; echo B; echo C"], timeout=5
+        )
+        assert out == "A\nB\nC\n"
+        echoed = capsys.readouterr().out
+        # 多个 chunk 合并后仍保持 A B C 顺序
+        idx_a, idx_b, idx_c = echoed.find("A"), echoed.find("B"), echoed.find("C")
+        assert 0 <= idx_a < idx_b < idx_c
+
+    def test_no_timeout_runs_to_completion(self, monkeypatch, capsys):
+        """timeout=None 时不应启用 deadline 分支，命令正常跑完。"""
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "0")
+        rc, out, _ = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "echo done"], timeout=None
+        )
+        assert rc == 0
+        assert out == "done\n"
+
+    def test_streaming_actually_arrives_before_process_exit(self, monkeypatch, capsys):
+        """关键的"实时性"断言：在子进程结束前，前半段 stdout 就已经被 echo 出来。
+
+        通过 monkeypatch 拦截 _stdout_echo.echo_chunk，在每次回调时打 timestamp，
+        然后比较第一次 chunk 到达时间与命令总耗时的差值。
+        """
+        monkeypatch.setenv("SAGE_ECHO_SHELL_OUTPUT", "1")
+        events: List[tuple] = []  # (t_relative, chunk)
+        original_echo = _stdout_echo.echo_chunk
+
+        def _spy(chunk):
+            events.append((time.monotonic(), chunk))
+            return original_echo(chunk)
+
+        monkeypatch.setattr(_stdout_echo, "echo_chunk", _spy)
+
+        t0 = time.monotonic()
+        rc, out, _ = run_with_streaming_stdout(
+            ["/bin/sh", "-c", "echo first; sleep 0.6; echo second"],
+            timeout=5,
+        )
+        total = time.monotonic() - t0
+
+        assert rc == 0
+        assert out == "first\nsecond\n"
+        assert events, "至少应该收到一次 echo_chunk 回调"
+
+        # 第一次 chunk 必须在命令真正结束前就到达
+        first_chunk_at = events[0][0] - t0
+        assert first_chunk_at < total - 0.2, (
+            f"first chunk 在 {first_chunk_at:.2f}s 才到达，"
+            f"总耗时 {total:.2f}s，未达到流式效果"
+        )
+        # 且第一次到达的 chunk 必含 'first' 而不含 'second'
+        assert "first" in events[0][1] and "second" not in events[0][1]

--- a/tests/sagents/utils/test_file_content_validator.py
+++ b/tests/sagents/utils/test_file_content_validator.py
@@ -1,0 +1,65 @@
+from sagents.utils.file_content_validator import FileContentValidator
+
+
+def test_json_validation_passes_for_valid_json():
+    result = FileContentValidator.validate("/tmp/sample.json", '{"name": "sage", "count": 1}')
+
+    assert result["status"] == "passed"
+    assert result["passed"] is True
+    assert result["validator"] == "json"
+
+
+def test_json_validation_reports_error_for_invalid_json():
+    result = FileContentValidator.validate("/tmp/sample.json", '{"name": "sage",}')
+
+    assert result["status"] == "error"
+    assert result["passed"] is False
+    assert "JSON 语法错误" in result["message"]
+
+
+def test_yaml_validation_passes_for_valid_yaml():
+    result = FileContentValidator.validate("/tmp/sample.yaml", "name: sage\ncount: 1\n")
+
+    assert result["status"] == "passed"
+    assert result["passed"] is True
+    assert result["validator"] == "yaml"
+
+
+def test_yaml_validation_reports_error_for_invalid_yaml():
+    result = FileContentValidator.validate("/tmp/sample.yaml", "name: sage\n  count: 1\n")
+
+    assert result["status"] == "error"
+    assert result["passed"] is False
+    assert "YAML 语法错误" in result["message"]
+
+
+def test_python_validation_passes_for_valid_python():
+    result = FileContentValidator.validate("/tmp/sample.py", "def hello():\n    return 1\n")
+
+    assert result["status"] == "passed"
+    assert result["passed"] is True
+    assert result["validator"] == "python"
+
+
+def test_python_validation_reports_error_for_invalid_python():
+    result = FileContentValidator.validate("/tmp/sample.py", "def hello(\n    return 1\n")
+
+    assert result["status"] == "error"
+    assert result["passed"] is False
+    assert "Python 语法错误" in result["message"]
+
+
+def test_toml_validation_passes_for_valid_toml():
+    result = FileContentValidator.validate("/tmp/sample.toml", "name = 'sage'\ncount = 1\n")
+
+    assert result["status"] == "passed"
+    assert result["passed"] is True
+    assert result["validator"] == "toml"
+
+
+def test_unsupported_extension_is_skipped():
+    result = FileContentValidator.validate("/tmp/sample.md", "# title\n")
+
+    assert result["status"] == "skipped"
+    assert result["skipped"] is True
+    assert result["passed"] is True


### PR DESCRIPTION
## Summary
- **ChipInput (desktop + server-web):** On paste, skip default rich-HTML insertion for non-file clipboard content; insert plain text only (text/plain, or text extracted from text/html) so dark-theme contrast is not broken by copied inline `color` styles. File/image paste still handled by `MessageInput` first via `emit('paste')`.
- **Tests:** New/added unit tests for agent workspace delete, self-check paths, file system tool, file content validator, stdout echo, passthrough provider.
- **change_log.md:** 2026-04-21 entry.

## Test plan
- [ ] Manually paste formatted text from web/doc into chat input; text should use theme color.
- [ ] Paste image from clipboard; attachment flow unchanged.

Made with [Cursor](https://cursor.com)