### PR TITLE
fix(common): AnyTool URL, agent abilities JSON shape

### DIFF
--- a/app/desktop/core/lifecycle.py
+++ b/app/desktop/core/lifecycle.py
@@ -41,6 +41,11 @@ def _setup_memory_root_path():
 
 async def initialize_system():
     logger.info("sage-desktop：开始初始化")
+    from common.runtime_patches.agent_abilities_prompt import (
+        apply_agent_abilities_items_object_prompt_fix,
+    )
+
+    apply_agent_abilities_items_object_prompt_fix()
     _setup_memory_root_path()
     _start_host_watchdog()
     await initialize_observability()

--- a/app/server/lifecycle.py
+++ b/app/server/lifecycle.py
@@ -30,6 +30,11 @@ async def _require_initialized(name: str, initializer_result):
 
 async def initialize_system(cfg: StartupConfig):
     logger.info("Sage开始初始化")
+    from common.runtime_patches.agent_abilities_prompt import (
+        apply_agent_abilities_items_object_prompt_fix,
+    )
+
+    apply_agent_abilities_items_object_prompt_fix()
 
     # 1. 优先初始化数据库和数据
     await _require_initialized("db connection", initialize_db_connection(cfg))

--- a/change_log.md
+++ b/change_log.md
@@ -1,3 +1,7 @@
+2026-04-27 13:10 不修改 sagents/tool_manager：AnyTool 端口由 mcp_service 重写 URL，聊天侧 extra MCP 经 mcp_anytool_url 对齐 SAGE_PORT；英文能力列表「缺少 items」因 prompt 写「JSON 数组」与解析器要 {"items":[]}，于 desktop/server lifecycle 启动时对 PromptManager 做 runtime 文案补丁（zh/en/pt）。
+
+2026-04-27 12:25 修复 AnyTool MCP 502：DB 等存储的 streamable_http_url 残留旧端口与 SAGE_PORT 不一致时，mcp_service 对 kind=anytool 按 _get_backend_port 重写 URL。
+
 2026-04-27 12:05 修复桌面端打包后 fetch 报 CORS：为 Tauri 源增加显式 allow_origins（tauri://localhost、http/https://tauri.localhost）与锚定 fullmatch 正则；main 设置 SAGE_INTERNAL_DESKTOP_PROCESS=1 防止误走 server 空 CORS； abilities 等接口若仍 500 可在修复 CORS 后从响应体看到真实错误。
 
 2026-04-26 23:50 桌面端构建优化两项：(1) PyInstaller 配置统一到 sage-desktop.spec，build.sh 不再传一长串 flags，仅通过 SAGE_PYI_MODE 控制 strip；(2) CSP 收紧，default-src 'self'、script-src 仅 'self'（彻底禁止 inline script），style-src 保留 'unsafe-inline' 兼容 radix-vue 运行时样式，显式声明 img/media/font/connect/worker/object/base-uri/frame-ancestors。

--- a/common/runtime_patches/__init__.py
+++ b/common/runtime_patches/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime-only fixes that avoid editing sagents sources."""

--- a/common/runtime_patches/agent_abilities_prompt.py
+++ b/common/runtime_patches/agent_abilities_prompt.py
@@ -1,0 +1,70 @@
+"""Align bundled agent_abilities user prompts with sagents.utils.agent_abilities JSON shape.
+
+The parser requires a top-level object: {\"items\": [...]}. Older prompt text asked for a bare
+JSON array, which English models often follow literally → missing \"items\" field error.
+This module patches PromptManager in memory at startup (no sagents file edits).
+"""
+
+from __future__ import annotations
+
+from loguru import logger
+
+_AGENT = "common_util"
+_KEY = "agent_abilities_user_prompt"
+
+
+def apply_agent_abilities_items_object_prompt_fix() -> None:
+    try:
+        from sagents.utils.prompt_manager import PromptManager
+    except Exception as exc:  # pragma: no cover
+        logger.warning(f"agent_abilities prompt patch skipped: {exc}")
+        return
+
+    pm = PromptManager()
+    replacements: dict[str, tuple[tuple[str, str], ...]] = {
+        "zh": (
+            (
+                "3. 输出必须是严格 JSON 数组。\n4. 每一项必须包含 id、title、description、promptText 四个字段。",
+                '3. 输出必须是严格 JSON 对象，顶层只能有一个字段 "items"，其值为数组。\n4. "items" 中每一项必须包含 id、title、description、promptText 四个字段。',
+            ),
+            (
+                "请只返回 JSON 数组，不要输出解释或额外文本。",
+                '请只返回形如 {"items":[...]} 的 JSON，不要使用代码围栏，不要输出解释或额外文本。',
+            ),
+        ),
+        "en": (
+            (
+                "3. The output must be a strict JSON array.\n4. Each item must contain the fields id, title, description, and promptText.",
+                '3. The output must be one JSON object with a single top-level key "items" whose value is an array.\n4. Each object in "items" must contain id, title, description, and promptText.',
+            ),
+            (
+                "Return JSON only, without explanations or extra text.",
+                "Return only that JSON object (no markdown fences, no extra text).",
+            ),
+        ),
+        "pt": (
+            (
+                "3. A saída deve ser um array JSON estrito.\n4. Cada item deve conter os campos id, title, description e promptText.",
+                '3. A saída deve ser um objeto JSON com uma única chave de nível superior "items", cujo valor é um array.\n4. Cada objeto em "items" deve conter id, title, description e promptText.',
+            ),
+            (
+                "Retorne apenas JSON, sem explicações ou texto extra.",
+                "Retorne apenas esse objeto JSON (sem cercas de código markdown, sem texto extra).",
+            ),
+        ),
+    }
+
+    for lang, pairs in replacements.items():
+        store = pm.agent_prompts_map.get(lang)
+        if not store:
+            continue
+        block = store.get(_AGENT)
+        if not block or _KEY not in block:
+            continue
+        text = block[_KEY]
+        for old, new in pairs:
+            if old in text:
+                text = text.replace(old, new)
+        block[_KEY] = text
+
+    logger.debug("agent_abilities prompt patched for {\"items\": [...]} JSON shape")

--- a/common/services/chat_service.py
+++ b/common/services/chat_service.py
@@ -456,6 +456,9 @@ async def _register_extra_mcp_tools(request: StreamRequest) -> None:
             logger.warning(f"Invalid MCP config for {key}: missing connection parameters")
             continue
 
+        from common.utils.mcp_anytool_url import coalesce_anytool_streamable_url
+
+        value = coalesce_anytool_streamable_url(key, value)
         registered_tools = await tm.register_mcp_server(key, value)
         if not registered_tools:
             logger.warning(f"Failed to register MCP server {key} with tools")

--- a/common/services/mcp_service.py
+++ b/common/services/mcp_service.py
@@ -15,6 +15,19 @@ from mcp_servers.anytool.anytool_runtime import (
 DEFAULT_ANYTOOL_SERVER_NAME = "AnyTool"
 
 
+def _anytool_url_path_segment(normalized: Dict[str, Any]) -> str:
+    """Resolve /api/mcp/anytool/<segment> from stored config (URL may have a stale port)."""
+    url = normalized.get("streamable_http_url")
+    if isinstance(url, str) and "/api/mcp/anytool/" in url:
+        seg = url.split("/api/mcp/anytool/", 1)[-1].strip().rstrip("/")
+        if seg:
+            return seg
+    name = normalized.get("name")
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+    return DEFAULT_ANYTOOL_SERVER_NAME
+
+
 def _has_anytool_name_whitespace(name: Any) -> bool:
     return any(ch.isspace() for ch in str(name or ""))
 
@@ -107,9 +120,10 @@ def _normalize_server_config(config_data: Dict[str, Any]) -> Dict[str, Any]:
     normalized.setdefault("kind", "external")
     if normalized.get("kind") == "anytool":
         normalized["protocol"] = "streamable_http"
-        normalized.setdefault(
-            "streamable_http_url",
-            f"http://127.0.0.1:{_get_backend_port()}/api/mcp/anytool/{normalized.get('name', '')}",
+        # Always rewrite URL: DB / mcp_setting may keep an old port (e.g. 18080) after SAGE_PORT moved.
+        path_seg = _anytool_url_path_segment(normalized)
+        normalized["streamable_http_url"] = (
+            f"http://127.0.0.1:{_get_backend_port()}/api/mcp/anytool/{path_seg}"
         )
         normalized["tools"] = normalize_anytool_tools(normalized.get("tools", []))
         simulator = normalized.get("simulator")

--- a/common/utils/mcp_anytool_url.py
+++ b/common/utils/mcp_anytool_url.py
@@ -1,0 +1,24 @@
+"""Rewrite built-in AnyTool streamable_http_url to the current backend port (common-only, no sagents)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def coalesce_anytool_streamable_url(server_name: str, cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Point AnyTool MCP URLs at 127.0.0.1:<SAGE_PORT> when config still has a stale port."""
+    out = dict(cfg)
+    url = out.get("streamable_http_url") or out.get("url")
+    kind = str(out.get("kind", "") or "").lower()
+    if kind != "anytool" and not (
+        isinstance(url, str) and "/api/mcp/anytool/" in url
+    ):
+        return out
+    from common.services.mcp_service import _get_backend_port
+
+    out["kind"] = "anytool"
+    sn = (server_name or "").strip()
+    out["streamable_http_url"] = (
+        f"http://127.0.0.1:{_get_backend_port()}/api/mcp/anytool/{sn}"
+    )
+    return out


### PR DESCRIPTION
## Changes (this commit)
- `mcp_service`: rewrite AnyTool `streamable_http_url` to current `SAGE_PORT`.
- `mcp_anytool_url` + `chat_service`: align extra MCP AnyTool URLs without touching sagents.
- Runtime patch: fix `agent_abilities_user_prompt` (zh/en/pt) to require `{"items": [...]}` vs bare array.
- Lifecycle: apply patch at desktop/server startup.

## Note
Branch may include earlier desktop build commits from the same PR branch history.

Made with [Cursor](https://cursor.com)