### PR TITLE
feat: tag coerced turn_status with metadata.coerced_from and i18n note

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -1,3 +1,5 @@
+2026-04-27 19:00 turn_status-only 补轮 coerce 留痕：被改写的 tool 结果打 metadata.coerced_from，strip 时保留这对 pair 让 LLM 看到事实；改写 note 文案走 PromptManager(zh/en/pt) 并注入原始工具名。
+
 2026-04-27 18:40 turn_status 拒绝文案 i18n：新增 simple_agent_prompts.turn_status_rejection_message（zh/en/pt），SimpleAgent 改写工具结果时按 session 语言通过 PromptManager 取文案，硬编码中文消息移除。
 
 2026-04-27 18:09 ModelProviderList 高级配置：移除 maxTokens/temperature/topP/presencePenalty/maxModelLen 输入框 placeholder，卡片展示的 temperature 兜底改为 '-'，避免清空后视觉上像是没改。

--- a/sagents/agent/simple_agent.py
+++ b/sagents/agent/simple_agent.py
@@ -1,6 +1,6 @@
 from sagents.context.messages.message_manager import MessageManager
 from .agent_base import AgentBase
-from typing import Any, Dict, List, Optional, AsyncGenerator, Union, cast
+from typing import Any, Dict, List, Optional, AsyncGenerator, Tuple, Union, cast
 from sagents.utils.logger import logger
 from sagents.context.messages.message import MessageChunk, MessageRole, MessageType
 from sagents.context.session_context import SessionContext
@@ -384,30 +384,48 @@ class SimpleAgent(AgentBase):
     def _coerce_invalid_status_only_tool_calls(
         self,
         tool_calls: Dict[str, Any],
-    ) -> Dict[str, Any]:
+        language: str = 'en',
+    ) -> Tuple[Dict[str, Any], str, List[str]]:
         """状态补调用阶段，模型若试图调用行动工具，则转成 continue_work 状态。
 
         一些 OpenAI-compatible 后端会在 `tools` 仅包含 turn_status 且
         `tool_choice=required` 时仍返回不在 tools 列表里的旧工具名。这里不执行
-        违规工具，而是把“想继续行动”的意图表达为 turn_status(status=continue_work)。
+        违规工具，而是把"想继续行动"的意图表达为 turn_status(status=continue_work)。
+
+        返回 (改写后的 tool_calls, coerced_turn_status_id, 原始违规工具名列表)。
+        调用方可据此在生成的 tool 结果上打 metadata.coerced_from，并通过
+        strip_turn_status_from_llm_context 让 LLM 下一轮看到这次改写。
         """
+        original_names: List[str] = []
+        seen: set = set()
+        for tc in tool_calls.values():
+            nm = ((tc.get('function') or {}).get('name') or '').strip()
+            if nm and nm not in seen:
+                seen.add(nm)
+                original_names.append(nm)
+
         original_id = next(iter(tool_calls.keys()), None) or f"turn_status_{uuid.uuid4().hex[:8]}"
-        return {
+        note_template = PromptManager().get_agent_prompt_auto(
+            'turn_status_coerced_note', language=language
+        )
+        try:
+            note = note_template.format(tools=", ".join(original_names) or "<unknown>")
+        except (KeyError, IndexError):
+            note = note_template
+        new_tool_calls = {
             original_id: {
                 "id": original_id,
                 "type": "function",
                 "function": {
                     "name": "turn_status",
                     "arguments": json.dumps(
-                        {
-                            "status": "continue_work",
-                            "note": "model attempted an action tool during status-only protocol",
-                        },
+                        {"status": "continue_work", "note": note},
                         ensure_ascii=False,
                     ),
                 },
             }
         }
+        return new_tool_calls, original_id, original_names
 
     def _should_request_turn_status_after_text_response(
         self,
@@ -936,13 +954,19 @@ class SimpleAgent(AgentBase):
                 for tool_call in tool_calls.values()
                 if ((tool_call.get("function") or {}).get("name") or "") not in allowed_tool_names
             }
+            coerced_turn_status_id: Optional[str] = None
+            coerced_from_names: List[str] = []
             if invalid_tool_names:
                 if self._is_turn_status_only_request(tools_json, force_tool_choice_required):
                     logger.warning(
                         f"SimpleAgent: turn_status-only 阶段模型返回了未提供的工具 {sorted(invalid_tool_names)}，"
                         "已改写为 turn_status(status=continue_work)"
                     )
-                    tool_calls = self._coerce_invalid_status_only_tool_calls(tool_calls)
+                    live_ctx_for_coerce = self._get_live_session_context(session_id)
+                    coerce_lang = live_ctx_for_coerce.get_language() if live_ctx_for_coerce is not None else 'en'
+                    tool_calls, coerced_turn_status_id, coerced_from_names = (
+                        self._coerce_invalid_status_only_tool_calls(tool_calls, language=coerce_lang)
+                    )
                 else:
                     logger.warning(
                         f"SimpleAgent: 模型返回未提供的工具 {sorted(invalid_tool_names)}，拒绝执行"
@@ -1026,6 +1050,19 @@ class SimpleAgent(AgentBase):
                             )
                             msg.content = rejection
                             msg.metadata = {**(msg.metadata or {}), 'turn_status_rejected': True}
+
+                # status-only 补轮里被改写的 turn_status：在 tool 结果上打 metadata.coerced_from，
+                # 让 strip_turn_status_from_llm_context 保留这对 pair，模型下一轮就能明白
+                # "上次调 X 被忽略，所以现在 should_end=false"。SSE 侧仍按 tool_call_id 隐藏。
+                if coerced_turn_status_id and not is_complete:
+                    coerced_from_label = ",".join(coerced_from_names) or "<unknown>"
+                    for msg in messages:
+                        if msg.role == MessageRole.TOOL.value and msg.tool_call_id == coerced_turn_status_id:
+                            logger.info(
+                                f"SimpleAgent: 标记 coerced turn_status 工具结果 {msg.tool_call_id} "
+                                f"coerced_from={coerced_from_label}"
+                            )
+                            msg.metadata = {**(msg.metadata or {}), 'coerced_from': coerced_from_label}
 
                 yield (messages, is_complete)
 

--- a/sagents/context/messages/message_manager.py
+++ b/sagents/context/messages/message_manager.py
@@ -742,10 +742,11 @@ class MessageManager:
         """
         从即将发往 LLM 的消息列表中移除 turn_status 工具调用及其 tool 回复。
 
-        例外：被 SimpleAgent 标记 ``metadata.turn_status_rejected=True`` 的 tool 结果
-        必须保留（连同对应 assistant tool_call），让模型下一轮能看到"先写总结再调
-        turn_status"的反馈，避免反复重蹈覆辙；SSE 侧仍由
-        ``_redact_hidden_tools_from_chunk`` 按 tool_call_id 隐藏，前端不会感知。
+        例外：被 SimpleAgent 标记 ``metadata.turn_status_rejected=True`` 或
+        ``metadata.coerced_from`` 的 tool 结果必须保留（连同对应 assistant tool_call），
+        让模型下一轮能看到"先写总结再调 turn_status"的反馈或"上次调 X 被改写"的事实，
+        避免反复重蹈覆辙；SSE 侧仍由 ``_redact_hidden_tools_from_chunk`` 按
+        tool_call_id 隐藏，前端不会感知。
 
         不影响 message_manager.messages / messages.json 中的原始记录；
         仅在构造 API 请求或 extract_messages_for_inference 出口处使用。
@@ -762,18 +763,21 @@ class MessageManager:
                 if name == TURN_STATUS_TOOL_NAME and tid:
                     turn_ids.add(tid)
 
-        rejected_ids: set[str] = set()
+        preserved_ids: set[str] = set()
         for msg in messages:
             if (
                 msg.role == MessageRole.TOOL.value
                 and msg.tool_call_id
                 and msg.tool_call_id in turn_ids
                 and isinstance(msg.metadata, dict)
-                and msg.metadata.get('turn_status_rejected') is True
+                and (
+                    msg.metadata.get('turn_status_rejected') is True
+                    or msg.metadata.get('coerced_from')
+                )
             ):
-                rejected_ids.add(msg.tool_call_id)
+                preserved_ids.add(msg.tool_call_id)
 
-        strip_ids = turn_ids - rejected_ids
+        strip_ids = turn_ids - preserved_ids
 
         out: List[MessageChunk] = []
         for msg in messages:
@@ -784,8 +788,8 @@ class MessageManager:
                 kept: List[Any] = []
                 for tc in msg.tool_calls:
                     name, tid = MessageManager._tool_call_entry_name_and_id(tc)
-                    # 仅当这条 turn_status 调用对应的 tool 结果未被标记 rejected 时才剔除；
-                    # rejected 的 pair 整体保留，避免出现孤儿 tool 消息。
+                    # 仅当这条 turn_status 调用对应的 tool 结果未被标记 rejected/coerced 时才剔除；
+                    # 被保留的 pair 整体保留，避免出现孤儿 tool 消息。
                     if name == TURN_STATUS_TOOL_NAME and tid in strip_ids:
                         continue
                     kept.append(tc)

--- a/sagents/prompts/simple_agent_prompts.py
+++ b/sagents/prompts/simple_agent_prompts.py
@@ -90,6 +90,26 @@ turn_status_rejection_message = {
 }
 
 
+# turn_status_only 补轮中模型仍调用了未提供的工具时，将其改写为 continue_work 时的 note 文案。
+# 占位符 {tools} 会被替换为原始违规工具名（逗号分隔）。
+turn_status_coerced_note = {
+    "zh": (
+        "系统检测到本轮只允许调用 turn_status，但模型尝试调用了未提供的工具：{tools}。"
+        "已忽略这些工具调用，并按 continue_work 处理；本轮不会结束，下一轮请先输出面向用户的说明再决定状态。"
+    ),
+    "en": (
+        "System: this turn only allows calling turn_status, but the model attempted unavailable tools: {tools}. "
+        "Those calls were ignored and treated as continue_work; this turn does not end. "
+        "Next turn, write a user-facing summary first, then decide the status."
+    ),
+    "pt": (
+        "Sistema: este turno só permite chamar turn_status, mas o modelo tentou ferramentas indisponíveis: {tools}. "
+        "Essas chamadas foram ignoradas e tratadas como continue_work; este turno não termina. "
+        "No próximo turno, escreva primeiro um resumo voltado ao usuário e depois decida o status."
+    ),
+}
+
+
 # 任务完成判断模板
 task_complete_template = {
     "zh": """你要根据历史的对话以及用户的请求，以及 agent 的配置中对于事情的执行要求，判断此刻是否可以安全地中断执行任务（视为阶段结束），还是应该继续执行。

--- a/tests/sagents/agent/test_simple_agent_finish_summary.py
+++ b/tests/sagents/agent/test_simple_agent_finish_summary.py
@@ -155,6 +155,38 @@ def test_turn_status_tools_only_filters_action_tools():
     assert _agent()._turn_status_tools_only(tools_json) == [{"function": {"name": "turn_status"}}]
 
 
+def test_coerce_invalid_status_only_returns_continue_work_with_metadata():
+    """status-only 补轮里改写违规工具：保留原 id、记录原始工具名、note 走 i18n。"""
+    import json
+
+    invalid_calls = {
+        "call_X": {
+            "id": "call_X",
+            "type": "function",
+            "function": {"name": "todo_write", "arguments": "{}"},
+        },
+        "call_Y": {
+            "id": "call_Y",
+            "type": "function",
+            "function": {"name": "load_skill", "arguments": "{}"},
+        },
+    }
+    new_calls, coerced_id, original_names = _agent()._coerce_invalid_status_only_tool_calls(
+        invalid_calls, language="zh"
+    )
+
+    assert coerced_id == "call_X"
+    assert set(original_names) == {"todo_write", "load_skill"}
+    assert list(new_calls.keys()) == ["call_X"]
+    fn = new_calls["call_X"]["function"]
+    assert fn["name"] == "turn_status"
+    args = json.loads(fn["arguments"])
+    assert args["status"] == "continue_work"
+    # 中文文案 + 原始工具名注入到 note
+    assert "todo_write" in args["note"] and "load_skill" in args["note"]
+    assert "turn_status" in args["note"]
+
+
 def test_turn_status_from_tool_call_reads_continue_work():
     tool_call = {
         "function": {

--- a/tests/sagents/messages/test_turn_status_llm_strip.py
+++ b/tests/sagents/messages/test_turn_status_llm_strip.py
@@ -196,6 +196,29 @@ def test_strip_keeps_rejected_pair_inside_mixed_tool_calls():
     assert out[2].tool_call_id == "rej_3"
 
 
+def test_strip_keeps_coerced_turn_status_pair():
+    """status-only 补轮里被改写的 turn_status (metadata.coerced_from) 必须保留，让 LLM 看到改写事实。"""
+    assistant = MessageChunk(
+        role=MessageRole.ASSISTANT.value,
+        content=None,
+        tool_calls=[_tc(TURN_STATUS_TOOL_NAME, "coerce_1")],
+        message_type=MessageType.TOOL_CALL.value,
+    )
+    tool_msg = MessageChunk(
+        role=MessageRole.TOOL.value,
+        content='{"success":true,"status":"success","should_end":false}',
+        tool_call_id="coerce_1",
+        message_type=MessageType.TOOL_CALL_RESULT.value,
+        metadata={"coerced_from": "todo_write"},
+    )
+    out = MessageManager.strip_turn_status_from_llm_context([assistant, tool_msg])
+    assert len(out) == 2
+    assert out[0].role == MessageRole.ASSISTANT.value
+    assert out[0].tool_calls and out[0].tool_calls[0]["id"] == "coerce_1"
+    assert out[1].role == MessageRole.TOOL.value
+    assert out[1].tool_call_id == "coerce_1"
+
+
 def test_idempotent():
     m = [
         MessageChunk(


### PR DESCRIPTION
## Summary
- In the turn_status-only fallback round, when the model still calls a non-allowlisted tool (e.g. `todo_write`), the call is coerced into `turn_status(status=continue_work)` as before — but now the resulting tool result is tagged with `metadata.coerced_from=<original tool names>`.
- `strip_turn_status_from_llm_context` preserves this pair (alongside `turn_status_rejected`) so the LLM sees on the next turn that its prior call was rewritten and `should_end=false` is intentional, instead of believing it really invoked `todo_write`.
- The `note` field of the coerced `turn_status` argument is now sourced via `PromptManager` (`turn_status_coerced_note`, zh/en/pt) and includes the original tool names via `{tools}`.
- SSE behavior unchanged — coerced `turn_status` is still hidden from the user via `HIDDEN_FROM_STREAM_TOOL_NAMES`.

## Test plan
- [x] `tests/sagents/messages/test_turn_status_llm_strip.py::test_strip_keeps_coerced_turn_status_pair`
- [x] `tests/sagents/agent/test_simple_agent_finish_summary.py::test_coerce_invalid_status_only_returns_continue_work_with_metadata`
- [x] Existing redact + strip suites still green (36 tests)
- [ ] Manual smoke: trigger the original repro (model returns `todo_write` in a status-only round) and verify the next turn shows the coerce note in the LLM input

Made with [Cursor](https://cursor.com)