### PR TITLE
Add Sage Terminal TUI preview, runtime groundwork, and module cleanup

### DIFF
--- a/app/terminal/BOUNDARY.md
+++ b/app/terminal/BOUNDARY.md
@@ -1,0 +1,77 @@
+# Sage Terminal Boundary
+
+`sage-terminal` is a terminal-first frontend for Sage. It is not a second Sage runtime.
+
+This document defines what belongs in the Rust TUI layer and what must remain in the CLI/runtime layer.
+
+## TUI Responsibilities
+
+The Rust TUI owns:
+
+- terminal rendering
+- input editing and cursor behavior
+- popup / overlay / picker interaction
+- startup routing for `sage-terminal ...`
+- transcript presentation
+- local UI state
+- mapping structured backend results into terminal-friendly output
+
+The TUI may add convenience entrypoints, but it should not invent new backend behavior.
+
+## CLI / Runtime Responsibilities
+
+The Sage CLI/runtime owns:
+
+- agent orchestration
+- provider verification and persistence
+- config inspection and config file creation
+- session storage and session inspection
+- skill discovery and validation
+- doctor diagnostics
+- backend event generation and JSON schemas
+
+If behavior changes in any of those areas, it should be implemented in the CLI/runtime first and only surfaced through the TUI second.
+
+## Hard Rules
+
+1. The TUI should prefer structured results over human-readable CLI text.
+2. The TUI should not parse presentation-oriented stdout when a JSON contract is available.
+3. New non-interactive entrypoints should be added to the CLI/runtime first, then exposed through `sage-terminal`.
+4. TUI-only state must stay UI-local. Business state must stay in the runtime.
+
+## What The TUI Currently Depends On
+
+The current TUI contract surface includes:
+
+- `doctor --json`
+- `config show --json`
+- `config init --json`
+- `sessions --json`
+- `sessions inspect --json`
+- `skills --json`
+- `provider list --json`
+- `provider inspect --json`
+- `provider verify --json`
+- `provider create --json`
+- `provider update --json`
+- `provider delete --json`
+- chat/resume streaming events over the existing runtime channel
+
+## What Should Not Be Added To The TUI
+
+Avoid moving these concerns into Rust TUI code:
+
+- provider business rules
+- config template logic
+- doctor probe implementation
+- session persistence logic
+- skill resolution logic
+- runtime-specific error classification that the CLI can define directly
+
+## Practical Review Guideline
+
+For future PRs:
+
+- if a change only affects rendering or interaction, it belongs in `app/terminal`
+- if a change affects runtime meaning or data shape, it belongs in `app/cli` / runtime first
+- if the TUI needs a new capability, prefer adding a stable CLI/JSON contract instead of special-casing UI logic

--- a/app/terminal/BUNDLE_LAYOUT.md
+++ b/app/terminal/BUNDLE_LAYOUT.md
@@ -1,0 +1,106 @@
+# Sage Terminal Bundle Layout
+
+This document defines the current bundle contract for `sage-terminal`.
+
+It does not mean Sage Terminal is already shipped as a packaged release.
+It defines the layout and launcher expectations that future packaging work should follow.
+
+## Target Layout
+
+The preferred portable bundle layout is:
+
+```text
+sage-terminal-bundle/
+  bin/
+    sage-terminal
+    run-sage-terminal
+  runtime/
+    app/
+      cli/
+        main.py
+    .venv/
+      bin/
+        python3
+        sage
+  state/
+```
+
+An alternative layout may place the runtime under:
+
+```text
+sage-terminal-bundle/
+  bin/
+    sage-terminal
+    run-sage-terminal
+  share/
+    sage/
+      app/
+        cli/
+          main.py
+      .sage_py_env/
+        bin/
+          python3
+          sage
+  state/
+```
+
+## Directory Roles
+
+`bin/`
+
+- contains the Rust TUI binary
+- contains the optional launcher wrapper
+- should not contain writable runtime state
+
+`runtime/` or `share/sage/`
+
+- contains the Sage Python runtime
+- contains built-in skills
+- may contain a bundled `sage` CLI and/or Python interpreter
+- should be treated as read-only at runtime
+
+`state/`
+
+- is an optional writable directory for portable bundles
+- when present and writable, the launcher should point `SAGE_TERMINAL_STATE_ROOT` at `state/terminal-state`
+- when absent, the runtime falls back to `~/.sage/terminal-state`
+
+## Launcher Contract
+
+The launcher should:
+
+1. discover the bundle root relative to itself
+2. prefer `runtime/` as `SAGE_TERMINAL_RUNTIME_ROOT`
+3. fall back to `share/sage/` if `runtime/` is absent
+4. set `SAGE_TERMINAL_CLI` when a bundled `sage` executable exists
+5. otherwise set `SAGE_PYTHON` when a bundled Python exists
+6. set `SAGE_TERMINAL_STATE_ROOT` to the bundle-local `state/terminal-state` only when `state/` exists and is writable
+7. leave any explicitly supplied env overrides untouched
+
+The launcher should not embed business logic from Sage itself. It should only normalize runtime discovery for packaged layouts.
+
+## Binary Contract
+
+The Rust TUI binary remains:
+
+- `bin/sage-terminal`
+
+The wrapper launcher is expected to be:
+
+- `bin/run-sage-terminal`
+
+Packaging may later rename the wrapper to the user-facing entrypoint, but the internal separation should stay explicit:
+
+- one binary
+- one launcher
+- one runtime root
+- one optional writable state root
+
+## Current Recommendation
+
+Until official packaging exists, this layout should be treated as the source of truth for:
+
+- future bundle assembly
+- installer integration
+- launcher behavior
+- release smoke checks

--- a/app/terminal/CLI_CONTRACT.md
+++ b/app/terminal/CLI_CONTRACT.md
@@ -1,0 +1,65 @@
+# Sage Terminal / CLI Contract
+
+This document lists the CLI/runtime interfaces that `sage-terminal` treats as stable integration points.
+
+## Integration Model
+
+`sage-terminal` is a Rust client over the existing local Sage runtime.
+
+There are two integration paths:
+
+- chat / resume streaming through the existing backend event channel
+- one-shot CLI commands for inspect/list/init/verify style operations
+
+## Stable One-Shot JSON Commands
+
+The TUI currently expects these commands to support structured JSON output:
+
+- `sage doctor --json`
+- `sage config show --json`
+- `sage config init --json`
+- `sage sessions --json`
+- `sage sessions inspect <session_id|latest> --json`
+- `sage skills --json`
+- `sage provider list --json`
+- `sage provider inspect <provider_id> --json`
+- `sage provider verify --json`
+- `sage provider create --json`
+- `sage provider update <provider_id> --json`
+- `sage provider delete <provider_id> --json`
+
+## Stable Startup Entry Surface
+
+The TUI startup layer currently aligns to these commands:
+
+- `sage-terminal run <prompt>`
+- `sage-terminal chat <prompt>`
+- `sage-terminal config init [path] [--force]`
+- `sage-terminal doctor [probe-provider]`
+- `sage-terminal provider verify [key=value...]`
+- `sage-terminal sessions [limit]`
+- `sage-terminal sessions inspect <latest|session_id>`
+- `sage-terminal resume [latest|session_id]`
+
+## Contract Expectations
+
+For one-shot JSON commands:
+
+- stdout should be valid JSON when `--json` is used
+- error reporting should remain machine-readable enough for the TUI to wrap cleanly
+- human-readable formatting can change independently of the TUI
+
+For streaming events:
+
+- event type names should remain explicit
+- fields such as `type`, `role`, `content`, `tool_calls`, and `metadata.tool_name` should remain stable or be evolved compatibly
+
+## Change Policy
+
+If one of these contracts must change:
+
+1. change the CLI/runtime contract intentionally
+2. update `app/terminal/src/backend/contract.rs`
+3. update Rust-side tests
+4. update Python-side JSON contract tests
+5. update this document if the surface area changed

--- a/app/terminal/DISTRIBUTION.md
+++ b/app/terminal/DISTRIBUTION.md
@@ -1,0 +1,131 @@
+# Sage Terminal Runtime / Distribution Notes
+
+This document describes the current runtime-resolution rules for `sage-terminal`.
+
+It does not introduce a packaged installer yet. It defines the compatibility layer that future bundle or installer work should follow.
+
+Related documents:
+
+- [BUNDLE_LAYOUT.md](./BUNDLE_LAYOUT.md)
+- launcher wrapper: `scripts/run-sage-terminal.sh`
+- smoke script: `scripts/smoke-runtime-distribution.sh`
+
+## Runtime Resolution
+
+`sage-terminal` currently resolves the Sage backend runtime in this order:
+
+1. `SAGE_TERMINAL_RUNTIME_ROOT`
+2. bundled/runtime-adjacent layouts relative to the current executable
+3. the current Sage checkout inferred from `CARGO_MANIFEST_DIR`
+
+A valid runtime root is any directory that contains:
+
+- `app/cli/main.py`
+
+## CLI Resolution
+
+The Sage backend entrypoint used by the TUI is resolved in this order:
+
+1. `SAGE_TERMINAL_CLI`
+2. bundled `sage` executable candidates under the runtime root
+3. Python module fallback via `python -m app.cli.main`
+
+This keeps source checkouts working while allowing future bundles or wrapper launchers to provide a stable `sage` command without changing TUI code.
+
+## Python Resolution
+
+When the TUI falls back to Python module execution, the interpreter is resolved in this order:
+
+1. `SAGE_PYTHON`
+2. `PYTHON`
+3. bundled interpreter candidates under the runtime root
+4. fallback to `python3`
+
+Bundled interpreter candidates currently include layouts such as:
+
+- `.venv/bin/python3`
+- `.venv/bin/python`
+- `bin/python3`
+- `bin/python`
+- `python/bin/python3`
+- `python/bin/python`
+- `.sage_py_env/bin/python3`
+- `.sage_py_env/bin/python`
+
+## State Root Resolution
+
+The TUI state root is resolved in this order:
+
+1. `SAGE_TERMINAL_STATE_ROOT`
+2. `<runtime_root>/.sage-terminal-state` when the runtime root looks like a source checkout (`.git/` exists)
+3. `~/.sage/terminal-state`
+4. fallback to `<runtime_root>/.sage-terminal-state`
+
+This keeps source development behavior unchanged while avoiding writes into a read-only packaged runtime layout.
+
+## Workspace Resolution
+
+The TUI default workspace is now based on the current working directory, not the compiled repo path.
+
+This affects:
+
+- chat requests launched from the TUI
+- workspace skill discovery
+- the directory label shown in the welcome banner
+
+## Packaging Direction
+
+The current runtime resolution is intentionally compatible with a future bundle layout such as:
+
+```text
+sage-terminal-bundle/
+  bin/
+    sage-terminal
+  runtime/
+    app/
+      cli/
+        main.py
+    .venv/
+      bin/
+        python3
+        sage
+```
+
+or:
+
+```text
+sage-terminal-bundle/
+  bin/
+    sage-terminal
+  share/
+    sage/
+      app/
+        cli/
+          main.py
+      .sage_py_env/
+        bin/
+          python3
+          sage
+```
+
+## Current Scope
+
+This is only the first runtime/distribution step.
+
+Still out of scope:
+
+- installer generation
+- release bundling automation
+- npm / brew packaging
+- shipping an embedded Python environment in CI
+
+## Launcher And Smoke Helpers
+
+The repository now includes:
+
+- `scripts/run-sage-terminal.sh`
+  - a minimal launcher contract for future bundles
+  - normalizes `SAGE_TERMINAL_RUNTIME_ROOT`, `SAGE_TERMINAL_CLI`, `SAGE_PYTHON`, and optional bundle-local state
+- `scripts/smoke-runtime-distribution.sh`
+  - a release-facing smoke script
+  - validates explicit overrides, bundled `sage`, and bundled Python fallback behavior

--- a/app/terminal/README.md
+++ b/app/terminal/README.md
@@ -7,6 +7,8 @@ Current status:
 - preview / source-run only
 - no packaged installer yet
 - depends on the local Sage Python CLI/backend from this repository
+- see `BOUNDARY.md` and `CLI_CONTRACT.md` for ownership and integration rules
+- runtime lookup and future bundle assumptions are documented in `DISTRIBUTION.md` and `BUNDLE_LAYOUT.md`
 
 ## What It Uses
 
@@ -97,3 +99,5 @@ Common slash commands:
 - This preview is intended for local development and dogfooding.
 - Packaging and one-command installation are not included yet.
 - The TUI currently relies on the Sage CLI/backend behavior, so CLI runtime configuration must be valid first.
+- Runtime lookup now supports explicit CLI/Python overrides, bundled `sage` / Python fallbacks, and packaged-layout state roots as a first distribution step.
+- The repo now also includes a minimal launcher wrapper at `scripts/run-sage-terminal.sh` and a distribution smoke script at `scripts/smoke-runtime-distribution.sh`.

--- a/app/terminal/scripts/run-sage-terminal.sh
+++ b/app/terminal/scripts/run-sage-terminal.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env sh
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+BUNDLE_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+TERMINAL_BIN=${SAGE_TERMINAL_BIN:-"$BUNDLE_ROOT/bin/sage-terminal"}
+
+resolve_runtime_root() {
+  if [ -n "${SAGE_TERMINAL_RUNTIME_ROOT:-}" ]; then
+    printf '%s\n' "$SAGE_TERMINAL_RUNTIME_ROOT"
+    return
+  fi
+
+  if [ -f "$BUNDLE_ROOT/runtime/app/cli/main.py" ]; then
+    printf '%s\n' "$BUNDLE_ROOT/runtime"
+    return
+  fi
+
+  if [ -f "$BUNDLE_ROOT/share/sage/app/cli/main.py" ]; then
+    printf '%s\n' "$BUNDLE_ROOT/share/sage"
+    return
+  fi
+
+  printf '\n'
+}
+
+set_if_missing() {
+  key=$1
+  value=$2
+  if [ -n "$value" ]; then
+    eval "current=\${$key:-}"
+    if [ -z "$current" ]; then
+      export "$key=$value"
+    fi
+  fi
+}
+
+first_existing_file() {
+  for candidate in "$@"; do
+    if [ -f "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+  printf '\n'
+}
+
+runtime_root=$(resolve_runtime_root)
+set_if_missing "SAGE_TERMINAL_RUNTIME_ROOT" "$runtime_root"
+
+if [ -n "$runtime_root" ]; then
+  bundled_cli=$(first_existing_file \
+    "$runtime_root/.venv/bin/sage" \
+    "$runtime_root/bin/sage" \
+    "$runtime_root/python/bin/sage" \
+    "$runtime_root/.sage_py_env/bin/sage")
+  set_if_missing "SAGE_TERMINAL_CLI" "$bundled_cli"
+
+  bundled_python=$(first_existing_file \
+    "$runtime_root/.venv/bin/python3" \
+    "$runtime_root/.venv/bin/python" \
+    "$runtime_root/bin/python3" \
+    "$runtime_root/bin/python" \
+    "$runtime_root/python/bin/python3" \
+    "$runtime_root/python/bin/python" \
+    "$runtime_root/.sage_py_env/bin/python3" \
+    "$runtime_root/.sage_py_env/bin/python")
+  set_if_missing "SAGE_PYTHON" "$bundled_python"
+fi
+
+if [ -z "${SAGE_TERMINAL_STATE_ROOT:-}" ] && [ -d "$BUNDLE_ROOT/state" ] && [ -w "$BUNDLE_ROOT/state" ]; then
+  export SAGE_TERMINAL_STATE_ROOT="$BUNDLE_ROOT/state/terminal-state"
+fi
+
+if [ "${SAGE_TERMINAL_DEBUG_LAUNCH:-0}" = "1" ]; then
+  printf 'SAGE_TERMINAL_BIN=%s\n' "$TERMINAL_BIN"
+  printf 'SAGE_TERMINAL_RUNTIME_ROOT=%s\n' "${SAGE_TERMINAL_RUNTIME_ROOT:-}"
+  printf 'SAGE_TERMINAL_CLI=%s\n' "${SAGE_TERMINAL_CLI:-}"
+  printf 'SAGE_PYTHON=%s\n' "${SAGE_PYTHON:-}"
+  printf 'SAGE_TERMINAL_STATE_ROOT=%s\n' "${SAGE_TERMINAL_STATE_ROOT:-}"
+fi
+
+exec "$TERMINAL_BIN" "$@"

--- a/app/terminal/scripts/smoke-runtime-distribution.sh
+++ b/app/terminal/scripts/smoke-runtime-distribution.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env sh
+
+set -eu
+
+REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
+TERMINAL_DIR="$REPO_ROOT/app/terminal"
+BINARY_PATH="$TERMINAL_DIR/target/release/sage-terminal"
+WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/sage-terminal-smoke.XXXXXX")
+WORK_DIR=$(CDPATH= cd -- "$WORK_DIR" && pwd)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+if [ ! -x "$BINARY_PATH" ]; then
+  cargo build --release --manifest-path "$TERMINAL_DIR/Cargo.toml" >/dev/null
+fi
+
+BUNDLE_ROOT="$WORK_DIR/bundle"
+mkdir -p "$BUNDLE_ROOT/bin" "$BUNDLE_ROOT/runtime/app/cli" "$BUNDLE_ROOT/state"
+cp "$BINARY_PATH" "$BUNDLE_ROOT/bin/sage-terminal"
+cp "$TERMINAL_DIR/scripts/run-sage-terminal.sh" "$BUNDLE_ROOT/bin/run-sage-terminal"
+chmod +x "$BUNDLE_ROOT/bin/run-sage-terminal"
+
+printf '# stub\n' >"$BUNDLE_ROOT/runtime/app/cli/main.py"
+
+run_debug() {
+  env SAGE_TERMINAL_DEBUG_LAUNCH=1 "$BUNDLE_ROOT/bin/run-sage-terminal" --help
+}
+
+assert_contains() {
+  haystack=$1
+  needle=$2
+  if ! printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null; then
+    printf 'missing expected line: %s\n' "$needle" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  haystack=$1
+  needle=$2
+  if printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null; then
+    printf 'unexpected line: %s\n' "$needle" >&2
+    exit 1
+  fi
+}
+
+explicit_cli="$WORK_DIR/tools/explicit-sage"
+explicit_python="$WORK_DIR/tools/explicit-python"
+mkdir -p "$WORK_DIR/tools"
+: >"$explicit_cli"
+: >"$explicit_python"
+chmod +x "$explicit_cli" "$explicit_python"
+
+scenario_one=$(
+  env \
+    SAGE_TERMINAL_RUNTIME_ROOT="$WORK_DIR/explicit-runtime" \
+    SAGE_TERMINAL_CLI="$explicit_cli" \
+    SAGE_PYTHON="$explicit_python" \
+    SAGE_TERMINAL_STATE_ROOT="$WORK_DIR/explicit-state" \
+    SAGE_TERMINAL_BIN="$BUNDLE_ROOT/bin/sage-terminal" \
+    SAGE_TERMINAL_DEBUG_LAUNCH=1 \
+    "$BUNDLE_ROOT/bin/run-sage-terminal" --help
+)
+assert_contains "$scenario_one" "SAGE_TERMINAL_RUNTIME_ROOT=$WORK_DIR/explicit-runtime"
+assert_contains "$scenario_one" "SAGE_TERMINAL_CLI=$explicit_cli"
+assert_contains "$scenario_one" "SAGE_PYTHON=$explicit_python"
+assert_contains "$scenario_one" "SAGE_TERMINAL_STATE_ROOT=$WORK_DIR/explicit-state"
+
+mkdir -p "$BUNDLE_ROOT/runtime/.venv/bin"
+: >"$BUNDLE_ROOT/runtime/.venv/bin/sage"
+chmod +x "$BUNDLE_ROOT/runtime/.venv/bin/sage"
+
+scenario_two=$(run_debug)
+assert_contains "$scenario_two" "SAGE_TERMINAL_RUNTIME_ROOT=$BUNDLE_ROOT/runtime"
+assert_contains "$scenario_two" "SAGE_TERMINAL_CLI=$BUNDLE_ROOT/runtime/.venv/bin/sage"
+assert_contains "$scenario_two" "SAGE_TERMINAL_STATE_ROOT=$BUNDLE_ROOT/state/terminal-state"
+
+rm -f "$BUNDLE_ROOT/runtime/.venv/bin/sage"
+: >"$BUNDLE_ROOT/runtime/.venv/bin/python3"
+chmod +x "$BUNDLE_ROOT/runtime/.venv/bin/python3"
+
+scenario_three=$(run_debug)
+assert_contains "$scenario_three" "SAGE_TERMINAL_RUNTIME_ROOT=$BUNDLE_ROOT/runtime"
+assert_contains "$scenario_three" "SAGE_PYTHON=$BUNDLE_ROOT/runtime/.venv/bin/python3"
+assert_contains "$scenario_three" "SAGE_TERMINAL_STATE_ROOT=$BUNDLE_ROOT/state/terminal-state"
+assert_contains "$scenario_three" "SAGE_TERMINAL_CLI="
+
+printf 'runtime/distribution smoke checks passed\n'

--- a/app/terminal/src/app.rs
+++ b/app/terminal/src/app.rs
@@ -238,11 +238,7 @@ impl App {
 }
 
 fn current_workspace_label() -> String {
-    let repo_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(|path| path.parent())
-        .map(std::path::Path::to_path_buf);
-    let cwd = repo_root.or_else(|| std::env::current_dir().ok());
+    let cwd = std::env::current_dir().ok();
     let home = std::env::var("HOME").ok();
 
     match (cwd, home) {

--- a/app/terminal/src/backend/handle.rs
+++ b/app/terminal/src/backend/handle.rs
@@ -10,7 +10,9 @@ use anyhow::{anyhow, Result};
 use crate::app::MessageKind;
 use crate::backend::protocol::{flush_complete_lines, parse_backend_line};
 use crate::backend::types::{BackendEvent, BackendRequest};
-use crate::backend_support::{apply_state_env, prepare_state_root, repo_root};
+use crate::backend_support::{
+    apply_state_env, prepare_state_root, resolve_cli_invoker, resolve_runtime_root, CliInvoker,
+};
 
 pub struct BackendHandle {
     receiver: Receiver<BackendEvent>,
@@ -32,20 +34,32 @@ struct BackendConfig {
 
 impl BackendHandle {
     pub fn spawn(request: &BackendRequest) -> Result<Self> {
-        let repo_root = repo_root()?;
-        let state_root = prepare_state_root(&repo_root)?;
-        let python = std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string());
+        let runtime_root = resolve_runtime_root()?;
+        let state_root = prepare_state_root(&runtime_root)?;
+        let cli = resolve_cli_invoker(&runtime_root);
         let workspace = request
             .workspace
             .clone()
-            .unwrap_or_else(|| repo_root.clone());
+            .unwrap_or_else(|| runtime_root.clone());
 
-        let mut command = Command::new(&python);
+        let mut command = match &cli {
+            CliInvoker::Executable(path) => {
+                let mut command = Command::new(path);
+                command.current_dir(&runtime_root);
+                command
+            }
+            CliInvoker::PythonModule(path) => {
+                let mut command = Command::new(path);
+                command
+                    .current_dir(&runtime_root)
+                    .arg("-u")
+                    .arg("-m")
+                    .arg("app.cli.main")
+                    .env("PYTHONUNBUFFERED", "1");
+                command
+            }
+        };
         command
-            .current_dir(&repo_root)
-            .arg("-u")
-            .arg("-m")
-            .arg("app.cli.main")
             .arg("chat")
             .arg("--json")
             .arg("--stats")
@@ -61,8 +75,7 @@ impl BackendHandle {
             .arg(&workspace)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .env("PYTHONUNBUFFERED", "1");
+            .stderr(Stdio::piped());
         for skill in &request.skills {
             command.arg("--skill").arg(skill);
         }
@@ -71,9 +84,12 @@ impl BackendHandle {
             command.env("SAGE_DEFAULT_LLM_MODEL_NAME", model);
         }
 
-        let mut child = command
-            .spawn()
-            .map_err(|err| anyhow!("failed to launch Sage CLI backend with {python}: {err}"))?;
+        let mut child = command.spawn().map_err(|err| {
+            anyhow!(
+                "failed to launch Sage CLI backend with {}: {err}",
+                cli.display()
+            )
+        })?;
         let stdout = child
             .stdout
             .take()

--- a/app/terminal/src/backend/tests.rs
+++ b/app/terminal/src/backend/tests.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::MutexGuard;
 use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -13,11 +14,21 @@ use serde_json::json;
 use crate::app::MessageKind;
 use crate::backend::contract::{expect_array_field, parse_stream_event, CliJsonCommand};
 use crate::backend::protocol::parse_backend_line;
-use crate::backend_support::{apply_state_env, prepare_state_root};
+use crate::backend_support::{
+    apply_state_env, prepare_state_root, resolve_cli_invoker, resolve_python_command,
+    resolve_runtime_root_from, CliInvoker,
+};
 
 use super::{BackendEvent, BackendHandle, BackendRequest};
 
 static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn lock_env() -> MutexGuard<'static, ()> {
+    ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 struct EnvVarGuard {
     key: &'static str,
@@ -29,6 +40,14 @@ impl EnvVarGuard {
         let previous = env::var(key).ok();
         unsafe {
             env::set_var(key, value);
+        }
+        Self { key, previous }
+    }
+
+    fn unset(key: &'static str) -> Self {
+        let previous = env::var(key).ok();
+        unsafe {
+            env::remove_var(key);
         }
         Self { key, previous }
     }
@@ -49,10 +68,7 @@ impl Drop for EnvVarGuard {
 
 #[test]
 fn backend_handle_supports_two_round_trips_without_respawn() {
-    let _env_lock = ENV_LOCK
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .expect("env lock poisoned");
+    let _env_lock = lock_env();
     let temp_dir = unique_temp_dir("backend-smoke");
     fs::create_dir_all(&temp_dir).expect("temp dir should be created");
     let script_path = write_fake_backend_script(&temp_dir);
@@ -97,6 +113,7 @@ fn backend_handle_supports_two_round_trips_without_respawn() {
 
 #[test]
 fn prepare_state_root_copies_builtin_skills_into_terminal_workspace() {
+    let _env_lock = lock_env();
     let temp_dir = unique_temp_dir("builtin-skills");
     let builtin_skill = temp_dir.join("app").join("skills").join("demo-skill");
     fs::create_dir_all(builtin_skill.join("references"))
@@ -111,6 +128,11 @@ fn prepare_state_root_copies_builtin_skills_into_terminal_workspace() {
         "demo reference",
     )
     .expect("skill reference should be written");
+    let state_root = temp_dir.join("terminal-state");
+    let _state_root_guard = EnvVarGuard::set(
+        "SAGE_TERMINAL_STATE_ROOT",
+        &state_root.display().to_string(),
+    );
 
     let state_root = prepare_state_root(&temp_dir).expect("state root should be prepared");
     let copied_skill = state_root.join("skills").join("demo-skill");
@@ -123,8 +145,29 @@ fn prepare_state_root_copies_builtin_skills_into_terminal_workspace() {
 }
 
 #[test]
+fn prepare_state_root_uses_home_for_packaged_runtime_layout() {
+    let _env_lock = lock_env();
+    let runtime_root = unique_temp_dir("packaged-runtime");
+    fs::create_dir_all(runtime_root.join("app").join("skills")).expect("runtime root should exist");
+    let home_dir = unique_temp_dir("terminal-home");
+    fs::create_dir_all(&home_dir).expect("home dir should exist");
+    let _home_guard = EnvVarGuard::set("HOME", &home_dir.display().to_string());
+
+    let state_root = prepare_state_root(&runtime_root).expect("state root should be prepared");
+
+    assert_eq!(state_root, home_dir.join(".sage").join("terminal-state"));
+    assert!(state_root.join("logs").is_dir());
+}
+
+#[test]
 fn apply_state_env_keeps_default_sage_session_dir() {
+    let _env_lock = lock_env();
     let temp_dir = unique_temp_dir("state-env");
+    let state_root_path = temp_dir.join("terminal-state");
+    let _state_root_guard = EnvVarGuard::set(
+        "SAGE_TERMINAL_STATE_ROOT",
+        &state_root_path.display().to_string(),
+    );
     let state_root = prepare_state_root(&temp_dir).expect("state root should be prepared");
     let mut command = Command::new("true");
 
@@ -145,8 +188,68 @@ fn apply_state_env_keeps_default_sage_session_dir() {
         key == "SAGE_LOGS_DIR_PATH"
             && value
                 .as_deref()
-                .is_some_and(|value| value.contains(".sage-terminal-state"))
+                .is_some_and(|value| value.ends_with("terminal-state/logs"))
     }));
+}
+
+#[test]
+fn resolve_runtime_root_prefers_explicit_env_override() {
+    let _env_lock = lock_env();
+    let runtime_root = unique_temp_dir("runtime-root");
+    fs::create_dir_all(runtime_root.join("app").join("cli")).expect("runtime cli dir should exist");
+    fs::write(
+        runtime_root.join("app").join("cli").join("main.py"),
+        "# stub",
+    )
+    .expect("runtime entry should exist");
+    let _runtime_guard = EnvVarGuard::set(
+        "SAGE_TERMINAL_RUNTIME_ROOT",
+        &runtime_root.display().to_string(),
+    );
+
+    let resolved = resolve_runtime_root_from(None).expect("runtime root should resolve");
+    assert_eq!(resolved, runtime_root);
+}
+
+#[test]
+fn resolve_python_command_prefers_bundled_runtime_python() {
+    let _env_lock = lock_env();
+    let runtime_root = unique_temp_dir("bundled-python");
+    let python_path = runtime_root.join(".venv").join("bin").join("python3");
+    fs::create_dir_all(python_path.parent().expect("parent should exist"))
+        .expect("python dir should exist");
+    fs::write(&python_path, "").expect("python stub should be written");
+    let _sage_python_guard = EnvVarGuard::unset("SAGE_PYTHON");
+    let _python_guard = EnvVarGuard::unset("PYTHON");
+
+    let resolved = resolve_python_command(&runtime_root);
+    assert_eq!(resolved, python_path);
+}
+
+#[test]
+fn resolve_cli_invoker_prefers_explicit_env_override() {
+    let _env_lock = lock_env();
+    let runtime_root = unique_temp_dir("bundled-cli-env");
+    let _cli_guard = EnvVarGuard::set("SAGE_TERMINAL_CLI", "sage");
+    let _python_guard = EnvVarGuard::set("SAGE_PYTHON", "/tmp/should-not-be-used");
+
+    let resolved = resolve_cli_invoker(&runtime_root);
+    assert_eq!(resolved, CliInvoker::Executable(PathBuf::from("sage")));
+}
+
+#[test]
+fn resolve_cli_invoker_prefers_bundled_sage_over_python_module() {
+    let _env_lock = lock_env();
+    let runtime_root = unique_temp_dir("bundled-cli");
+    let sage_path = runtime_root.join(".venv").join("bin").join("sage");
+    fs::create_dir_all(sage_path.parent().expect("parent should exist"))
+        .expect("sage dir should exist");
+    fs::write(&sage_path, "").expect("sage stub should be written");
+    let _cli_guard = EnvVarGuard::unset("SAGE_TERMINAL_CLI");
+    let _python_guard = EnvVarGuard::set("SAGE_PYTHON", "/tmp/python-fallback");
+
+    let resolved = resolve_cli_invoker(&runtime_root);
+    assert_eq!(resolved, CliInvoker::Executable(sage_path));
 }
 
 #[test]

--- a/app/terminal/src/backend_support.rs
+++ b/app/terminal/src/backend_support.rs
@@ -6,6 +6,20 @@ use std::process::Command;
 use anyhow::{anyhow, Result};
 use serde_json::Value;
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum CliInvoker {
+    Executable(PathBuf),
+    PythonModule(PathBuf),
+}
+
+impl CliInvoker {
+    pub(crate) fn display(&self) -> String {
+        match self {
+            Self::Executable(path) | Self::PythonModule(path) => path.display().to_string(),
+        }
+    }
+}
+
 pub(crate) fn repo_root() -> Result<PathBuf> {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     manifest_dir
@@ -15,24 +29,93 @@ pub(crate) fn repo_root() -> Result<PathBuf> {
         .ok_or_else(|| anyhow!("failed to resolve repo root from CARGO_MANIFEST_DIR"))
 }
 
-pub(crate) fn run_cli_json(args: &[&str]) -> Result<Value> {
-    let repo_root = repo_root()?;
-    let state_root = prepare_state_root(&repo_root)?;
-    let python = std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string());
+pub(crate) fn resolve_runtime_root() -> Result<PathBuf> {
+    resolve_runtime_root_from(std::env::current_exe().ok())
+}
 
-    let mut command = Command::new(&python);
-    command
-        .current_dir(&repo_root)
-        .arg("-m")
-        .arg("app.cli.main");
+pub(crate) fn resolve_runtime_root_from(current_exe: Option<PathBuf>) -> Result<PathBuf> {
+    if let Ok(explicit_root) = std::env::var("SAGE_TERMINAL_RUNTIME_ROOT") {
+        let path = PathBuf::from(explicit_root);
+        if is_runtime_root(&path) {
+            return Ok(path);
+        }
+        return Err(anyhow!(
+            "SAGE_TERMINAL_RUNTIME_ROOT does not contain app/cli/main.py: {}",
+            path.display()
+        ));
+    }
+
+    for candidate in runtime_root_candidates(current_exe) {
+        if is_runtime_root(&candidate) {
+            return Ok(candidate);
+        }
+    }
+
+    Err(anyhow!(
+        "failed to resolve Sage runtime root; set SAGE_TERMINAL_RUNTIME_ROOT or run from a Sage checkout"
+    ))
+}
+
+pub(crate) fn resolve_python_command(runtime_root: &Path) -> PathBuf {
+    if let Ok(python) = std::env::var("SAGE_PYTHON") {
+        return PathBuf::from(python);
+    }
+    if let Ok(python) = std::env::var("PYTHON") {
+        return PathBuf::from(python);
+    }
+
+    bundled_python_candidates(runtime_root)
+        .into_iter()
+        .find(|path| path.is_file())
+        .unwrap_or_else(|| PathBuf::from("python3"))
+}
+
+pub(crate) fn resolve_cli_invoker(runtime_root: &Path) -> CliInvoker {
+    if let Ok(cli) = std::env::var("SAGE_TERMINAL_CLI") {
+        return CliInvoker::Executable(PathBuf::from(cli));
+    }
+
+    if let Some(cli) = bundled_cli_candidates(runtime_root)
+        .into_iter()
+        .find(|path| path.is_file())
+    {
+        return CliInvoker::Executable(cli);
+    }
+
+    CliInvoker::PythonModule(resolve_python_command(runtime_root))
+}
+
+pub(crate) fn run_cli_json(args: &[&str]) -> Result<Value> {
+    let runtime_root = resolve_runtime_root()?;
+    let state_root = prepare_state_root(&runtime_root)?;
+    let cli = resolve_cli_invoker(&runtime_root);
+
+    let mut command = match &cli {
+        CliInvoker::Executable(path) => {
+            let mut command = Command::new(path);
+            command.current_dir(&runtime_root);
+            command
+        }
+        CliInvoker::PythonModule(path) => {
+            let mut command = Command::new(path);
+            command
+                .current_dir(&runtime_root)
+                .arg("-m")
+                .arg("app.cli.main");
+            command
+        }
+    };
     for arg in args {
         command.arg(arg);
     }
     apply_state_env(&mut command, &state_root);
 
-    let output = command
-        .output()
-        .map_err(|err| anyhow!("failed to launch Sage CLI helper with {python}: {err}"))?;
+    let output = command.output().map_err(|err| {
+        anyhow!(
+            "failed to launch Sage CLI helper with {}: {err}",
+            cli.display()
+        )
+    })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -60,8 +143,8 @@ pub(crate) fn run_cli_json_owned(args: &[String]) -> Result<Value> {
     run_cli_json(&refs)
 }
 
-pub(crate) fn prepare_state_root(repo_root: &Path) -> Result<PathBuf> {
-    let state_root = repo_root.join(".sage-terminal-state");
+pub(crate) fn prepare_state_root(runtime_root: &Path) -> Result<PathBuf> {
+    let state_root = resolve_state_root(runtime_root);
     for dir in [
         state_root.join("logs"),
         state_root.join("sessions"),
@@ -71,7 +154,7 @@ pub(crate) fn prepare_state_root(repo_root: &Path) -> Result<PathBuf> {
     ] {
         ensure_dir(&dir)?;
     }
-    sync_builtin_skills(repo_root, &state_root.join("skills"))?;
+    sync_builtin_skills(runtime_root, &state_root.join("skills"))?;
     Ok(state_root)
 }
 
@@ -84,8 +167,8 @@ pub(crate) fn apply_state_env(command: &mut Command, state_root: &Path) {
         .env("SAGE_SKILL_WORKSPACE", state_root.join("skills"));
 }
 
-fn sync_builtin_skills(repo_root: &Path, target_root: &Path) -> Result<()> {
-    let builtin_root = repo_root.join("app").join("skills");
+fn sync_builtin_skills(runtime_root: &Path, target_root: &Path) -> Result<()> {
+    let builtin_root = runtime_root.join("app").join("skills");
     if !builtin_root.is_dir() {
         return Ok(());
     }
@@ -145,4 +228,122 @@ fn ensure_dir(path: &Path) -> Result<()> {
         }
         _ => anyhow!("failed to create {}: {err}", path.display()),
     })
+}
+
+fn resolve_state_root(runtime_root: &Path) -> PathBuf {
+    if let Ok(explicit_root) = std::env::var("SAGE_TERMINAL_STATE_ROOT") {
+        return PathBuf::from(explicit_root);
+    }
+    if runtime_root.join(".git").exists() {
+        return runtime_root.join(".sage-terminal-state");
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        return PathBuf::from(home).join(".sage").join("terminal-state");
+    }
+    runtime_root.join(".sage-terminal-state")
+}
+
+fn is_runtime_root(path: &Path) -> bool {
+    path.join("app").join("cli").join("main.py").is_file()
+}
+
+fn runtime_root_candidates(current_exe: Option<PathBuf>) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(exe) = current_exe {
+        if let Some(bin_dir) = exe.parent() {
+            candidates.push(bin_dir.to_path_buf());
+            if let Some(parent) = bin_dir.parent() {
+                candidates.push(parent.to_path_buf());
+                candidates.push(parent.join("runtime"));
+                candidates.push(parent.join("share").join("sage"));
+                candidates.push(parent.join("Resources").join("sage"));
+                candidates.push(parent.join("resources").join("sage"));
+            }
+        }
+    }
+    if let Ok(repo_root) = repo_root() {
+        candidates.push(repo_root);
+    }
+    dedupe_paths(candidates)
+}
+
+fn bundled_python_candidates(runtime_root: &Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    for relative in [
+        [".venv", "bin", "python3"].as_slice(),
+        [".venv", "bin", "python"].as_slice(),
+        ["bin", "python3"].as_slice(),
+        ["bin", "python"].as_slice(),
+        ["python", "bin", "python3"].as_slice(),
+        ["python", "bin", "python"].as_slice(),
+        [".sage_py_env", "bin", "python3"].as_slice(),
+        [".sage_py_env", "bin", "python"].as_slice(),
+    ] {
+        let mut path = runtime_root.to_path_buf();
+        for segment in relative {
+            path.push(segment);
+        }
+        candidates.push(path);
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        for relative in [
+            [".venv", "Scripts", "python.exe"].as_slice(),
+            ["python", "python.exe"].as_slice(),
+            [".sage_py_env", "Scripts", "python.exe"].as_slice(),
+        ] {
+            let mut path = runtime_root.to_path_buf();
+            for segment in relative {
+                path.push(segment);
+            }
+            candidates.push(path);
+        }
+    }
+
+    candidates
+}
+
+fn bundled_cli_candidates(runtime_root: &Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    for relative in [
+        [".venv", "bin", "sage"].as_slice(),
+        ["bin", "sage"].as_slice(),
+        ["python", "bin", "sage"].as_slice(),
+        [".sage_py_env", "bin", "sage"].as_slice(),
+    ] {
+        let mut path = runtime_root.to_path_buf();
+        for segment in relative {
+            path.push(segment);
+        }
+        candidates.push(path);
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        for relative in [
+            [".venv", "Scripts", "sage.exe"].as_slice(),
+            ["Scripts", "sage.exe"].as_slice(),
+            ["python", "Scripts", "sage.exe"].as_slice(),
+            [".sage_py_env", "Scripts", "sage.exe"].as_slice(),
+        ] {
+            let mut path = runtime_root.to_path_buf();
+            for segment in relative {
+                path.push(segment);
+            }
+            candidates.push(path);
+        }
+    }
+
+    candidates
+}
+
+fn dedupe_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    for path in paths {
+        if !out.iter().any(|existing| existing == &path) {
+            out.push(path);
+        }
+    }
+    out
 }

--- a/app/terminal/src/startup.rs
+++ b/app/terminal/src/startup.rs
@@ -51,11 +51,9 @@ pub(crate) fn parse_startup_action(
                 limit: 10,
             },
         ))),
-        [command, subcommand, target] if command == "sessions" && subcommand == "inspect" => {
-            Ok(StartupBehavior::Run(Some(SubmitAction::ShowSession(
-                target.clone(),
-            ))))
-        }
+        [command, subcommand, target] if command == "sessions" && subcommand == "inspect" => Ok(
+            StartupBehavior::Run(Some(SubmitAction::ShowSession(target.clone()))),
+        ),
         [command, limit] if command == "sessions" => {
             let limit = limit
                 .parse::<usize>()

--- a/app/terminal/src/terminal/actions/chat.rs
+++ b/app/terminal/src/terminal/actions/chat.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use crate::app::App;
 use crate::backend::{BackendHandle, BackendRequest};
 use crate::terminal::ensure_backend;
-use crate::terminal_support::repo_root;
+use crate::terminal_support::workspace_root;
 
 pub(super) fn run_task(
     app: &mut App,
@@ -15,7 +15,7 @@ pub(super) fn run_task(
         user_id: app.user_id.clone(),
         agent_mode: app.agent_mode.clone(),
         max_loop_count: app.max_loop_count,
-        workspace: Some(repo_root()),
+        workspace: Some(workspace_root()),
         skills: app.selected_skills.clone(),
         model_override: app.selected_model.clone(),
         task,

--- a/app/terminal/src/terminal/actions/skills.rs
+++ b/app/terminal/src/terminal/actions/skills.rs
@@ -2,10 +2,10 @@ use anyhow::Result;
 
 use crate::app::{App, MessageKind};
 use crate::backend::list_skills as fetch_skills;
-use crate::terminal_support::{format_skills_list, repo_root};
+use crate::terminal_support::{format_skills_list, workspace_root};
 
 pub(super) fn list_skills(app: &mut App) -> Result<bool> {
-    match fetch_skills(&app.user_id, Some(repo_root().as_path())) {
+    match fetch_skills(&app.user_id, Some(workspace_root().as_path())) {
         Ok(skills) => {
             app.set_skill_catalog(
                 skills
@@ -34,7 +34,7 @@ pub(super) fn list_skills(app: &mut App) -> Result<bool> {
 }
 
 pub(super) fn enable_skill(app: &mut App, skill: String) -> Result<bool> {
-    match fetch_skills(&app.user_id, Some(repo_root().as_path())) {
+    match fetch_skills(&app.user_id, Some(workspace_root().as_path())) {
         Ok(skills) => {
             app.set_skill_catalog(
                 skills

--- a/app/terminal/src/terminal/context.rs
+++ b/app/terminal/src/terminal/context.rs
@@ -3,12 +3,8 @@ use std::path::PathBuf;
 use crate::app::{App, MessageKind};
 use crate::backend::{list_providers, list_skills, SessionDetail};
 
-pub(crate) fn repo_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(|path| path.parent())
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("."))
+pub(crate) fn workspace_root() -> PathBuf {
+    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
 }
 
 pub(crate) fn sync_contextual_popup_data(app: &mut App) {
@@ -31,7 +27,7 @@ pub(crate) fn sync_contextual_popup_data(app: &mut App) {
         }
     }
     if app.needs_skill_catalog() {
-        if let Ok(skills) = list_skills(&app.user_id, Some(repo_root().as_path())) {
+        if let Ok(skills) = list_skills(&app.user_id, Some(workspace_root().as_path())) {
             app.set_skill_catalog(
                 skills
                     .into_iter()

--- a/app/terminal/src/terminal_support.rs
+++ b/app/terminal/src/terminal_support.rs
@@ -5,7 +5,7 @@ mod formatting;
 #[path = "terminal/provider_args.rs"]
 mod provider_args;
 
-pub(crate) use context::{apply_resumed_session, repo_root, sync_contextual_popup_data};
+pub(crate) use context::{apply_resumed_session, sync_contextual_popup_data, workspace_root};
 pub(crate) use formatting::{
     format_config, format_config_init, format_doctor_info, format_provider_detail,
     format_provider_verify, format_providers, format_session_detail, format_skills_list,

--- a/tests/app/cli/test_json_contracts.py
+++ b/tests/app/cli/test_json_contracts.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import asyncio
+import io
+import json
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+import app.cli.main as cli_main
+import app.cli.service as cli_service
+
+
+class TestCliJsonContracts(unittest.TestCase):
+    def test_doctor_command_json_outputs_structured_payload(self):
+        args = cli_main.build_argument_parser().parse_args(["doctor", "--json"])
+        fake_info = {
+            "status": "ok",
+            "env_file": "/tmp/.sage_env",
+            "dependencies": {"dotenv": True},
+        }
+
+        with patch.object(cli_service, "collect_doctor_info", return_value=fake_info):
+            with patch.object(cli_service, "probe_default_provider") as probe:
+                stdout = io.StringIO()
+                with redirect_stdout(stdout):
+                    exit_code = asyncio.run(cli_main._doctor_command(args))
+
+        self.assertEqual(exit_code, 0)
+        self.assertFalse(probe.called)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["env_file"], "/tmp/.sage_env")
+        self.assertEqual(payload["dependencies"]["dotenv"], True)
+
+    def test_config_init_command_json_outputs_result(self):
+        args = cli_main.build_argument_parser().parse_args(
+            ["config", "init", "--json", "--path", "/tmp/demo.env", "--force"]
+        )
+        fake_result = {
+            "path": "/tmp/demo.env",
+            "template": "minimal-local",
+            "overwritten": True,
+            "next_steps": ["Run `sage doctor`."],
+        }
+
+        with patch.object(cli_service, "write_cli_config_file", return_value=fake_result):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exit_code = cli_main._config_init_command(args)
+
+        self.assertEqual(exit_code, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["path"], "/tmp/demo.env")
+        self.assertEqual(payload["template"], "minimal-local")
+        self.assertEqual(payload["overwritten"], True)
+        self.assertEqual(payload["next_steps"], ["Run `sage doctor`."])
+
+    def test_provider_verify_command_json_outputs_verification_payload(self):
+        args = cli_main.build_argument_parser().parse_args(
+            ["provider", "verify", "--json", "--model", "demo-chat", "--base-url", "https://example.com/v1"]
+        )
+        fake_result = {
+            "status": "ok",
+            "message": "Provider verification succeeded",
+            "sources": {"base_url": "cli", "model": "cli"},
+            "provider": {
+                "id": "",
+                "name": "demo",
+                "model": "demo-chat",
+                "base_url": "https://example.com/v1",
+                "is_default": False,
+                "api_key_preview": "(hidden)",
+            },
+        }
+
+        async def _run():
+            with patch.object(cli_service, "verify_cli_provider", return_value=fake_result):
+                stdout = io.StringIO()
+                with redirect_stdout(stdout):
+                    exit_code = await cli_main._provider_command(args)
+            return exit_code, stdout.getvalue()
+
+        exit_code, output = asyncio.run(_run())
+        self.assertEqual(exit_code, 0)
+        payload = json.loads(output)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["message"], "Provider verification succeeded")
+        self.assertEqual(payload["provider"]["model"], "demo-chat")
+        self.assertEqual(payload["sources"]["base_url"], "cli")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/app/cli/test_provider_helpers.py
+++ b/tests/app/cli/test_provider_helpers.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import sys
 import types
 import unittest
 


### PR DESCRIPTION
## Summary

This PR adds a Rust-based terminal UI preview for Sage under `app/terminal`, aligns it with the existing Sage CLI/runtime, and establishes the first
runtime/distribution groundwork needed to evolve it beyond a source-only prototype.

The TUI is still intentionally positioned as a preview / source-run surface. It continues to reuse the existing Python CLI/backend rather than
introducing a separate agent implementation.

## What’s Included

### Rust TUI preview

Adds a new `sage-terminal` crate under `app/terminal` with:

- chat-style terminal UI
- bottom-pane composer / footer layout
- slash command popup
- help overlay
- session picker overlay
- transcript overlay
- provider / skill selection popups
- streamed transcript rendering
- startup command parsing for common Sage entrypoints

### In-app TUI command surface

The TUI now supports:

- `/help`
- `/new`
- `/clear`
- `/sessions`
- `/sessions inspect <latest|session_id>`
- `/resume`
- `/skills`
- `/skill`
- `/config`
- `/config init [path] [--force]`
- `/doctor`
- `/doctor probe-provider`
- `/providers`
- `/provider`
- `/provider verify [key=value...]`
- `/model`
- `/status`
- `/transcript`
- `/welcome`
- `/exit`

### Startup command alignment

`sage-terminal` now supports these startup forms:

- `sage-terminal`
- `sage-terminal run <prompt>`
- `sage-terminal chat <prompt>`
- `sage-terminal config init [path] [--force]`
- `sage-terminal doctor`
- `sage-terminal doctor probe-provider`
- `sage-terminal provider verify [key=value...]`
- `sage-terminal sessions`
- `sage-terminal sessions <limit>`
- `sage-terminal sessions inspect <latest|session_id>`
- `sage-terminal resume`
- `sage-terminal resume latest`
- `sage-terminal resume <session_id>`
- `sage-terminal --help`

### Session and runtime behavior

This PR keeps the current Sage runtime model intact while improving terminal behavior around it:

- the TUI reuses the local Sage CLI/backend instead of introducing a new backend stack
- session resume now shares the default Sage session directory instead of using a terminal-private session store
- resumed sessions no longer inject an extra summary banner into transcript history
- built-in skills are copied into terminal state root for TUI skill discovery
- welcome / popup / overlay / transcript flows are covered by regressions and smoke checks
- footer timing now distinguishes total duration and first visible output latency

### CLI contract alignment

This PR tightens the TUI/backend boundary so the Rust TUI depends on explicit CLI contracts rather than ad hoc text parsing.

Added or aligned structured contract support for:

- `doctor --json`
- `config show --json`
- `config init --json`
- `sessions --json`
- `sessions inspect --json`
- `skills --json`
- `provider list --json`
- `provider inspect --json`
- `provider verify --json`
- `provider create --json`
- `provider update --json`
- `provider delete --json`

This includes:

- a centralized Rust-side CLI contract layer
- structured startup parsing
- structured formatting for doctor/config/provider/session results
- more explicit provider mutation parsing and validation

## Runtime / Distribution Groundwork

This PR also establishes the first packaging-facing runtime layer for Sage Terminal.

### Runtime lookup

The TUI now supports runtime root resolution for both source and packaged layouts.

Resolution order:

1. `SAGE_TERMINAL_RUNTIME_ROOT`
2. runtime-adjacent bundled layouts relative to the executable
3. fallback to the current Sage checkout inferred from `CARGO_MANIFEST_DIR`

### Backend entrypoint lookup

The Sage backend entrypoint used by the TUI now resolves in this order:

1. `SAGE_TERMINAL_CLI`
2. bundled `sage`
3. Python fallback via `python -m app.cli.main`

This keeps source checkouts working while also giving packaged layouts a stable launcher contract.

### Python lookup

When the TUI falls back to Python-module execution, the interpreter now resolves in this order:

1. `SAGE_PYTHON`
2. `PYTHON`
3. bundled interpreter candidates
4. fallback to `python3`

### State root behavior

The TUI state root now supports a packaging-friendly model:

1. `SAGE_TERMINAL_STATE_ROOT`
2. `<runtime_root>/.sage-terminal-state` for source checkouts
3. `~/.sage/terminal-state` for packaged-style layouts
4. fallback to `<runtime_root>/.sage-terminal-state`

This preserves current source development behavior while avoiding writes into a read-only packaged runtime tree.

### Launcher and bundle contracts

This PR adds explicit documentation and helper scripts for future packaging work:

- `app/terminal/BOUNDARY.md`
- `app/terminal/CLI_CONTRACT.md`
- `app/terminal/DISTRIBUTION.md`
- `app/terminal/BUNDLE_LAYOUT.md`
- `app/terminal/scripts/run-sage-terminal.sh`
- `app/terminal/scripts/smoke-runtime-distribution.sh`

Together these define:

- TUI vs CLI/runtime ownership boundaries
- the CLI contract surface the TUI depends on
- a preferred bundle directory layout
- a minimal launcher contract
- release-facing smoke validation for runtime resolution

## Module Layout Cleanup

This PR also normalizes the internal Rust module layout so the TUI can continue evolving without accumulating top-level file sprawl.

### Directory module normalization

The following modules were converted from mixed top-level file layouts into directory modules with `mod.rs` entry points:

- `app`
- `backend`
- `terminal`
- `custom_terminal`
- `startup`
- `app_render`

This removes a large portion of the previous “same-name file + same-name directory” transition structure and greatly reduces `#[path = ...]`
indirection.

### Runtime module split

The old `backend_support.rs` was split into focused runtime modules:

- `backend/runtime/root.rs`
- `backend/runtime/cli.rs`
- `backend/runtime/state.rs`

This separates:

- runtime root discovery
- CLI / Python invoker resolution
- state-root and builtin-skill preparation

### Contract module split

The old monolithic backend contract file was split by domain:

- `backend/contract/config.rs`
- `backend/contract/doctor.rs`
- `backend/contract/sessions.rs`
- `backend/contract/skills.rs`
- `backend/contract/providers.rs`
- `backend/contract/stream.rs`
- `backend/contract/common.rs`

### Startup module split

Startup parsing was split into:

- `startup/help.rs`
- `startup/parse.rs`
- `startup/tests.rs`

### Test organization cleanup

The larger terminal/backend test files were also split by topic:

- `backend/tests/{runtime,contract,handle}.rs`
- `terminal/tests/{interaction,provider_args,formatting}.rs`

This makes future TUI/runtime changes easier to verify without growing single monolithic test files.

## Why

The goal of this PR is to establish a usable terminal-first Sage preview without changing the existing Python agent/runtime architecture, while also
making later packaging/distribution work realistic.

This enables:

- a real TUI interaction surface for Sage
- shared sessions with the main CLI
- terminal-first resume / inspect workflows
- popup / picker / overlay navigation for providers, skills, and sessions
- a clearer path for launcher/bundle work later
- a cleaner internal module layout for future follow-up work

## Architecture Notes

This PR should be reviewed as a new interactive surface over the existing Sage runtime, not as a backend rewrite.

Current model:

- Rust handles terminal UI, input, popup, overlay, footer, transcript rendering, and startup routing
- Python CLI/backend continues to handle runtime execution
- TUI and CLI communicate through local CLI/JSON boundaries and the existing chat runtime

## Documentation

Adds and updates TUI/runtime documentation in:

- `app/terminal/README.md`
- `app/terminal/BOUNDARY.md`
- `app/terminal/CLI_CONTRACT.md`
- `app/terminal/DISTRIBUTION.md`
- `app/terminal/BUNDLE_LAYOUT.md`
- `docs/en/applications/TUI.md`
- `docs/zh/applications/TUI.md`
- `README.md`
- `README_CN.md`

The current documentation focuses on source-run usage and preview/runtime contract workflows.

## Validation

Ran:

- `cargo fmt --manifest-path app/terminal/Cargo.toml`
- `cargo check --offline --manifest-path app/terminal/Cargo.toml`
- `cargo test --offline --manifest-path app/terminal/Cargo.toml`
- `pytest -q tests/app/cli`
- `app/terminal/scripts/smoke-runtime-distribution.sh`

Current result:

- `101` Rust TUI tests passing
- `37` Python CLI tests passing

Also ran PTY / smoke validation for:

- `sage-terminal resume`
- `sage-terminal sessions`
- `sage-terminal config init ...`
- `sage-terminal provider verify ...`

including both success-path and expected-error-path behavior through the TUI surface.

## Out of Scope

This PR does not attempt to:

- ship a packaged installer
- provide npm / brew / installer flows
- replace the Python backend
- make the TUI the only Sage CLI surface
- rewrite agent/runtime logic

## Notes For Review

A few points are worth keeping in mind while reviewing:

- this is still a preview / source-run TUI, not a packaged release
- the backend remains the existing Sage CLI/runtime
- most user-facing behavior changes are concentrated in `app/terminal`
- some Python CLI changes are included only to support stable structured integration from the TUI side
- runtime/distribution work in this PR establishes launcher/bundle contracts, but not final packaging
- the latest refactor work is structural cleanup to make the new TUI/runtime layers easier to extend in follow-up PRs