### PR TITLE
docs: fix zh API front matter (sidebar uses page.lang)

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -1,5 +1,7 @@
 2026-04-22 文档站：修复多份 `HTTP_API_*.md` 误写为 `## layout` 的 front matter，恢复侧栏「HTTP API 参考」下二级子页；新增中/英 `API_DOCS` 为「API 文档」父页，HTTP 与历史 Python 参考分栏并调 README 地图。
 
+2026-04-22 文档站：修复 `docs/zh` 中 `API_DOCS`、`HTTP_API_REFERENCE`、`API_REFERENCE` 的 front matter（`## layout` 误为标题导致无 `lang`），侧栏按 `page.lang` 过滤，否则回退为英文目录。
+
 2026-04-22 messages 测试补缺：新增 `test_history_anchor.py` 23 个用例，覆盖 `compute_history_anchor_index` 边界、`add_messages` 自动刷新锚点、`prepare_history_split` 新返回、`extract_all_context_messages` 不再被 `active_start_index` 截断、memory 工具锚点边界、旧 config 向后兼容；messages 全套 47 个用例通过。
 
 2026-04-22 死代码清理：删 `_build_dropped_prefix_bridge`/`_plain_preview_for_bridge`/`_extract_current_query`/`dropped_history_bridge_budget`；`prepare_history_split` 瘦身只保留 budget 计算与锚点刷新；`ContextBudgetManager` 删 `split_messages`/`recent_turns` 及配套私有方法。messages+sagents 单测全过。

--- a/docs/zh/API_DOCS.md
+++ b/docs/zh/API_DOCS.md
@@ -1,12 +1,12 @@
 ---
-
-## layout: default
+layout: default
 title: API 文档
 nav_order: 8.5
 has_children: true
 description: "当前 HTTP 与历史 Python 运行时 API 的入口与说明"
 lang: zh
 ref: api-docs
+---
 
 {% include lang_switcher.html %}
 

--- a/docs/zh/API_REFERENCE.md
+++ b/docs/zh/API_REFERENCE.md
@@ -1,12 +1,12 @@
 ---
-
-## layout: default
+layout: default
 title: Python 运行时 API（历史 v0.9）
 parent: API 文档
 nav_order: 2
 description: "历史 v0.9 运行时侧 Python 类与方法的参考（非当前 HTTP 对外接口）"
 lang: zh
 ref: api-reference
+---
 
 {% include lang_switcher.html %}
 

--- a/docs/zh/HTTP_API_REFERENCE.md
+++ b/docs/zh/HTTP_API_REFERENCE.md
@@ -1,6 +1,5 @@
 ---
-
-## layout: default
+layout: default
 title: HTTP API 参考
 parent: API 文档
 nav_order: 1
@@ -8,6 +7,7 @@ has_children: true
 description: "基于当前代码库的后端 HTTP API 参考"
 lang: zh
 ref: http-api-reference
+---
 
 {% include lang_switcher.html %}
 


### PR DESCRIPTION
Restores valid Jekyll YAML for `API_DOCS`, `HTTP_API_REFERENCE`, and `API_REFERENCE` under `docs/zh/` so `lang: zh` is parsed; sidebar filters by `page.lang` and was falling back to English when front matter was invalid.

Made with [Cursor](https://cursor.com)