### PR TITLE
Fix: 兼容 gpt-5.4 strict 模式的工具 Schema 校验

### DIFF
--- a/sagents/tool/impl/execute_command_tool.py
+++ b/sagents/tool/impl/execute_command_tool.py
@@ -66,7 +66,7 @@ class ExecuteCommandTool:
             "command": {"type": "string", "description": "Shell command to execute"},
             "workdir": {"type": "string", "description": "Working directory (virtual path)"},
             "timeout": {"type": "integer", "default": 30},
-            "env_vars": {"type": "object", "description": "Additional environment variables"},
+            "env_vars": {"type": "string", "description": "Additional environment variables as a JSON object string, e.g. '{\"KEY\": \"VALUE\"}'. Leave empty if not needed."},
             "session_id": {"type": "string", "description": "Session ID"},
         },
         return_data={
@@ -86,7 +86,7 @@ class ExecuteCommandTool:
         command: str,
         workdir: Optional[str] = None,
         timeout: int = 30,
-        env_vars: Optional[Dict[str, str]] = None,
+        env_vars: Optional[str] = None,
         session_id: str = None,
     ) -> Dict[str, Any]:
         """
@@ -96,7 +96,7 @@ class ExecuteCommandTool:
             command: Shell 命令字符串
             workdir: 执行目录（虚拟路径）
             timeout: 超时秒数
-            env_vars: 附加环境变量
+            env_vars: 附加环境变量（JSON 字符串格式，如 '{"KEY": "VALUE"}'）
             session_id: 会话ID（必填）
 
         Returns:
@@ -104,6 +104,17 @@ class ExecuteCommandTool:
         """
         if not session_id:
             raise ValueError("ExecuteCommandTool: session_id is required")
+
+        # env_vars 以 JSON 字符串传入，解析为 dict
+        parsed_env_vars: Optional[Dict[str, str]] = None
+        if env_vars and isinstance(env_vars, str) and env_vars.strip():
+            try:
+                import json as _json
+                parsed_env_vars = _json.loads(env_vars)
+            except Exception:
+                logger.warning(f"env_vars 解析失败，忽略: {env_vars!r}")
+        elif isinstance(env_vars, dict):
+            parsed_env_vars = env_vars
 
         logger.info(f"🖥️ ExecuteCommandTool: {command[:100]}{'...' if len(command) > 100 else ''}")
 
@@ -130,7 +141,7 @@ class ExecuteCommandTool:
                 command=command,
                 workdir=workdir,
                 timeout=timeout,
-                env_vars=env_vars,
+                env_vars=parsed_env_vars,
             )
         finally:
             echo_footer(result.return_code if result is not None else None)

--- a/sagents/tool/impl/questionnaire_tool.py
+++ b/sagents/tool/impl/questionnaire_tool.py
@@ -118,7 +118,7 @@ class QuestionnaireTool:
                             }
                         },
                         "default": {
-                            "oneOf": [
+                            "anyOf": [
                                 {"type": "string", "description": "单选或文本题的默认值"},
                                 {"type": "array", "items": {"type": "string"}, "description": "多选题的默认值(字符串数组)"}
                             ],

--- a/sagents/tool/tool_manager.py
+++ b/sagents/tool/tool_manager.py
@@ -887,6 +887,10 @@ class ToolManager:
         # (e.g. updates="{\"start_at\":\"...\"}") which breaks MCP validation.
         kwargs = self._normalize_kwargs_by_schema(tool, tool_name, kwargs)
 
+        # In strict mode the LLM passes null for optional parameters; strip them out
+        # so tools receive their Python default values instead of None.
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+
         # Step 2: Execute based on tool type (self-call prevention handled at agent level)
 
         try:

--- a/sagents/tool/tool_schema.py
+++ b/sagents/tool/tool_schema.py
@@ -168,6 +168,82 @@ def convert_spec_to_openai_format(
         if isinstance(localized_returns.get("properties"), dict):
             _apply_prop_i18n(localized_returns["properties"], rdi_map)
 
+    # In strict mode, ALL properties must be in required, and every nested object
+    # must also have additionalProperties: false with a complete required array.
+    # session_id at the top level is always auto-injected and must not be exposed to the LLM.
+    _AUTO_INJECT_PARAMS = {"session_id"}
+
+    def _enforce_strict_schema(node: Any) -> None:
+        """Recursively enforce OpenAI strict-mode constraints on all nested object schemas.
+
+        Rules applied:
+        - oneOf / allOf → replaced with anyOf (strict mode only permits anyOf)
+        - Objects with properties: add additionalProperties=false; make ALL keys required;
+          optional properties (absent from original required) are wrapped as anyOf:[type, null]
+        - Bare objects (no properties): converted to string type with JSON-format hint
+        - Arrays: recurse into items
+        - anyOf members: recurse into each member
+        """
+        if not isinstance(node, dict):
+            return
+
+        # Replace forbidden combiners with anyOf
+        for forbidden in ("oneOf", "allOf"):
+            if forbidden in node:
+                node["anyOf"] = node.pop(forbidden)
+
+        if node.get("type") == "object":
+            if "properties" in node and isinstance(node["properties"], dict):
+                node["additionalProperties"] = False
+                original_required = set(node.get("required", []))
+                for prop_key, prop_node in node["properties"].items():
+                    _enforce_strict_schema(prop_node)
+                    if prop_key not in original_required:
+                        # Optional nested property: wrap as nullable
+                        desc = prop_node.pop("description", "")
+                        inner = dict(prop_node)
+                        prop_node.clear()
+                        prop_node["anyOf"] = [inner, {"type": "null"}]
+                        if desc:
+                            prop_node["description"] = desc
+                node["required"] = list(node["properties"].keys())
+            else:
+                # Free-form dict — not representable in strict mode; convert to string.
+                original_desc = node.get("description", "")
+                node.clear()
+                node["type"] = "string"
+                node["description"] = (
+                    (original_desc + " " if original_desc else "")
+                    + "(Pass as a JSON object string, e.g. '{\"key\": \"value\"}')"
+                ).strip()
+            return  # children already handled above
+
+        if node.get("type") == "array" and "items" in node:
+            _enforce_strict_schema(node["items"])
+
+        # Recurse into anyOf members (handles oneOf→anyOf converted nodes too)
+        if "anyOf" in node and isinstance(node["anyOf"], list):
+            for member in node["anyOf"]:
+                _enforce_strict_schema(member)
+
+    strictly_required = set(getattr(tool_spec, "required", []))
+    schema_params = {k: v for k, v in localized_params.items() if k not in _AUTO_INJECT_PARAMS}
+
+    for key, param_node in schema_params.items():
+        _enforce_strict_schema(param_node)
+        if key not in strictly_required:
+            # Strict mode requires ALL properties in required.
+            # For optional params, wrap as anyOf: [type, null] so the LLM can pass null.
+            desc = param_node.pop("description", "")
+            inner = dict(param_node)
+            param_node.clear()
+            param_node["anyOf"] = [inner, {"type": "null"}]
+            if desc:
+                param_node["description"] = desc
+
+    # Now all schema_params are required (optional ones accept null).
+    schema_required = list(schema_params.keys())
+
     return {
         "type": "function",
         "function": {
@@ -175,8 +251,8 @@ def convert_spec_to_openai_format(
             "description": localized_desc,
             "parameters": {
                 "type": "object",
-                "properties": localized_params,
-                "required": getattr(tool_spec, "required", []),
+                "properties": schema_params,
+                "required": schema_required,
                 "additionalProperties": False,
             },
             "strict": True,


### PR DESCRIPTION
### 问题
gpt-5.4 对 `strict: true` 的 schema 校验更严格，导致所有工具调用报 400 错误。

### 根因
strict 模式要求：
- `properties` 里的所有 key 必须在 `required` 里
- 每层 object 必须有 `additionalProperties: false`
- 只允许 `anyOf`，不允许 `oneOf` / `allOf`
- 可选参数用 `anyOf: [原类型, null]` 表达

### 修复思路
在 `convert_spec_to_openai_format` 统一处理，无需逐个修改各工具。

### 改动
- **`tool_schema.py`**：新增 `_enforce_strict_schema` 递归函数，自动修复所有嵌套 schema；可选参数统一包装为 `anyOf: [type, null]`；排除 `session_id`（运行时自动注入）
- **`tool_manager.py`**：执行前过滤 LLM 传来的 `null` 值，保证工具函数收到正确默认值
- **`execute_command_tool.py`**：`env_vars` 改为 JSON 字符串传入（自由 dict 无法在 strict 模式下合法表达）
- **`questionnaire_tool.py`**：`oneOf` 改为 `anyOf`

### 兼容性
对其他模型（Claude、Gemini、旧版 GPT）完全向后兼容。