### PR TITLE
Desktop: PyInstaller spec in repo, CI/workflow fixes, Windows build, docs

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -99,7 +99,8 @@ jobs:
             ~/.cache/pip
             ~/Library/Caches/pip
             ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-pip-${{ hashFiles('app/desktop/core/requirements.txt') }}
+          # 与 build.sh / build_windows.ps1 一致：根目录 requirements.txt
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+# 桌面侧车 spec 为仓库内唯一真源，必须提交；否则 CI 报 Spec file not found
+!app/desktop/sage-desktop.spec
 
 # Installer logs
 pip-log.txt

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-<div align="center">
+
 
 # 🌟 **Experience Sage's Power**
 
-![cover](assets/cover.png)
+cover
 
-[![English](https://img.shields.io/badge/Language-English-blue.svg)](README.md)
-[![简体中文](https://img.shields.io/badge/语言-简体中文-red.svg)](README_CN.md)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?logo=opensourceinitiative)](LICENSE)
-[![Python 3.10+](https://img.shields.io/badge/Python-3.10%2B-blue.svg?logo=python)](https://python.org)
-[![Version](https://img.shields.io/badge/Version-1.1.0-green.svg)](https://github.com/ZHangZHengEric/Sage)
-[![DeepWiki](https://img.shields.io/badge/DeepWiki-Learn%20More-purple.svg)](https://deepwiki.com/ZHangZHengEric/Sage)
-[![Slack](https://img.shields.io/badge/Slack-Join%20Community-4A154B?logo=slack)](https://join.slack.com/t/sage-b021145/shared_invite/zt-3t8nabs6c-qCEDzNUYtMblPshQTKSWOA)
+[English](README.md)
+[简体中文](README_CN.md)
+[License: MIT](LICENSE)
+[Python 3.10+](https://python.org)
+[Version](https://github.com/ZHangZHengEric/Sage)
+[DeepWiki](https://deepwiki.com/ZHangZHengEric/Sage)
+[Slack](https://join.slack.com/t/sage-b021145/shared_invite/zt-3t8nabs6c-qCEDzNUYtMblPshQTKSWOA)
 
 # 🧠 **Sage Agent Platform**
 
@@ -18,32 +18,21 @@
 
 > 🌟 **A production-ready agent platform for task execution, automation, browser workflows, IM delivery, and enterprise deployment.**
 
-</div>
+
 
 ---
 
 ## 📸 **Product Screenshots**
 
-<div align="center">
 
-<table>
-  <tr>
-    <td align="center" width="33%">
-      <img src="assets/screenshots/workbench.png" width="100%" alt="Workbench"/>
-      <br/><strong>Visual Workbench</strong>
-    </td>
-    <td align="center" width="33%">
-      <img src="assets/screenshots/chat.png" width="100%" alt="Chat"/>
-      <br/><strong>Real-time Collaboration</strong>
-    </td>
-    <td align="center" width="33%">
-      <img src="assets/screenshots/preview.png" width="100%" alt="Preview"/>
-      <br/><strong>Multi-format Support</strong>
-    </td>
-  </tr>
-</table>
 
-</div>
+
+|                      |                             |                          |
+| -------------------- | --------------------------- | ------------------------ |
+| **Visual Workbench** | **Real-time Collaboration** | **Multi-format Support** |
+
+
+
 
 > 📖 **Detailed Documentation**: [https://wiki.sage.zavixai.com/](https://wiki.sage.zavixai.com/)
 
@@ -64,69 +53,33 @@
 
 ## 🚀 **Quick Start**
 
-### Installation
+**Prerequisites (web from source):** Python 3.10+, Node.js 18+.
+
+### Web (clone and run)
 
 ```bash
 git clone https://github.com/ZHangZHengEric/Sage.git
 cd Sage
-```
-
-### Running Sage
-
-**Option 1: One-Command Startup (Recommended for Development)**
-
-```bash
-# 1. Optional: activate your environment first
-# conda activate your-env
-
-# 2. Set your LLM API Key
 export SAGE_DEFAULT_LLM_API_KEY="your-api-key"
 export SAGE_DEFAULT_LLM_API_BASE_URL="https://api.deepseek.com/v1"
 export SAGE_DEFAULT_LLM_MODEL_NAME="deepseek-chat"
-
-# 3. Run the startup script
 ./scripts/dev-up.sh
 ```
 
-The script will automatically:
-- Check Python (>= 3.10) and Node.js (>= 18) versions
-- Create configuration files (minimal mode: SQLite, no external dependencies)
-- Install dependencies and start both backend and frontend services
-- Create `logs/server.log` automatically
-- Honor `SAGE_PORT` from `.env` for backend startup and health checks
+Open [http://localhost:5173](http://localhost:5173). The first run may ask for **Minimal** (SQLite) vs **Full** stacks — Minimal is the quickest. Optional: `PYTHON_BIN=...` or `USE_UV=1 ./scripts/dev-up.sh` if you use a custom Python or [uv](https://github.com/astral-sh/uv).
 
-Optional overrides:
+**Detailed documentation:** [Web Application](docs/en/applications/WEB.md) — manual backend + Vite, Docker Compose, and port notes.
 
-```bash
-# Explicitly choose a Python executable
-PYTHON_BIN=/path/to/python ./scripts/dev-up.sh
+### Desktop (installers)
 
-# Use uv instead of python -m pip / python -m ...
-USE_UV=1 ./scripts/dev-up.sh
-```
-
-**First time?** The script will prompt you to choose between:
-- **Minimal mode**: SQLite, no external dependencies (recommended for quick start)
-- **Full mode**: MySQL + Elasticsearch + RustFS (for production-like environment)
-
-After starting, open: http://localhost:5173
-
-**Option 2: Desktop Application (Recommended for Users)**
-
-Download the latest desktop package from [GitHub Releases](https://github.com/ZHangZHengEric/Sage/releases):
-- **macOS**: `.dmg` (Intel & Apple Silicon)
-- **Windows**: `.exe` / `.msi`
-- **Linux**: `.deb` (x86_64 / arm64)
-
-#### Desktop Installation Guide
+Download the latest `.dmg` (macOS), `.exe` / `.msi` (Windows), or `.deb` (Linux) from [GitHub Releases](https://github.com/ZHangZHengEric/Sage/releases), then install as below.
 
 **macOS**
 
-1. Download the `.dmg` for your CPU architecture and open it.
-2. Drag `Sage.app` into the `Applications` folder.
-3. The current macOS build is not yet signed/notarized by Apple. If you see a warning that the developer cannot be verified or Apple cannot check the app for malicious software, open `Applications`, right-click `Sage.app`, choose `Open`, and then click `Open` again in the dialog.
-4. If macOS still blocks the app, go to `System Settings -> Privacy & Security`, find the Sage warning near the bottom, and click `Open Anyway`.
-5. If macOS says the app is damaged or still refuses to launch, run the following command and try again:
+1. Open the `.dmg` for your CPU (Intel or Apple Silicon), drag **Sage.app** into **Applications**.
+2. The build is **not** currently Apple-notarized. If macOS says the developer cannot be verified or the app cannot be checked for malware: in **Finder → Applications**, **right‑click** `Sage.app` → **Open**, then confirm **Open** in the dialog (this adds a one-time exception for Gatekeeper).
+3. If it is still blocked: **System Settings → Privacy & Security**, scroll to the message about Sage, click **Open Anyway**, then try opening the app again.
+4. If macOS reports the app is **damaged** or will not open, clear the quarantine flag and retry:
 
 ```bash
 xattr -dr com.apple.quarantine /Applications/Sage.app
@@ -134,113 +87,48 @@ xattr -dr com.apple.quarantine /Applications/Sage.app
 
 **Windows**
 
-1. Download the `.exe` installer and run it.
-2. Follow the setup wizard to finish installation.
-3. If Windows SmartScreen shows a warning, click `More info` -> `Run anyway`.
+1. Run the `.exe` installer and complete the wizard.
+2. If **Windows SmartScreen** warns about an unknown publisher, click **More info** → **Run anyway** (wording may vary by Windows version).
 
-**Linux**
+**Linux (Debian / Ubuntu)**
 
-1. Download the `.deb` package for your architecture from [GitHub Releases](https://github.com/ZHangZHengEric/Sage/releases).
-2. On Debian/Ubuntu, you can install it directly by double-clicking it, or by running:
+1. Download the `.deb` for your architecture from Releases.
+2. Install from a terminal (adjust the filename):
 
 ```bash
 sudo apt install ./Sage-<version>-<arch>.deb
 ```
 
-If you prefer to build the desktop app from source, use the commands below.
+You can also double-click the `.deb` in many desktop environments.
+
+**Detailed documentation:** [Desktop Application](docs/en/applications/DESKTOP.md) — build from source, env, and platform notes.
+
+### CLI
 
 ```bash
-# macOS/Linux
-app/desktop/scripts/build.sh release
-
-# Windows
-./app/desktop/scripts/build_windows.ps1 release
-```
-
-**Command Line Interface (CLI)**:
-```bash
-# Install editable package
 pip install -e .
-
-# Configure the minimum runtime variables
 export SAGE_DEFAULT_LLM_API_KEY="your-api-key"
 export SAGE_DEFAULT_LLM_API_BASE_URL="https://api.deepseek.com/v1"
 export SAGE_DEFAULT_LLM_MODEL_NAME="deepseek-chat"
 export SAGE_DB_TYPE="file"
-
-# Diagnose local runtime config
 sage doctor
-
-# Create a shared local CLI/Desktop config in ~/.sage/.sage_env if needed
-sage config init
-
-# Run a quick task
-sage run --stats "Say hello briefly."
-
-# Start an interactive chat session
-sage chat
+sage run "Say hello briefly."
+# or: sage chat
 ```
 
-Detailed CLI usage is documented here:
-- English: [docs/en/applications/CLI.md](docs/en/applications/CLI.md)
-- 中文: [docs/zh/applications/CLI.md](docs/zh/applications/CLI.md)
+**Detailed documentation:** [CLI Guide](docs/en/applications/CLI.md)
 
-The CLI now defaults to the same local data root as desktop: `~/.sage/`.
-By default it reads `~/.sage/.sage_env` first, and then lets a repository-local `.env` override it for development.
-When `--json` is enabled, the CLI emits stream events and appends a final `cli_stats` event for structured post-run inspection.
+### TUI
 
-**Terminal UI (TUI preview)**:
+After `pip install -e .` and the same `SAGE_DEFAULT_*` + `SAGE_DB_TYPE=file` as above, use `sage-terminal` (or run from `app/terminal/` with `cargo` — see the guide).
 
-```bash
-# Make the local Sage CLI/backend available first
-pip install -e .
+**Detailed documentation:** [TUI Guide](docs/en/applications/TUI.md)
 
-# Configure the same minimum local runtime
-export SAGE_DEFAULT_LLM_API_KEY="your-api-key"
-export SAGE_DEFAULT_LLM_API_BASE_URL="https://api.deepseek.com/v1"
-export SAGE_DEFAULT_LLM_MODEL_NAME="deepseek-chat"
-export SAGE_DB_TYPE="file"
+### Chrome extension
 
-# Run the Rust TUI from source
-cargo run --quiet --offline --manifest-path app/terminal/Cargo.toml
-```
+Load the unpacked extension from `app/chrome-extension/` in `chrome://extensions/` (Developer mode). Point the extension at your local Sage backend if the port differs from defaults.
 
-Current startup forms:
-
-```bash
-sage-terminal
-sage-terminal run "inspect this repo"
-sage-terminal chat "hello"
-sage-terminal config init
-sage-terminal config init /tmp/.sage_env --force
-sage-terminal doctor
-sage-terminal doctor probe-provider
-sage-terminal provider verify
-sage-terminal provider verify model=deepseek-chat base=https://api.deepseek.com/v1
-sage-terminal sessions
-sage-terminal sessions 25
-sage-terminal sessions inspect latest
-sage-terminal sessions inspect <session_id>
-sage-terminal resume
-sage-terminal resume latest
-sage-terminal resume <session_id>
-```
-
-Detailed TUI usage is documented here:
-- English: [docs/en/applications/TUI.md](docs/en/applications/TUI.md)
-- 中文: [docs/zh/applications/TUI.md](docs/zh/applications/TUI.md)
-
-**Web Application (FastAPI + Vue3)**:
-
-```bash
-# Start backend
-python -m app.server.main
-
-# Start frontend (in another terminal)
-cd app/server/web
-npm install
-npm run dev
-```
+**Detailed documentation:** [Chrome extension](docs/en/applications/CHROME_EXTENSION.md)
 
 ---
 
@@ -363,53 +251,36 @@ We welcome contributions! Please see our [GitHub Issues](https://github.com/ZHan
 
 ## 💖 **Sponsors**
 
-<div align="center">
+
 
 We are grateful to our sponsors for their support in making Sage better:
 
-<table>
-  <tr>
-    <td align="center" width="33%">
-      <a href="#" target="_blank">
-        <img src="assets/sponsors/dudubashi_logo.png" height="50" alt="Dudu Bus"/>
-      </a>
-      <br/>
-    </td>
-    <td align="center" width="33%">
-      <a href="#" target="_blank">
-        <img src="assets/sponsors/xunhuanzhineng_logo.svg" height="50" alt="RcrAI"/>
-      </a>
-    </td>
-    <td align="center" width="33%">
-      <a href="#" target="_blank">
-        <img src="assets/sponsors/idata_logo.png" height="50" alt="Data"/>
-      </a>
-    </td>
-  </tr>
-</table>
 
-</div>
+|     |     |     |
+| --- | --- | --- |
+|     |     |     |
+
+
+
 
 ---
 
 ## 🦌 **Join Our Community**
 
-<div align="center">
+
 
 ### 💬 Connect with us
 
-[![Slack](https://img.shields.io/badge/Slack-Join%20Community-4A154B?logo=slack&style=for-the-badge)](https://join.slack.com/t/sage-b021145/shared_invite/zt-3t8nabs6c-qCEDzNUYtMblPshQTKSWOA)
+[Slack](https://join.slack.com/t/sage-b021145/shared_invite/zt-3t8nabs6c-qCEDzNUYtMblPshQTKSWOA)
 
 ### 📱 WeChat Group
 
-<img src="assets/WeChatGroup.jpg" width="300" alt="WeChat Group QR Code"/>
+
 
 *Scan to join our WeChat community 🦌*
 
-</div>
+
 
 ---
 
-<div align="center">
 Built with ❤️ by the Sage Team 🦌
-</div>

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,16 +1,14 @@
-<div align="center">
-
 # 🌟 **体验 Sage 的强大能力**
 
-![cover](assets/cover.png)
+cover
 
-[![English](https://img.shields.io/badge/Language-English-blue.svg)](README.md)
-[![简体中文](https://img.shields.io/badge/语言-简体中文-red.svg)](README_CN.md)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?logo=opensourceinitiative)](LICENSE)
-[![Python 3.10+](https://img.shields.io/badge/Python-3.10%2B-blue.svg?logo=python)](https://python.org)
-[![Version](https://img.shields.io/badge/Version-1.1.0-green.svg)](https://github.com/ZHangZHengEric/Sage)
-[![DeepWiki](https://img.shields.io/badge/DeepWiki-查看文档-purple.svg)](https://deepwiki.com/ZHangZHengEric/Sage)
-[![Slack](https://img.shields.io/badge/Slack-加入社区-4A154B?logo=slack)](https://join.slack.com/t/sage-b021145/shared_invite/zt-3t8nabs6c-qCEDzNUYtMblPshQTKSWOA)
+[English](README.md)
+[简体中文](README_CN.md)
+[License: MIT](LICENSE)
+[Python 3.10+](https://python.org)
+[Version](https://github.com/ZHangZHengEric/Sage)
+[DeepWiki](https://deepwiki.com/ZHangZHengEric/Sage)
+[Slack](https://join.slack.com/t/sage-b021145/shared_invite/zt-3t8nabs6c-qCEDzNUYtMblPshQTKSWOA)
 
 # 🧠 **Sage 智能体平台**
 
@@ -18,32 +16,15 @@
 
 > 🌟 **面向任务执行、自动化调度、浏览器工作流、IM 交付与企业部署的生产级智能体平台。**
 
-</div>
-
 ---
 
 ## 📸 **产品截图**
 
-<div align="center">
 
-<table>
-  <tr>
-    <td align="center" width="33%">
-      <img src="assets/screenshots/workbench.png" width="100%" alt="工作台"/>
-      <br/><strong>可视化工作台</strong>
-    </td>
-    <td align="center" width="33%">
-      <img src="assets/screenshots/chat.png" width="100%" alt="对话"/>
-      <br/><strong>实时协作</strong>
-    </td>
-    <td align="center" width="33%">
-      <img src="assets/screenshots/preview.png" width="100%" alt="预览"/>
-      <br/><strong>多格式支持</strong>
-    </td>
-  </tr>
-</table>
+|            |          |           |
+| ---------- | -------- | --------- |
+| **可视化工作台** | **实时协作** | **多格式支持** |
 
-</div>
 
 > 📖 **详细文档**: [https://wiki.sage.zavixai.com/](https://wiki.sage.zavixai.com/)
 
@@ -64,67 +45,33 @@
 
 ## 🚀 **快速开始**
 
-### 安装
+**环境要求（从源码跑 Web）：** Python 3.10+、Node.js 18+。
+
+### Web（克隆后一键启动）
 
 ```bash
 git clone https://github.com/ZHangZHengEric/Sage.git
 cd Sage
-```
-
-### 运行 Sage
-
-**一键启动脚本（推荐本地开发）**：
-
-```bash
-# 1. 可选：先激活你的环境
-# conda activate your-env
-
-# 2. 设置 LLM Key
 export SAGE_DEFAULT_LLM_API_KEY="your-api-key"
 export SAGE_DEFAULT_LLM_API_BASE_URL="https://api.deepseek.com/v1"
 export SAGE_DEFAULT_LLM_MODEL_NAME="deepseek-chat"
-
-# 3. 运行启动脚本
 ./scripts/dev-up.sh
 ```
 
-启动脚本会自动：
-- 检查 Python（>= 3.10）和 Node.js（>= 18）
-- 自动创建配置文件（最小模式默认使用 SQLite）
-- 自动安装依赖并启动后端、前端
-- 自动创建 `logs/server.log`
-- 优先使用 `.env` 中的 `SAGE_PORT`
+浏览器打开 [http://localhost:5173](http://localhost:5173)。首次可能提示**最小模式**（SQLite）与**完整模式**等选择，想最快跑通选最小模式即可。可选：`PYTHON_BIN=...` 或 `USE_UV=1 ./scripts/dev-up.sh` 指定解释器或用 [uv](https://github.com/astral-sh/uv) 装依赖。
 
-可选覆盖方式：
+**详细文档：** [Web 应用](docs/zh/applications/WEB.md)（手工起前后端、Docker Compose 全栈、端口等）
 
-```bash
-# 显式指定 Python
-PYTHON_BIN=/path/to/python ./scripts/dev-up.sh
+### 桌面端（安装包）
 
-# 显式使用 uv
-USE_UV=1 ./scripts/dev-up.sh
-```
-
-首次运行时，脚本会提示你选择：
-- **最小模式**：SQLite、无外部依赖，适合快速开始
-- **完整模式**：MySQL + Elasticsearch + RustFS，适合更接近生产的环境
-
-**桌面应用（推荐）**：
-
-桌面版安装包请前往 [GitHub Releases](https://github.com/ZHangZHengEric/Sage/releases) 下载最新版本：
-- **macOS**: `.dmg` (Intel & Apple Silicon)
-- **Windows**: `.exe` / `.msi`
-- **Linux**: `.deb` (x86_64 / arm64)
-
-#### 桌面版安装指南
+在 [GitHub Releases](https://github.com/ZHangZHengEric/Sage/releases) 下载 `**.dmg`（macOS）**、`**.exe` / `.msi`（Windows）** 或 `**.deb`（Linux）**，按下面安装。
 
 **macOS**
 
-1. 下载对应架构的 `.dmg` 文件并双击打开。
-2. 将 `Sage.app` 拖动到“应用程序”文件夹。
-3. 当前发布包暂未经过 Apple Developer 签名/公证，首次启动如果看到“无法验证开发者”或“Apple 无法检查其是否包含恶意软件”，请在“应用程序”中找到 `Sage.app`，右键选择“打开”，然后在弹窗中再次点击“打开”。
-4. 如果系统仍然拦截，请前往“系统设置 -> 隐私与安全性”，在底部找到 `Sage` 的安全提示后点击“仍要打开”。
-5. 如果 macOS 提示应用“已损坏”或始终无法启动，可在终端执行以下命令后重试：
+1. 打开对应 CPU 架构的 `.dmg`，将 **Sage.app** 拖入 **应用程序**。
+2. 当前安装包**尚未**经 Apple 公证/签名。若提示「无法验证开发者」或「无法检查是否包含恶意软件」：在 **访达 → 应用程序** 中 **右键** `Sage.app` → **打开**，在弹窗中再次点 **打开**（为 Gatekeeper 增加一次性例外）。
+3. 若仍被拦截：**系统设置 → 隐私与安全性**，在页面下方找到与 Sage 相关的提示，点 **仍要打开** 后再启动一次。
+4. 若提示应用**已损坏**或始终无法打开，可在终端清除隔离属性后重试：
 
 ```bash
 xattr -dr com.apple.quarantine /Applications/Sage.app
@@ -132,113 +79,48 @@ xattr -dr com.apple.quarantine /Applications/Sage.app
 
 **Windows**
 
-1. 下载 `.exe` 安装包并双击运行。
-2. 按照安装向导完成安装。
-3. 如果系统弹出 SmartScreen 警告，可点击“更多信息”->“仍要运行”继续安装。
+1. 运行 `.exe` 安装程序并按向导完成安装。
+2. 若出现 **SmartScreen**「已保护你的电脑」等提示，可点 **更多信息** → **仍要运行**（具体文案因系统版本可能略有不同）。
 
-**Linux**
+**Linux（Debian / Ubuntu）**
 
-1. 从 [GitHub Releases](https://github.com/ZHangZHengEric/Sage/releases) 下载对应架构的 `.deb` 安装包。
-2. 在 Debian / Ubuntu 上可直接双击安装，或执行以下命令安装：
+1. 从 Releases 下载对应架构的 `.deb`。
+2. 在终端安装（请按实际文件名替换）：
 
 ```bash
 sudo apt install ./Sage-<version>-<arch>.deb
 ```
 
-如需自行从源码构建桌面版，可使用下面的命令：
+多数桌面环境也可直接双击 `.deb` 安装。
+
+**详细文档：** [桌面应用](docs/zh/applications/DESKTOP.md)（从源码构建、环境变量、各平台说明）
+
+### CLI
 
 ```bash
-# macOS/Linux
-app/desktop/scripts/build.sh release
-
-# Windows
-./app/desktop/scripts/build_windows.ps1 release
-```
-
-**命令行工具 (CLI)**：
-```bash
-# 先安装为可编辑包
 pip install -e .
-
-# 配置最小运行环境变量
 export SAGE_DEFAULT_LLM_API_KEY="your-api-key"
 export SAGE_DEFAULT_LLM_API_BASE_URL="https://api.deepseek.com/v1"
 export SAGE_DEFAULT_LLM_MODEL_NAME="deepseek-chat"
 export SAGE_DB_TYPE="file"
-
-# 检查本地运行环境
 sage doctor
-
-# 在 ~/.sage/.sage_env 生成共享的 CLI/Desktop 最小配置
-sage config init
-
-# 快速执行一次任务
-sage run --stats "用一句话介绍你自己"
-
-# 进入交互式对话
-sage chat
+sage run "用一句话打个招呼"
+# 或: sage chat
 ```
 
-完整 CLI 使用说明请看：
-- English: [docs/en/applications/CLI.md](docs/en/applications/CLI.md)
-- 中文: [docs/zh/applications/CLI.md](docs/zh/applications/CLI.md)
+**详细文档：** [CLI 使用指南](docs/zh/applications/CLI.md)
 
-CLI 现在默认和 desktop 共用 `~/.sage/` 本地数据目录。
-默认会先读取 `~/.sage/.sage_env`，开发时如果仓库内存在 `.env`，则会再用本地 `.env` 覆盖。
-启用 `--json` 时，CLI 会输出流式事件，并在结束时附加一个最终的 `cli_stats` 结构化摘要事件。
+### TUI
 
-**终端 UI（TUI 预览）**：
+先 `pip install -e .` 并设置与上相同的 `SAGE_DEFAULT_`* 与 `SAGE_DB_TYPE=file`，再使用 `sage-terminal`（或按文档从 `app/terminal/` 用 `cargo` 运行）。
 
-```bash
-# 先让本地 Sage CLI/backend 可用
-pip install -e .
+**详细文档：** [TUI 使用指南](docs/zh/applications/TUI.md)
 
-# 配置同一套最小运行环境
-export SAGE_DEFAULT_LLM_API_KEY="your-api-key"
-export SAGE_DEFAULT_LLM_API_BASE_URL="https://api.deepseek.com/v1"
-export SAGE_DEFAULT_LLM_MODEL_NAME="deepseek-chat"
-export SAGE_DB_TYPE="file"
+### Chrome 扩展
 
-# 从源码运行 Rust TUI
-cargo run --quiet --offline --manifest-path app/terminal/Cargo.toml
-```
+在 `chrome://extensions/` 中开启「开发者模式」，**加载已解压的扩展程序**，选择目录 `app/chrome-extension/`。若本机服务端口与默认探测不一致，在扩展中填写后端地址。
 
-当前支持的启动形式：
-
-```bash
-sage-terminal
-sage-terminal run "inspect this repo"
-sage-terminal chat "hello"
-sage-terminal config init
-sage-terminal config init /tmp/.sage_env --force
-sage-terminal doctor
-sage-terminal doctor probe-provider
-sage-terminal provider verify
-sage-terminal provider verify model=deepseek-chat base=https://api.deepseek.com/v1
-sage-terminal sessions
-sage-terminal sessions 25
-sage-terminal sessions inspect latest
-sage-terminal sessions inspect <session_id>
-sage-terminal resume
-sage-terminal resume latest
-sage-terminal resume <session_id>
-```
-
-完整 TUI 使用说明请看：
-- English: [docs/en/applications/TUI.md](docs/en/applications/TUI.md)
-- 中文: [docs/zh/applications/TUI.md](docs/zh/applications/TUI.md)
-
-**Web 应用 (FastAPI + Vue3)**：
-
-```bash
-# 启动后端
-python -m app.server.main
-
-# 启动前端（在另一个终端）
-cd app/server/web
-npm install
-npm run dev
-```
+**详细文档：** [Chrome 扩展](docs/zh/applications/CHROME_EXTENSION.md)
 
 ---
 
@@ -296,6 +178,8 @@ graph TD
         Runtime -.-> Obs["👁️ 可观测性<br/>OpenTelemetry"]
     end
 ```
+
+
 
 ---
 
@@ -361,53 +245,26 @@ Sage/
 
 ## 💖 **赞助者**
 
-<div align="center">
-
 感谢以下赞助者对 Sage 的支持：
 
-<table>
-  <tr>
-    <td align="center" width="33%">
-      <a href="#" target="_blank">
-        <img src="assets/sponsors/dudubashi_logo.png" height="50" alt="嘟嘟巴士"/>
-      </a>
-      <br/>
-    </td>
-    <td align="center" width="33%">
-      <a href="#" target="_blank">
-        <img src="assets/sponsors/xunhuanzhineng_logo.svg" height="50" alt="循环智能"/>
-      </a>
-    </td>
-    <td align="center" width="33%">
-      <a href="#" target="_blank">
-        <img src="assets/sponsors/idata_logo.png" height="50" alt="Data"/>
-      </a>
-    </td>
-  </tr>
-</table>
 
-</div>
+|     |     |     |
+| --- | --- | --- |
+|     |     |     |
+
 
 ---
 
 ## 🦌 **加入我们的社区**
 
-<div align="center">
-
 ### 💬 与我们交流
 
-[![Slack](https://img.shields.io/badge/Slack-加入社区-4A154B?logo=slack&style=for-the-badge)](https://join.slack.com/t/sage-b021145/shared_invite/zt-3t8nabs6c-qCEDzNUYtMblPshQTKSWOA)
+[Slack](https://join.slack.com/t/sage-b021145/shared_invite/zt-3t8nabs6c-qCEDzNUYtMblPshQTKSWOA)
 
 ### 📱 微信群
 
-<img src="assets/WeChatGroup.jpg" width="300" alt="微信群二维码"/>
-
 *扫码加入我们的微信社区 🦌*
-
-</div>
 
 ---
 
-<div align="center">
 Built with ❤️ by the Sage Team 🦌
-</div>

--- a/app/desktop/sage-desktop.spec
+++ b/app/desktop/sage-desktop.spec
@@ -1,0 +1,128 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""
+PyInstaller spec for the Sage desktop sidecar.
+
+This file is the single source of truth for the PyInstaller bundle.
+`app/desktop/scripts/build.sh` invokes `pyinstaller sage-desktop.spec`
+instead of passing CLI flags. Behaviour is parameterised via env vars:
+
+  SAGE_PYI_MODE     release | debug  (default: release)
+                      release => strip=True; on Windows, sidecar EXE is built
+                        without a console (no black terminal window)
+                      debug   => strip=False; on Windows, console is kept for logs
+"""
+
+import os
+import sys
+
+from PyInstaller.utils.hooks import collect_all, collect_submodules
+
+
+# --- mode ---
+_MODE = os.environ.get("SAGE_PYI_MODE", "release").lower()
+_STRIP = _MODE == "release"
+# Windows: release sidecar should not pop a console when Tauri spawns it; debug keeps one.
+# macOS/Linux: unchanged (stdio/Tauri behavior; no extra terminal window in typical use).
+_IS_WIN = sys.platform == "win32"
+if _IS_WIN:
+    _CONSOLE = _MODE != "release"
+else:
+    _CONSOLE = True
+
+
+# --- collect deps that PyInstaller cannot trace statically ---
+datas = []
+binaries = []
+
+# `sagents.tool.impl.__init__` uses lazy `__getattr__` for tool modules,
+# so the static tracer never reaches the @tool decorators. Collect the
+# whole `sagents` tree so every tool/skill module ends up in the PYZ.
+hiddenimports = [
+    "aiosqlite",
+    "greenlet",
+    "sqlalchemy.dialects.sqlite.aiosqlite",
+    "certifi",
+    "croniter",
+    "scrapling",
+    "scrapling.fetchers",
+    "apify_fingerprint_datapoints",
+    "browserforge",
+    "undetected_playwright",
+]
+hiddenimports += collect_submodules("sagents")
+hiddenimports += collect_submodules("sagents.tool.impl")
+hiddenimports += collect_submodules("sagents.skill")
+
+for _pkg in (
+    "certifi",
+    "croniter",
+    "scrapling",
+    "apify_fingerprint_datapoints",
+    "browserforge",
+    "undetected_playwright",
+):
+    _datas, _bins, _hidden = collect_all(_pkg)
+    datas += _datas
+    binaries += _bins
+    hiddenimports += _hidden
+
+
+# Modules safe to drop to keep the bundle small. `distutils` intentionally
+# kept (excluding it breaks undetected_playwright on some versions).
+excludes = [
+    # browserforge ships an injector that is incompatible with the version
+    # of undetected_playwright we vendor; let our own copy win.
+    "browserforge.injectors.undetected_playwright",
+    "tkinter",
+    "unittest",
+    "email.test",
+    "test",
+    "tests",
+    "setuptools",
+    "xmlrpc",
+    "IPython",
+    "notebook",
+]
+
+
+a = Analysis(
+    ["entry.py"],
+    pathex=[],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=excludes,
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="sage-desktop",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=_STRIP,
+    upx=False,
+    console=_CONSOLE,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=_STRIP,
+    upx=False,
+    upx_exclude=[],
+    name="sage-desktop",
+)

--- a/app/desktop/scripts/build_windows.ps1
+++ b/app/desktop/scripts/build_windows.ps1
@@ -133,9 +133,9 @@ function Install-PythonDeps {
 Install-PythonDeps -RootDirParam $RootDir -CacheDirParam $CacheDir -EnvNameParam $EnvName
 
 function Build-PythonSidecar {
-    param($DistDirParam, $TauriSidecarDirParam, $AppDirParam, $RootDirParam, $ModeParam)
+    param($DistDirParam, $TauriSidecarDirParam, $AppDirParam, $RootDirParam, $ModeParam, $CacheDirParam)
 
-    Write-Host "[Sidecar] Building Python Sidecar..." -ForegroundColor Cyan
+    Write-Host "[Sidecar] Building Python Sidecar (sage-desktop.spec)..." -ForegroundColor Cyan
 
     if ($ModeParam -eq "release") {
         if (Test-Path $DistDirParam) {
@@ -147,54 +147,29 @@ function Build-PythonSidecar {
     }
 
     $env:PYINSTALLER_CONFIG_DIR = Join-Path $RootDirParam ".pyinstaller"
-    $pyPath = "$RootDirParam;$env:PYTHONPATH"
-    $env:PYTHONPATH = $pyPath
+    $env:PYTHONPATH = "$RootDirParam;$($env:PYTHONPATH)"
+    $env:SAGE_PYI_MODE = if ($ModeParam -eq "release") { "release" } else { "debug" }
 
     Set-Location $AppDirParam
 
-    $PyiFlags = @(
+    $workPath = Join-Path $CacheDirParam "pyi-work"
+    if (-not (Test-Path $workPath)) {
+        New-Item -ItemType Directory -Force -Path $workPath | Out-Null
+    }
+    $specPath = Join-Path $AppDirParam "sage-desktop.spec"
+
+    $pyiArgs = @(
         "--noconfirm",
-        "--onedir",
         "--log-level=WARN",
-        "--name", "sage-desktop",
-        "--windowed",
-        "--hidden-import=aiosqlite",
-        "--hidden-import=greenlet",
-        "--hidden-import=sqlalchemy.dialects.sqlite.aiosqlite",
-        # Scrapling and its dependencies for web fetching
-        "--hidden-import=scrapling",
-        "--hidden-import=scrapling.fetchers",
-        "--hidden-import=apify_fingerprint_datapoints",
-        "--hidden-import=browserforge",
-        "--collect-all=scrapling",
-        "--collect-all=apify_fingerprint_datapoints",
-        "--collect-all=browserforge",
-        "--exclude-module=tkinter",
-        "--exclude-module=unittest",
-        "--exclude-module=email.test",
-        "--exclude-module=test",
-        "--exclude-module=tests",
-        "--exclude-module=distutils",
-        "--exclude-module=setuptools",
-        "--exclude-module=xmlrpc",
-        "--exclude-module=IPython",
-        "--exclude-module=notebook"
+        "--distpath", $DistDirParam,
+        "--workpath", $workPath
     )
-
     if ($ModeParam -eq "release") {
-        $PyiFlags += "--noupx"
-        $PyiFlags += "--clean"
+        $pyiArgs += "--clean"
     }
+    $pyiArgs += $specPath
 
-    $entryPath = Join-Path $AppDirParam "entry.py"
-    $pyinstallerCmd = "pyinstaller"
-    foreach ($flag in $PyiFlags) {
-        $pyinstallerCmd += " $flag"
-    }
-    $pyinstallerCmd += " $entryPath"
-
-    Invoke-Expression $pyinstallerCmd
-
+    & pyinstaller @pyiArgs
     if ($LASTEXITCODE -ne 0) {
         Write-Host "[ERROR] PyInstaller build failed" -ForegroundColor Red
         exit 1
@@ -205,7 +180,7 @@ function Build-PythonSidecar {
     Get-ChildItem -Path $DistDirParam -Recurse -File -Filter "*.pyc" | Remove-Item -Force -ErrorAction SilentlyContinue
     Get-ChildItem -Path $DistDirParam -Recurse -File -Filter ".DS_Store" | Remove-Item -Force -ErrorAction SilentlyContinue
 
-    Write-Host "[Sidecar] Copying mcp_servers to dist..." -ForegroundColor Cyan
+    Write-Host "[Sidecar] Resolving onedir root for data copies (_internal)..." -ForegroundColor Cyan
     $targetMcpDir = Join-Path $DistDirParam "sage-desktop"
     if (Test-Path (Join-Path $DistDirParam "sage-desktop\_internal")) {
         $targetMcpDir = Join-Path $DistDirParam "sage-desktop\_internal"
@@ -213,6 +188,7 @@ function Build-PythonSidecar {
 
     $mcpServersSrc = Join-Path $RootDirParam "mcp_servers"
     if (Test-Path $mcpServersSrc) {
+        Write-Host "[Sidecar] Copying mcp_servers to dist..." -ForegroundColor Cyan
         Copy-Item -Path $mcpServersSrc -Destination $targetMcpDir -Recurse -Force
         $mcpPath = Join-Path $targetMcpDir "mcp_servers"
         Get-ChildItem -Path $mcpPath -Recurse -Directory -Filter "__pycache__" | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
@@ -220,14 +196,38 @@ function Build-PythonSidecar {
         Get-ChildItem -Path $mcpPath -Recurse -File -Filter ".DS_Store" | Remove-Item -Force -ErrorAction SilentlyContinue
     }
 
-    Write-Host "[Sidecar] Copying skills to dist..." -ForegroundColor Cyan
-    $skillsSrc = Join-Path $RootDirParam "app/skills"
+    $skillsSrc = Join-Path $RootDirParam "app\skills"
     if (Test-Path $skillsSrc) {
+        Write-Host "[Sidecar] Copying skills to dist..." -ForegroundColor Cyan
         Copy-Item -Path $skillsSrc -Destination $targetMcpDir -Recurse -Force
         $skillsPath = Join-Path $targetMcpDir "skills"
         Get-ChildItem -Path $skillsPath -Recurse -Directory -Filter "__pycache__" | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
         Get-ChildItem -Path $skillsPath -Recurse -Directory -Filter ".git" | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
         Get-ChildItem -Path $skillsPath -Recurse -File -Filter ".DS_Store" | Remove-Item -Force -ErrorAction SilentlyContinue
+    }
+
+    $wikiSrc = Join-Path $RootDirParam "app\wiki"
+    if (Test-Path $wikiSrc) {
+        Write-Host "[Sidecar] Copying wiki to dist..." -ForegroundColor Cyan
+        $wikiDst = Join-Path $targetMcpDir "wiki"
+        if (Test-Path $wikiDst) { Remove-Item -Recurse -Force $wikiDst }
+        Copy-Item -Path $wikiSrc -Destination $wikiDst -Recurse -Force
+        Get-ChildItem -Path $wikiDst -Recurse -Directory -Filter "node_modules" -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+        Get-ChildItem -Path $wikiDst -Recurse -Directory -Filter ".vitepress" -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+        Get-ChildItem -Path $wikiDst -Recurse -File -Filter ".DS_Store" -ErrorAction SilentlyContinue | Remove-Item -Force -ErrorAction SilentlyContinue
+    }
+
+    $docsTargetRoot = Join-Path $targetMcpDir "docs"
+    foreach ($lang in @("en", "zh")) {
+        $langSrc = Join-Path $RootDirParam "docs\$lang"
+        if (Test-Path $langSrc) {
+            Write-Host "[Sidecar] Copying docs/$lang to dist..." -ForegroundColor Cyan
+            $langDst = Join-Path $docsTargetRoot $lang
+            New-Item -ItemType Directory -Force -Path $langDst | Out-Null
+            Get-ChildItem -Path $langSrc -Filter "*.md" -File | ForEach-Object {
+                Copy-Item -Path $_.FullName -Destination $langDst -Force
+            }
+        }
     }
 
     Set-Location $RootDirParam
@@ -274,6 +274,7 @@ function Build-Frontend {
         $NewHash | Out-File -FilePath $HashFile -Encoding UTF8
     }
 
+    $env:NODE_OPTIONS = "--max-old-space-size=4096"
     npm run build
     Set-Location $RootDirParam
 }
@@ -345,7 +346,7 @@ function Prepare-BundledNodeRuntime {
 
 Write-Host ">>> Starting build tasks..." -ForegroundColor Cyan
 
-Build-PythonSidecar -DistDirParam $DistDir -TauriSidecarDirParam $TauriSidecarDir -AppDirParam $AppDir -RootDirParam $RootDir -ModeParam $Mode
+Build-PythonSidecar -DistDirParam $DistDir -TauriSidecarDirParam $TauriSidecarDir -AppDirParam $AppDir -RootDirParam $RootDir -ModeParam $Mode -CacheDirParam $CacheDir
 if ($LASTEXITCODE -ne 0) {
     Write-Host "[ERROR] Sidecar build failed!" -ForegroundColor Red
     exit 1

--- a/app/desktop/tauri/tauri.conf.json
+++ b/app/desktop/tauri/tauri.conf.json
@@ -96,7 +96,7 @@
       "digestAlgorithm": "sha256",
       "timestampUrl": "",
       "wix": {
-        "language": "zh-CN",
+        "language": "en-US",
         "dialogImagePath": "icons/icon.png"
       },
       "nsis": {

--- a/change_log.md
+++ b/change_log.md
@@ -1,3 +1,23 @@
+2026-04-28 12:00 修复 CI「sage-desktop.spec not found」：根因是 .gitignore 的 *.spec 忽略未提交该文件；增加 !app/desktop/sage-desktop.spec 例外，需执行 git add app/desktop/sage-desktop.spec 并推送后 Linux/mac/Windows 打包才能找到 spec。
+
+2026-04-27 21:00 GitHub release-desktop workflow：pip 缓存 key 的 hashFiles 从无效的 app/desktop/core/requirements.txt 改为根目录 requirements.txt，与构建脚本实际依赖文件一致、依赖变更时缓存能正确失效。
+
+2026-04-27 20:00 sage-desktop.spec：Windows 在 release 下对侧车使用无控制台 EXE（console=False），避免 Tauri 拉起时出现黑框；SAGE_PYI_MODE=debug 时仍带控制台便于排错；macOS/Linux 行为不变。
+
+2026-04-27 19:30 桌面 Windows：build_windows.ps1 与 build.sh 对齐，PyInstaller 统一走 sage-desktop.spec（SAGE_PYI_MODE、dist/work 路径）；侧车补拷 wiki 与 docs/en、zh；前端构建设 NODE_OPTIONS 防 OOM；tauri Wix 语言改为 en-US 降低 GHA 打包失败率。
+
+2026-04-27 18:00 README / README_CN Quick Start：每种应用单独「详细文档」链到对应 docs 专页，去掉文末「更多」聚合；修正中文桌面段加粗乱码。
+
+2026-04-27 17:00 文档：新增 docs 应用入口下的 WEB（含 docker compose）/ DESKTOP / CHROME_EXTENSION 中英；GETTING 与 applications/README 建索引；README 主链至各专页。
+
+2026-04-27 16:00 README / README_CN 桌面安装包小节扩充：macOS 门闸/右键打开/系统设置仍要打开/xattr；Windows SmartScreen；Linux apt 与从源码构建一句。
+
+2026-04-27 15:00 README / README_CN Quick Start：各入口保留简要安装与用法（环境要求、Web/桌面/CLI/TUI/扩展小节后链文档），避免冗长说明。
+
+2026-04-27 14:20 README / README_CN Quick Start 增补 Web、桌面、CLI、TUI、Chrome 扩展各一行说明，并链到 GETTING_STARTED 与 CLI/TUI 文档。
+
+2026-04-27 14:00 精简 README.md / README_CN.md 的 Quick Start：只保留 clone + 环境变量 + dev-up 与访问地址，详细步骤指向 docs 中 GETTING_STARTED 与 wiki。
+
 2026-04-27 13:10 不修改 sagents/tool_manager：AnyTool 端口由 mcp_service 重写 URL，聊天侧 extra MCP 经 mcp_anytool_url 对齐 SAGE_PORT；英文能力列表「缺少 items」因 prompt 写「JSON 数组」与解析器要 {"items":[]}，于 desktop/server lifecycle 启动时对 PromptManager 做 runtime 文案补丁（zh/en/pt）。
 
 2026-04-27 12:25 修复 AnyTool MCP 502：DB 等存储的 streamable_http_url 残留旧端口与 SAGE_PORT 不一致时，mcp_service 对 kind=anytool 按 _get_backend_port 重写 URL。

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -22,7 +22,7 @@ This site documents the current repository as it exists today. It is organized a
 
 ## Start Here
 
-1. [Applications](applications/README.md) for getting started, CLI, and the main entry points
+1. [Applications](applications/README.md) for getting started, Web (incl. Docker), Desktop, CLI, TUI, and Chrome extension
 2. [Core Concepts](CORE_CONCEPTS.md) for the runtime model
 3. [Architecture](architecture/README.md) for repository and subsystem boundaries
 4. [Configuration](CONFIGURATION.md) for environment variables and deployment knobs
@@ -58,9 +58,12 @@ Read:
 
 ## Documentation Map
 
-- [Applications](applications/README.md): getting started, CLI, demo app, main server, and desktop build
+- [Applications](applications/README.md): getting started, Web, Desktop, CLI, TUI, Chrome extension
   - [Getting Started](applications/GETTING_STARTED.md)
-  - [CLI Guide](applications/CLI.md)
+  - [Web Application](applications/WEB.md) (manual stack + **Docker Compose**)
+  - [Desktop](applications/DESKTOP.md)
+  - [CLI Guide](applications/CLI.md) · [TUI Guide](applications/TUI.md)
+  - [Chrome extension](applications/CHROME_EXTENSION.md)
 - [Core Concepts](CORE_CONCEPTS.md): sessions, agents, tools, skills, flows, and sandboxing
 - [Architecture](architecture/README.md): how the codebase is organized (with sub-chapters)
   - App layer: [Server](architecture/ARCHITECTURE_APP_SERVER.md) · [Desktop](architecture/ARCHITECTURE_APP_DESKTOP.md) · [Other entries](architecture/ARCHITECTURE_APP_OTHERS.md)

--- a/docs/en/applications/CHROME_EXTENSION.md
+++ b/docs/en/applications/CHROME_EXTENSION.md
@@ -1,0 +1,51 @@
+---
+layout: default
+title: Chrome Extension
+parent: Applications
+nav_order: 6
+description: "Load the Sage browser extension and connect it to a local desktop or server backend"
+lang: en
+ref: chrome-extension
+---
+
+{% include lang_switcher.html %}
+
+# Chrome Extension (Browser Bridge)
+
+The **Chrome extension** under `app/chrome-extension/` is a **browser bridge**: it talks to a running Sage **Desktop** (or compatible local API) from the **Side Panel**, sends page context to the agent, and can execute simple browser actions from a command queue.
+
+It is not a replacement for the full **Web** app (`app/server` + browser at port 5173/8080) — it is a **lightweight sidecar** for people who work in Chrome next to a local Sage backend.
+
+**Canonical technical README (repo):** [app/chrome-extension/README.md](https://github.com/ZHangZHengEric/Sage/blob/main/app/chrome-extension/README.md)
+
+## What it does (summary)
+
+- Chat in the **Side Panel** (streams to the backend, e.g. desktop `/api/web-stream` when configured).
+- Detects whether a local Sage service is up before allowing chat.
+- Reports page context: title, URL, selection, short body summary.
+- Polls a **browser command queue** and runs actions in the active tab (navigate, click, fill, script, etc.) when the agent requests them.
+
+## Load unpacked (development)
+
+1. Open `chrome://extensions/`.
+2. Turn on **Developer mode** (top right).
+3. **Load unpacked** and select the directory: `app/chrome-extension` (the folder that contains the extension `manifest`).
+
+## Point it at your backend
+
+By default the extension tries common local URLs, including:
+
+- `http://127.0.0.1:8000` / `http://localhost:8000`
+- `http://127.0.0.1:8080` / `http://localhost:8080`
+
+If your API runs on a different host/port, set it in the **extension popup** and save.
+
+## Use the Side Panel
+
+Click the Sage icon in the toolbar; Chrome opens the **Side Panel** in split view so you can chat while browsing.
+
+## See also
+
+- [Architecture — other app entries](../architecture/ARCHITECTURE_APP_OTHERS.md) (Chrome extension section)
+- [Desktop](DESKTOP.md) — extension is usually used **with** a running desktop backend
+- [Web](WEB.md) — full browser product and Docker/server workflows

--- a/docs/en/applications/DESKTOP.md
+++ b/docs/en/applications/DESKTOP.md
@@ -1,0 +1,78 @@
+---
+
+## layout: default
+title: Desktop Application
+parent: Applications
+nav_order: 5
+description: "Install the Sage desktop app, first-launch on macOS/Windows, and build from source"
+lang: en
+ref: desktop-app
+
+{% include lang_switcher.html %}
+
+# Desktop Application
+
+The **Desktop** app is a Tauri-packaged product: a local HTTP backend on `127.0.0.1` plus a desktop shell UI. It is the best fit for daily **offline-friendly** work on a single machine without running the full `app/server` dev stack in terminals.
+
+
+| Topic                                           | Where                                                                                                                  |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Installers (`.dmg` / `.exe` / `.deb`)           | [GitHub Releases](https://github.com/ZHangZHengEric/Sage/releases)                                                     |
+| Build prerequisites (Rust, Node, Python, Tauri) | [Desktop build & install — detailed](../../../app/desktop/docs/installation.md)                                        |
+| End-user / ops topics                           | [Operations manual](../../../app/desktop/docs/ops_manual.md) · [User manual](../../../app/desktop/docs/user_manual.md) |
+| Architecture                                    | [Desktop app architecture](../architecture/ARCHITECTURE_APP_DESKTOP.md)                                                |
+
+
+## Install from release packages
+
+1. Download the package for your OS from [Releases](https://github.com/ZHangZHengEric/Sage/releases) (e.g. `.dmg` for macOS, `.exe` / `.msi` for Windows, `.deb` for Linux).
+2. Run the installer or drag the app as documented on the download page.
+3. Launch Sage from the Start menu, Applications folder, or app grid.
+
+## macOS: Gatekeeper and “damaged” app
+
+Releases are **not** always Apple-notarized. If you see *cannot be opened because the developer cannot be verified* or *Apple cannot check it for malware*:
+
+1. In **Finder → Applications**, **right-click** `Sage.app` → **Open** → confirm **Open** in the dialog.
+2. If still blocked: **System Settings → Privacy & Security** → find the Sage message → **Open Anyway**, then try again.
+3. If the app is reported as **damaged** or will not start, clear quarantine and retry:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/Sage.app
+```
+
+## Windows: SmartScreen
+
+If **Windows SmartScreen** blocks the installer, use **More info** → **Run anyway** (wording can vary by Windows version).
+
+## Linux: `.deb` install
+
+On Debian / Ubuntu, after downloading the matching `.deb`:
+
+```bash
+sudo apt install ./Sage-<version>-<arch>.deb
+```
+
+Many desktop environments also support double-clicking the package.
+
+## Build from source
+
+From the repository root (see [full steps](../../../app/desktop/docs/installation.md) for environment setup):
+
+```bash
+# macOS / Linux
+app/desktop/scripts/build.sh release
+```
+
+```powershell
+# Windows
+./app/desktop/scripts/build_windows.ps1 release
+```
+
+Artifacts and platform-specific notes are in the [installation guide](../../../app/desktop/docs/installation.md).
+
+## See also
+
+- [Getting Started](GETTING_STARTED.md) — also mentions desktop build at the end
+- [Environment variables — Desktop & install](../ENV_VARS.md#8-desktop--install)
+

--- a/docs/en/applications/GETTING_STARTED.md
+++ b/docs/en/applications/GETTING_STARTED.md
@@ -12,6 +12,8 @@ ref: getting-started
 
 # Getting Started
 
+**Deeper, app-specific quick starts:** [Web (browser + Docker Compose)](WEB.md) · [Desktop](DESKTOP.md) · [CLI](CLI.md) · [TUI](TUI.md) · [Chrome extension](CHROME_EXTENSION.md)
+
 ## One-Command Startup (Recommended)
 
 **Best for:** Local development, quick testing
@@ -74,7 +76,9 @@ The startup script will automatically create these configuration files:
 
 ## Manual Startup (Advanced)
 
-If you need manual control over the startup process, follow these steps.
+The full **Web** stack (manual processes, Vite, and [Docker Compose](WEB.md#docker-compose-full-stack)) is also documented in [Web Application](WEB.md).
+
+If you need manual control over the development startup process, follow these steps.
 
 ### Prerequisites
 
@@ -234,6 +238,8 @@ streamlit run examples/sage_demo.py -- \
 ---
 
 ## Build Desktop App from Source
+
+For installers, first-launch, and a fuller build walkthrough, see [Desktop Application](DESKTOP.md).
 
 ```bash
 app/desktop/scripts/build.sh release

--- a/docs/en/applications/README.md
+++ b/docs/en/applications/README.md
@@ -16,9 +16,12 @@ This section collects the main entry points for using and starting Sage. Read th
 
 ## Current Pages
 
-1. [Getting Started](GETTING_STARTED.md)
-2. [CLI Guide](CLI.md)
-3. [TUI Guide](TUI.md)
+1. [Getting Started](GETTING_STARTED.md) — first clone, `dev-up.sh`, shared config
+2. [Web Application](WEB.md) — Vite + FastAPI, manual split start, **Docker Compose**
+3. [Desktop](DESKTOP.md) — release installers, macOS/Windows first launch, build from source
+4. [CLI Guide](CLI.md)
+5. [TUI Guide](TUI.md)
+6. [Chrome extension](CHROME_EXTENSION.md) — load unpacked, connect to a local API
 
 ## Which Surface Should You Use
 

--- a/docs/en/applications/WEB.md
+++ b/docs/en/applications/WEB.md
@@ -1,0 +1,142 @@
+---
+
+## layout: default
+title: Web Application
+parent: Applications
+nav_order: 4
+description: "Run the browser-based Sage stack: dev script, manual backend + Vite, and Docker Compose"
+lang: en
+ref: web-app
+
+{% include lang_switcher.html %}
+
+# Web Application
+
+The **Web** product is the FastAPI server (`app/server/`) plus the Vue 3 client (`app/server/web/`). Use it when you need the full in-browser experience: auth, agents, tools, knowledge base, and the visual workbench.
+
+
+| Path                                                                 | Best for                                                              |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| [One-command startup](#one-command-startup)                          | Local development (same as [Getting Started](GETTING_STARTED.md))     |
+| [Manual: backend + Vite dev server](#manual-start-backend--frontend) | Split terminals, custom ports, or debugging one side only             |
+| [Docker Compose](#docker-compose-full-stack)                         | Containerized full stack (MySQL, Elasticsearch, RustFS, Jaeger, etc.) |
+
+
+## One-command startup
+
+```bash
+git clone https://github.com/ZHangZHengEric/Sage.git
+cd Sage
+export SAGE_DEFAULT_LLM_API_KEY="your-api-key"
+export SAGE_DEFAULT_LLM_API_BASE_URL="https://api.deepseek.com/v1"
+export SAGE_DEFAULT_LLM_MODEL_NAME="deepseek-chat"
+./scripts/dev-up.sh
+```
+
+After startup (defaults):
+
+- **Web UI (Vite dev):** [http://localhost:5173](http://localhost:5173)
+- **Backend API:** [http://localhost:8080](http://localhost:8080)
+- **Health:** [http://localhost:8080/api/health](http://localhost:8080/api/health)
+
+The script may offer **Minimal** (SQLite) vs **Full** dependencies — choose Minimal for the fastest first run. For generated `.env` layout and env vars, see [Getting Started — Configuration](GETTING_STARTED.md#configuration-files) and [Configuration](../CONFIGURATION.md).
+
+## Manual start: backend + frontend
+
+Use this when you do not use `dev-up.sh` or you want to run processes separately.
+
+1. **Install deps** (from repo root)
+
+```bash
+pip install -r requirements.txt
+cd app/server/web && npm install && cd ../../..
+```
+
+1. **Backend**
+
+```bash
+export SAGE_DEFAULT_LLM_API_KEY="your-api-key"
+# plus other env from .env if needed
+python -m app.server.main
+```
+
+Listens on `0.0.0.0:${SAGE_PORT:-8080}`.
+
+1. **Frontend** (second terminal)
+
+```bash
+cd app/server/web
+npm run dev
+```
+
+1. **Configure the SPA** — see `app/server/web/.env.example` and `VITE_SAGE_API_BASE_URL` (must point at your running API).
+
+## Docker Compose (full stack)
+
+The root `[docker-compose.yml](https://github.com/ZHangZHengEric/Sage/blob/main/docker-compose.yml)` starts a **full** platform profile: `sage-server`, static `sage-web`, optional `sage-wiki`, MySQL, Elasticsearch, RustFS (S3-compatible), and Jaeger. It is intended for **production-like** or integrated demos, not the lightest dev loop (for that, prefer `./scripts/dev-up.sh` in Minimal mode).
+
+**What gets exposed (defaults in the compose file):**
+
+
+| Service       | Host port (typical)          | Notes                                      |
+| ------------- | ---------------------------- | ------------------------------------------ |
+| `sage-server` | 30050 → 8080                 | Primary HTTP API                           |
+| `sage-web`    | 30051 → 80                   | Pre-built web assets behind nginx in image |
+| `sage-wiki`   | 30057 → 80                   | Wiki front-end (depends on API)            |
+| `sage-mysql`  | 30052 → 3306                 |                                            |
+| `sage-es`     | 30053 → 9200                 |                                            |
+| `sage-rustfs` | 30054 (API), 30055 (console) |                                            |
+
+
+### Prerequisites
+
+- Docker with **Compose v2** (`docker compose`)
+- Sufficient host resources (the compose file sets a **16G** memory limit on `sage-server`; adjust in `docker-compose.yml` if needed)
+- A valid `.env` at the **repository root** (Compose reads `env_file: .env`). Copy from `[.env.example](https://github.com/ZHangZHengEric/Sage/blob/main/.env.example)` and set at least **LLM** and **DB/ES/S3**-related variables. The example file is aligned with **in-cluster** hostnames: `sage-mysql`, `sage-es`, `sage-rustfs`, etc.
+
+`SAGE_ROOT` must point to a directory on the host used for **persistent volumes** (MySQL data, `sage-server` sessions/agents/logs, ES data, RustFS data, etc.).
+
+### Run
+
+```bash
+cd /path/to/Sage
+export SAGE_ROOT=/path/to/sage-data   # or e.g. $(pwd)/data
+cp .env.example .env
+# edit .env: SAGE_DEFAULT_LLM_API_KEY, secrets, SAGE_MYSQL_PASSWORD, SAGE_ELASTICSEARCH_PASSWORD, SAGE_S3_* as needed
+docker compose up -d --build
+```
+
+**Logs:**
+
+```bash
+docker compose logs -f sage-server
+docker compose logs -f sage-web
+```
+
+**Health check (API):**
+
+```bash
+curl -sS http://127.0.0.1:30050/api/health
+```
+
+**Open the web UI** — the default example uses a base path (`SAGE_WEB_BASE_PATH`, often `/sage`). With the sample `.env.example` values, try:
+
+- `http://127.0.0.1:30051` (then navigate using your configured base path, e.g. `/sage/`), *or* the exact URL your team documents for the deployed nginx route.
+
+`SAGE_API_BASE_URL` in `.env` must match how the **browser** reaches the API (e.g. `http://127.0.0.1:30050` when developing locally against published ports).
+
+### Stop
+
+```bash
+docker compose down
+```
+
+**Port conflicts:** If another process uses 30050–30057, change the `ports:` mappings in `docker-compose.yml` and update `.env` so API URLs and `SAGE_API_BASE_URL` stay consistent.
+
+## See also
+
+- [Getting Started](GETTING_STARTED.md) — first-run script and config overview
+- [Server architecture](../architecture/ARCHITECTURE_APP_SERVER.md)
+- [Configuration](../CONFIGURATION.md) · [Environment variables](../ENV_VARS.md)
+- [Troubleshooting](../TROUBLESHOOTING.md)
+

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -22,7 +22,7 @@ ref: home
 
 ## 建议先读
 
-1. [应用入口](applications/README.md)：快速开始、CLI 与主应用入口
+1. [应用入口](applications/README.md)：快速开始、Web（含 Docker）、桌面、CLI、TUI 与 Chrome 扩展
 2. [核心概念](CORE_CONCEPTS.md)：运行时模型
 3. [架构](architecture/README.md)：仓库与子系统边界
 4. [配置](CONFIGURATION.md)：环境变量与部署参数
@@ -58,9 +58,12 @@ ref: home
 
 ## 文档地图
 
-- [应用入口](applications/README.md)：快速开始、CLI、示例服务、主服务端与桌面版
+- [应用入口](applications/README.md)：快速开始、Web、桌面、CLI、TUI 与 Chrome 扩展
   - [快速开始](applications/GETTING_STARTED.md)
-  - [CLI 使用指南](applications/CLI.md)
+  - [Web 应用](applications/WEB.md)（手动启动 + **Docker Compose 全栈**）
+  - [桌面应用](applications/DESKTOP.md)
+  - [CLI 使用指南](applications/CLI.md) · [TUI 使用指南](applications/TUI.md)
+  - [Chrome 扩展](applications/CHROME_EXTENSION.md)
 - [核心概念](CORE_CONCEPTS.md)：会话、智能体、工具、技能、流程和沙箱
 - [架构](architecture/README.md)：代码库整体组织方式（含子章节）
   - 应用层：[Server](architecture/ARCHITECTURE_APP_SERVER.md) · [Desktop](architecture/ARCHITECTURE_APP_DESKTOP.md) · [其它入口](architecture/ARCHITECTURE_APP_OTHERS.md)

--- a/docs/zh/applications/CHROME_EXTENSION.md
+++ b/docs/zh/applications/CHROME_EXTENSION.md
@@ -1,0 +1,51 @@
+---
+layout: default
+title: Chrome 扩展
+parent: 应用入口
+nav_order: 6
+description: "加载 Sage 浏览器扩展并连接本地桌面端或服务端"
+lang: zh
+ref: chrome-extension
+---
+
+{% include lang_switcher.html %}
+
+# Chrome 扩展（浏览器桥接）
+
+仓库中 **`app/chrome-extension/`** 下的 **Chrome 扩展** 是**浏览器侧桥接**：在 **侧边栏** 与已运行的 Sage **桌面端**（或兼容的本地 API）通信，把页面上下文交给智能体，并可按命令队列在标签页上执行简单自动化。
+
+它不是完整 **Web 主产品**（`app/server` + 常规浏览器访问）的替代品，而是**在 Chrome 中配合本地 Sage 后端**的轻量入口。
+
+**仓库内技术说明原文：** [app/chrome-extension/README.md](https://github.com/ZHangZHengEric/Sage/blob/main/app/chrome-extension/README.md)
+
+## 能力概述
+
+- 在浏览器 **Side Panel** 中对话（按配置流式连接后端，例如桌面端 `/api/web-stream`）。
+- 在允许对话前检测本地 Sage 服务是否已启动。
+- 上报当前页上下文：标题、URL、选区、正文摘要等。
+- 轮询**浏览器命令队列**，在需要时于当前标签页执行导航、点击、填表、脚本等动作。
+
+## 加载未打包扩展（开发调试用）
+
+1. 打开 `chrome://extensions/`。
+2. 打开右上角**开发者模式**。
+3. 点击**加载已解压的扩展程序**，选择目录：仓库内 **`app/chrome-extension`**（含扩展 `manifest` 的文件夹）。
+
+## 配置后端地址
+
+扩展默认会尝试常见本机地址，包括：
+
+- `http://127.0.0.1:8000` / `http://localhost:8000`
+- `http://127.0.0.1:8080` / `http://localhost:8080`
+
+若你的服务端口或主机不同，在**扩展弹窗**中填写并保存。
+
+## 使用侧边栏
+
+点击工具栏中的 Sage 图标，Chrome 会以分屏方式打开 **Side Panel**，可在浏览网页的同时对话。
+
+## 延伸阅读
+
+- [其它应用入口架构 - Chrome 扩展](../architecture/ARCHITECTURE_APP_OTHERS.md) 中的扩展说明
+- [桌面应用](DESKTOP.md) — 扩展通常与**已启动的桌面端后端**一起使用
+- [Web 应用](WEB.md) — 完整 Web 与 Docker/服务端形态

--- a/docs/zh/applications/DESKTOP.md
+++ b/docs/zh/applications/DESKTOP.md
@@ -1,0 +1,75 @@
+---
+layout: default
+title: 桌面应用
+parent: 应用入口
+nav_order: 5
+description: "安装桌面端、macOS/Windows 首次打开说明，以及从源码构建"
+lang: zh
+ref: desktop-app
+---
+
+{% include lang_switcher.html %}
+
+# 桌面应用
+
+**桌面端** 为 Tauri 打包的本地产品：在 `127.0.0.1` 上起本地 HTTP 服务 + 桌面壳 UI。适合**单机、日常**使用，而无需在终端里长期跑完整 `app/server` 开发栈。
+
+| 内容 | 位置 |
+|------|------|
+| 安装包（`.dmg` / `.exe` / `.deb`） | [GitHub Releases](https://github.com/ZHangZHengEric/Sage/releases) |
+| 构建依赖与步骤（Rust、Node、Python、Tauri 等） | [桌面端安装与构建 — 详细](../../../app/desktop/docs/installation.md) |
+| 使用与运维 | [运维手册](../../../app/desktop/docs/ops_manual.md) · [用户说明](../../../app/desktop/docs/user_manual.md) |
+| 架构 | [桌面应用架构](../architecture/ARCHITECTURE_APP_DESKTOP.md) |
+
+## 使用发行包安装
+
+1. 在 [Releases](https://github.com/ZHangZHengEric/Sage/releases) 下载对应系统安装包（如 macOS 用 `.dmg`，Windows 用 `.exe` / `.msi`，Linux 用 `.deb`）。
+2. 按安装向导或拖拽到「应用程序」等完成安装。
+3. 从开始菜单、启动台或应用程序文件夹启动 Sage。
+
+## macOS：门闸与「已损坏」
+
+发布包**不一定**经过 Apple 公证。若出现「无法打开，因为无法验证开发者」或「无法检查是否包含恶意软件」：
+
+1. 在**访达 → 应用程序**中**右键** `Sage.app` → **打开** → 在弹窗中再点**打开**。
+2. 若仍被拦：**系统设置 → 隐私与安全性** → 找到关于 Sage 的提示 → **仍要打开** 后重试。
+3. 若提示应用**已损坏**或无法启动，可清除隔离后重试：
+
+```bash
+xattr -dr com.apple.quarantine /Applications/Sage.app
+```
+
+## Windows：SmartScreen
+
+若 **SmartScreen** 拦截安装程序，可点**更多信息** → **仍要运行**（不同版本文案可能略有差异）。
+
+## Linux：安装 `.deb`
+
+在 Debian / Ubuntu 上，下载对应架构的 `.deb` 后：
+
+```bash
+sudo apt install ./Sage-<version>-<arch>.deb
+```
+
+多数桌面环境也支持直接双击安装。
+
+## 从源码构建
+
+在仓库根目录（完整环境与依赖见 [安装指南](../../../app/desktop/docs/installation.md)）：
+
+```bash
+# macOS / Linux
+app/desktop/scripts/build.sh release
+```
+
+```powershell
+# Windows
+./app/desktop/scripts/build_windows.ps1 release
+```
+
+产物路径与各平台注意点以 [安装指南](../../../app/desktop/docs/installation.md) 为准。
+
+## 延伸阅读
+
+- [快速开始](GETTING_STARTED.md) — 文末亦含桌面构建说明
+- [环境变量 — 与桌面/安装相关](../ENV_VARS.md#8-桌面端--安装期)

--- a/docs/zh/applications/GETTING_STARTED.md
+++ b/docs/zh/applications/GETTING_STARTED.md
@@ -12,6 +12,8 @@ ref: getting-started
 
 # 快速开始
 
+**分入口专题：** [Web（浏览器 + Docker Compose）](WEB.md) · [桌面](DESKTOP.md) · [CLI](CLI.md) · [TUI](TUI.md) · [Chrome 扩展](CHROME_EXTENSION.md)
+
 ## 一键启动（推荐）
 
 **适用场景：** 本地开发、快速体验
@@ -74,7 +76,9 @@ export SAGE_DEFAULT_LLM_MODEL_NAME="deepseek-chat"
 
 ## 手动启动（进阶）
 
-如果你需要手动控制启动流程，可以参考以下步骤。
+**Web 专题**（含仅手动起前后端、[Docker Compose 全栈](WEB.md#docker-compose-全栈)）见 [Web 应用](WEB.md)。
+
+如果你需要按步骤手动控制开发环境启动，可参考以下步骤。
 
 ### 前置条件
 
@@ -177,6 +181,8 @@ npm run dev
 ---
 
 ## 桌面版构建
+
+安装包、首次打开、完整构建说明见 [桌面应用](DESKTOP.md)。
 
 从源码构建桌面应用时，可使用：
 

--- a/docs/zh/applications/README.md
+++ b/docs/zh/applications/README.md
@@ -16,9 +16,12 @@ ref: applications
 
 ## 当前文档
 
-1. [快速开始](GETTING_STARTED.md)
-2. [CLI 使用指南](CLI.md)
-3. [TUI 使用指南](TUI.md)
+1. [快速开始](GETTING_STARTED.md) — 克隆、一键脚本、公共配置
+2. [Web 应用](WEB.md) — 前后端、手动启动、**Docker Compose 全栈**
+3. [桌面应用](DESKTOP.md) — 安装包、macOS/Windows 首次打开、从源码构建
+4. [CLI 使用指南](CLI.md)
+5. [TUI 使用指南](TUI.md)
+6. [Chrome 扩展](CHROME_EXTENSION.md) — 加载未打包、连接本地服务
 
 ## 该选哪个入口
 

--- a/docs/zh/applications/WEB.md
+++ b/docs/zh/applications/WEB.md
@@ -1,0 +1,135 @@
+---
+layout: default
+title: Web 应用
+parent: 应用入口
+nav_order: 4
+description: "浏览器端 Sage：一键脚本、手动前后端、Docker Compose 全栈"
+lang: zh
+ref: web-app
+---
+
+{% include lang_switcher.html %}
+
+# Web 应用
+
+**Web** 指 FastAPI 服务端（`app/server/`）与 Vue 3 前端（`app/server/web/`）组成的主产品，在浏览器中提供完整能力（认证、智能体、工具、知识库、工作台等）。
+
+| 方式 | 适用场景 |
+|------|----------|
+| [一键启动](#一键启动) | 本地开发、最快上手（同 [快速开始](GETTING_STARTED.md)） |
+| [手动：后端 + Vite](#手动启动前后端) | 分终端、固定端口、只调试一侧 |
+| [Docker Compose](#docker-compose-全栈) | 容器化全栈（MySQL、ES、RustFS、Jaeger 等） |
+
+## 一键启动
+
+```bash
+git clone https://github.com/ZHangZHengEric/Sage.git
+cd Sage
+export SAGE_DEFAULT_LLM_API_KEY="your-api-key"
+export SAGE_DEFAULT_LLM_API_BASE_URL="https://api.deepseek.com/v1"
+export SAGE_DEFAULT_LLM_MODEL_NAME="deepseek-chat"
+./scripts/dev-up.sh
+```
+
+启动后（默认）：
+
+- **Web 界面（Vite 开发服）：** http://localhost:5173
+- **后端 API：** http://localhost:8080
+- **健康检查：** http://localhost:8080/api/health
+
+脚本可能提示 **最小模式**（SQLite）与 **完整依赖** 等，首次想最快跑通选最小模式。配置文件与变量说明见 [快速开始 - 配置说明](GETTING_STARTED.md#配置文件说明) 与 [配置说明](../CONFIGURATION.md)。
+
+## 手动启动：前后端
+
+在不想用 `dev-up.sh` 或需要分进程启动时使用。
+
+1. **安装依赖**（在仓库根目录）
+
+```bash
+pip install -r requirements.txt
+cd app/server/web && npm install && cd ../../..
+```
+
+2. **启动后端**
+
+```bash
+export SAGE_DEFAULT_LLM_API_KEY="your-api-key"
+# 其它变量见根目录 .env
+python -m app.server.main
+```
+
+默认监听 `0.0.0.0:${SAGE_PORT:-8080}`。
+
+3. **启动前端**（另开终端）
+
+```bash
+cd app/server/web
+npm run dev
+```
+
+4. **前端环境变量** — 见 `app/server/web/.env.example`，`VITE_SAGE_API_BASE_URL` 需指向已启动的后端地址。
+
+## Docker Compose 全栈
+
+仓库根目录 [`docker-compose.yml`](https://github.com/ZHangZHengEric/Sage/blob/main/docker-compose.yml) 会拉起 **完整** 依赖：`sage-server`、静态资源 `sage-web`、可选 `sage-wiki`，以及 MySQL、Elasticsearch、RustFS（S3 兼容）、Jaeger 等。偏 **类生产/整合演示**；若只是一般本地开发，更轻量的是「一键脚本 + 最小模式」。
+
+**与 compose 中常见端口（映射到宿主机）对应关系：**
+
+| 服务 | 宿主机端口（典型） | 说明 |
+|------|------------------|------|
+| `sage-server` | 30050 → 容器 8080 | 主 HTTP API |
+| `sage-web` | 30051 → 80 | 构建后的 Web 静态资源（镜像内 nginx） |
+| `sage-wiki` | 30057 → 80 | Wiki 前端（依赖 API） |
+| `sage-mysql` | 30052 → 3306 | |
+| `sage-es` | 30053 → 9200 | |
+| `sage-rustfs` | 30054 / 30055 | 对象存储 API / 控制台 |
+
+### 前置条件
+
+- 已安装 **Docker** 与 **Compose v2**（`docker compose`）
+- 宿主机资源充足（`docker-compose.yml` 中对 `sage-server` 等设了较大内存限制，可按需调小）
+- 在仓库根目录提供 **`.env`**（`docker compose` 使用 `env_file: .env`）。可复制 [`.env.example`](https://github.com/ZHangZHengEric/Sage/blob/main/.env.example) 后修改，至少配置 **LLM** 与 **数据库/ES/对象存储** 等；示例中服务主机名为集群内名：`sage-mysql`、`sage-es`、`sage-rustfs` 等。
+
+`SAGE_ROOT` 指向宿主机上用于**持久化卷**的目录（MySQL 数据、会话/日志、ES 数据、RustFS 等）。
+
+### 启动
+
+```bash
+cd /path/to/Sage
+export SAGE_ROOT=/path/to/sage-data   # 或例如 $(pwd)/data
+cp .env.example .env
+# 编辑 .env：SAGE_DEFAULT_LLM_API_KEY、各类密码、SAGE_MYSQL_PASSWORD、SAGE_ELASTICSEARCH_PASSWORD、SAGE_S3_* 等
+docker compose up -d --build
+```
+
+**查看日志：**
+
+```bash
+docker compose logs -f sage-server
+docker compose logs -f sage-web
+```
+
+**健康检查：**
+
+```bash
+curl -sS http://127.0.0.1:30050/api/health
+```
+
+**访问 Web** — 默认示例里常有 **基础路径**（`SAGE_WEB_BASE_PATH`，例如 `/sage`）。在示例 `.env` 下可尝试在浏览器打开 `http://127.0.0.1:30051` 并按你配置的路径（如 `/sage/`）进入；以团队实际部署的 nginx 路由为准。
+
+`.env` 中的 `SAGE_API_BASE_URL` 需与浏览器能访问到的 **API 根地址** 一致（本地映射端口时多为 `http://127.0.0.1:30050`）。
+
+### 停止
+
+```bash
+docker compose down
+```
+
+**端口冲突：** 若 30050–30057 等被占用，可改 `docker-compose.yml` 的 `ports:`，并同步修改 `.env` 中的公网/浏览器可达 URL 与 `SAGE_API_BASE_URL`。
+
+## 延伸阅读
+
+- [快速开始](GETTING_STARTED.md) — 一键脚本与总览
+- [服务端架构](../architecture/ARCHITECTURE_APP_SERVER.md)
+- [配置说明](../CONFIGURATION.md) · [环境变量](../ENV_VARS.md)
+- [问题排查](../TROUBLESHOOTING.md)


### PR DESCRIPTION
## Summary
- Track `app/desktop/sage-desktop.spec` via `.gitignore` exception (fixes CI `Spec file not found`).
- `release-desktop.yml`: pip cache key uses root `requirements.txt`.
- `build_windows.ps1`: align with `sage-desktop.spec` and sidecar assets; `tauri.conf` WiX language.
- README / docs applications (WEB, DESKTOP, Chrome) and related links.

## Test plan
- [ ] Desktop release workflow on tag `desktop-v*` (optional smoke)

Made with [Cursor](https://cursor.com)