### PR TITLE
Desktop: NSIS-only Windows bundle (remove MSI/WiX)

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -182,35 +182,16 @@ jobs:
         run: |
           $version = "${env:GITHUB_REF}" -replace '^refs/tags/desktop-v', ''
           $nsisDir = "app/desktop/tauri/target/release/bundle/nsis"
-          $msiDir = "app/desktop/tauri/target/release/bundle/msi"
-          
-          # Rename Installer
+          # Windows 仅打 NSIS（.exe）。WiX/light 在 GHA 上常失败，已禁用 MSI。
           if (Test-Path $nsisDir) {
             Get-ChildItem $nsisDir -Filter *.exe | ForEach-Object {
               Move-Item $_.FullName (Join-Path $nsisDir ("Sage-$version-x86_64-setup.exe")) -Force
             }
-            
-            # Rename Updater Bundles (zip & sig)
             Get-ChildItem $nsisDir -Filter *.zip | ForEach-Object {
               Move-Item $_.FullName (Join-Path $nsisDir ("Sage-$version-x86_64-setup.zip")) -Force
             }
             Get-ChildItem $nsisDir -Filter *.zip.sig | ForEach-Object {
               Move-Item $_.FullName (Join-Path $nsisDir ("Sage-$version-x86_64-setup.zip.sig")) -Force
-            }
-          }
-
-          # Rename Installer (MSI)
-          if (Test-Path $msiDir) {
-            Get-ChildItem $msiDir -Filter *.msi | ForEach-Object {
-              Move-Item $_.FullName (Join-Path $msiDir ("Sage-$version-x86_64-setup.msi")) -Force
-            }
-            
-            # Rename Updater Bundles (zip & sig)
-            Get-ChildItem $msiDir -Filter *.zip | ForEach-Object {
-              Move-Item $_.FullName (Join-Path $msiDir ("Sage-$version-x86_64-setup.msi.zip")) -Force
-            }
-            Get-ChildItem $msiDir -Filter *.zip.sig | ForEach-Object {
-              Move-Item $_.FullName (Join-Path $msiDir ("Sage-$version-x86_64-setup.msi.zip.sig")) -Force
             }
           }
 
@@ -231,9 +212,6 @@ jobs:
             app/desktop/tauri/target/release/bundle/nsis/*.exe
             app/desktop/tauri/target/release/bundle/nsis/*.zip
             app/desktop/tauri/target/release/bundle/nsis/*.zip.sig
-            app/desktop/tauri/target/release/bundle/msi/*.msi
-            app/desktop/tauri/target/release/bundle/msi/*.zip
-            app/desktop/tauri/target/release/bundle/msi/*.zip.sig
 
       - name: Collect Linux Release Assets
         if: matrix.platform == 'linux'

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Open [http://localhost:5173](http://localhost:5173). The first run may ask for *
 
 ### Desktop (installers)
 
-Download the latest `.dmg` (macOS), `.exe` / `.msi` (Windows), or `.deb` (Linux) from [GitHub Releases](https://github.com/ZHangZHengEric/Sage/releases), then install as below.
+Download the latest `.dmg` (macOS), `.exe` NSIS installer (Windows), or `.deb` (Linux) from [GitHub Releases](https://github.com/ZHangZHengEric/Sage/releases), then install as below.
 
 **macOS**
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -64,7 +64,7 @@ export SAGE_DEFAULT_LLM_MODEL_NAME="deepseek-chat"
 
 ### 桌面端（安装包）
 
-在 [GitHub Releases](https://github.com/ZHangZHengEric/Sage/releases) 下载 `**.dmg`（macOS）**、`**.exe` / `.msi`（Windows）** 或 `**.deb`（Linux）**，按下面安装。
+在 [GitHub Releases](https://github.com/ZHangZHengEric/Sage/releases) 下载 `**.dmg`（macOS）**、Windows 的 `**.exe`（NSIS 安装包）** 或 `**.deb`（Linux）**，按下面安装。
 
 **macOS**
 

--- a/app/desktop/tauri/tauri.conf.json
+++ b/app/desktop/tauri/tauri.conf.json
@@ -88,17 +88,12 @@
       "app",
       "dmg",
       "nsis",
-      "msi",
       "deb"
-      ],
+    ],
     "windows": {
       "certificateThumbprint": null,
       "digestAlgorithm": "sha256",
       "timestampUrl": "",
-      "wix": {
-        "language": "en-US",
-        "dialogImagePath": "icons/icon.png"
-      },
       "nsis": {
         "languages": ["SimpChinese"],
         "installerIcon": "icons/icon.ico",

--- a/change_log.md
+++ b/change_log.md
@@ -1,3 +1,5 @@
+2026-04-28 16:00 桌面 Windows 发布：从 bundle 中移除 MSI（仅保留 NSIS .exe），避免 GHA 上 WiX light.exe 失败；release-desktop workflow 同步去掉 msi 重命名与上传；README 说明 Windows 为 NSIS 安装包。
+
 2026-04-28 12:00 修复 CI「sage-desktop.spec not found」：根因是 .gitignore 的 *.spec 忽略未提交该文件；增加 !app/desktop/sage-desktop.spec 例外，需执行 git add app/desktop/sage-desktop.spec 并推送后 Linux/mac/Windows 打包才能找到 spec。
 
 2026-04-27 21:00 GitHub release-desktop workflow：pip 缓存 key 的 hashFiles 从无效的 app/desktop/core/requirements.txt 改为根目录 requirements.txt，与构建脚本实际依赖文件一致、依赖变更时缓存能正确失效。

--- a/docs/en/applications/DESKTOP.md
+++ b/docs/en/applications/DESKTOP.md
@@ -25,7 +25,7 @@ The **Desktop** app is a Tauri-packaged product: a local HTTP backend on `127.0.
 
 ## Install from release packages
 
-1. Download the package for your OS from [Releases](https://github.com/ZHangZHengEric/Sage/releases) (e.g. `.dmg` for macOS, `.exe` / `.msi` for Windows, `.deb` for Linux).
+1. Download the package for your OS from [Releases](https://github.com/ZHangZHengEric/Sage/releases) (e.g. `.dmg` for macOS, NSIS `.exe` for Windows, `.deb` for Linux).
 2. Run the installer or drag the app as documented on the download page.
 3. Launch Sage from the Start menu, Applications folder, or app grid.
 

--- a/docs/zh/applications/DESKTOP.md
+++ b/docs/zh/applications/DESKTOP.md
@@ -23,7 +23,7 @@ ref: desktop-app
 
 ## 使用发行包安装
 
-1. 在 [Releases](https://github.com/ZHangZHengEric/Sage/releases) 下载对应系统安装包（如 macOS 用 `.dmg`，Windows 用 `.exe` / `.msi`，Linux 用 `.deb`）。
+1. 在 [Releases](https://github.com/ZHangZHengEric/Sage/releases) 下载对应系统安装包（如 macOS 用 `.dmg`，Windows 用 NSIS 的 `.exe`，Linux 用 `.deb`）。
 2. 按安装向导或拖拽到「应用程序」等完成安装。
 3. 从开始菜单、启动台或应用程序文件夹启动 Sage。
 


### PR DESCRIPTION
## Summary
- Tauri: remove `msi` target; WiX `light` was failing on GHA; ship NSIS `.exe` only.
- Release workflow: drop MSI rename/upload; README and DESKTOP docs note NSIS installer.

## Test plan
- [ ] `Release Desktop App` on `desktop-v*` tag: Windows job completes; NSIS artifacts attach to release.

Made with [Cursor](https://cursor.com)