### PR TITLE
docs: restore Join Our Community and README_CN sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,20 +295,22 @@ We are grateful to our sponsors for their support in making Sage better:
 
 ## 🦌 **Join Our Community**
 
-
+<div align="center">
 
 ### 💬 Connect with us
 
-[Slack](https://join.slack.com/t/sage-b021145/shared_invite/zt-3t8nabs6c-qCEDzNUYtMblPshQTKSWOA)
+[![Slack](https://img.shields.io/badge/Slack-Join%20Community-4A154B?logo=slack&style=for-the-badge)](https://join.slack.com/t/sage-b021145/shared_invite/zt-3t8nabs6c-qCEDzNUYtMblPshQTKSWOA)
 
 ### 📱 WeChat Group
 
-
+<img src="assets/WeChatGroup.jpg" width="300" alt="WeChat Group QR Code"/>
 
 *Scan to join our WeChat community 🦌*
 
-
+</div>
 
 ---
 
+<div align="center">
 Built with ❤️ by the Sage Team 🦌
+</div>

--- a/README_CN.md
+++ b/README_CN.md
@@ -264,15 +264,32 @@ Sage/
 
 ## 💖 **赞助者**
 
-
+<div align="center">
 
 感谢以下赞助者对 Sage 的支持：
 
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <a href="#" target="_blank">
+        <img src="assets/sponsors/dudubashi_logo.png" height="50" alt="嘟嘟巴士"/>
+      </a>
+      <br/>
+    </td>
+    <td align="center" width="33%">
+      <a href="#" target="_blank">
+        <img src="assets/sponsors/xunhuanzhineng_logo.svg" height="50" alt="循环智能"/>
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="#" target="_blank">
+        <img src="assets/sponsors/idata_logo.png" height="50" alt="Data"/>
+      </a>
+    </td>
+  </tr>
+</table>
 
-|     |     |     |
-| --- | --- | --- |
-|     |     |     |
-
+</div>
 
 
 
@@ -280,14 +297,22 @@ Sage/
 
 ## 🦌 **加入我们的社区**
 
+<div align="center">
+
 ### 💬 与我们交流
 
-[Slack](https://join.slack.com/t/sage-b021145/shared_invite/zt-3t8nabs6c-qCEDzNUYtMblPshQTKSWOA)
+[![Slack](https://img.shields.io/badge/Slack-加入社区-4A154B?logo=slack&style=for-the-badge)](https://join.slack.com/t/sage-b021145/shared_invite/zt-3t8nabs6c-qCEDzNUYtMblPshQTKSWOA)
 
 ### 📱 微信群
 
+<img src="assets/WeChatGroup.jpg" width="300" alt="微信群二维码"/>
+
 *扫码加入我们的微信社区 🦌*
+
+</div>
 
 ---
 
+<div align="center">
 Built with ❤️ by the Sage Team 🦌
+</div>

--- a/change_log.md
+++ b/change_log.md
@@ -1,3 +1,5 @@
+2026-04-28 20:00 README / README_CN 恢复「加入社区」：居中、Slack for-the-badge 徽章、微信群 `WeChatGroup.jpg` 图，文末团队署名同区；README_CN 赞助者三列 Logo 与英文对齐。
+
 2026-04-28 19:00 README / README_CN 恢复文首 cover、shield 徽章、产品截图三列 HTML 表，与 2f2efddc 展示一致，Quick Start 等后续段落保持现状。
 
 2026-04-28 18:00 README / README_CN 恢复赞助者区 HTML 与三处 Logo 引用，修复空表；与 2f2efddc 前结构一致。


### PR DESCRIPTION
Follow-up to merged PR #120: restores the Join Our Community block (centered layout, Slack badge, WeChat QR image) in README and README_CN, fixes README_CN sponsor logos table to match English, and updates change_log.md.

Made with [Cursor](https://cursor.com)