### PR TITLE
feat: keep last turn_status pair in LLM context, tighten reasoning model detection

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -1,3 +1,5 @@
+2026-04-27 20:05 turn_status 上下文裁剪策略升级 + reasoning_effort 修正：strip_turn_status_from_llm_context 新增"保留最后一条 turn_status pair"，避免模型看不到自己上一轮状态决策反复重刷；新增白名单式 is_openai_reasoning_model 替换 agent_base 宽匹配（不再误伤 gpt-4o 等）；抽出 resolve_reasoning_effort，思考关闭时默认仍 low，新增 SAGE_REASONING_EFFORT_OFF 环境变量按需切 minimal/medium/high；补 strip 与 reasoning 判定/effort 单测。
+
 2026-04-27 19:00 turn_status-only 补轮 coerce 留痕：被改写的 tool 结果打 metadata.coerced_from，strip 时保留这对 pair 让 LLM 看到事实；改写 note 文案走 PromptManager(zh/en/pt) 并注入原始工具名。
 
 2026-04-27 18:40 turn_status 拒绝文案 i18n：新增 simple_agent_prompts.turn_status_rejection_message（zh/en/pt），SimpleAgent 改写工具结果时按 session 语言通过 PromptManager 取文案，硬编码中文消息移除。

--- a/sagents/agent/agent_base.py
+++ b/sagents/agent/agent_base.py
@@ -12,6 +12,7 @@ from sagents.context.messages.message_manager import MessageManager
 from sagents.utils.prompt_caching import add_cache_control_to_messages
 from sagents.llm.sage_openai import SageAsyncOpenAI
 from sagents.llm.capabilities import create_chat_completion_with_fallback
+from sagents.llm.model_capabilities import is_openai_reasoning_model, resolve_reasoning_effort
 from sagents.utils.llm_request_utils import (
     format_api_error_details,
     is_unsupported_input_format_error,
@@ -265,22 +266,24 @@ class AgentBase(ABC):
                     "_step_name": step_name # 观察用，记录下当前是哪个步骤的调用
                 }
 
-                # 判断是否为 OpenAI 推理模型
-                is_openai_reasoning_model = (
-                    model_name.startswith("o3-") or
-                    model_name.startswith("o1-") or
-                    "gpt" in model_name.lower() or
-                    "gpt-5.1" in model_name.lower()
-                )
+                # 判断是否为 OpenAI / 兼容三方 reasoning 模型（白名单前缀，避免误伤 gpt-4o 等）
+                is_reasoning_model = is_openai_reasoning_model(model_name)
 
-                if is_openai_reasoning_model:
+                if is_reasoning_model:
                     # OpenAI 推理模型使用 reasoning_effort 参数
                     # low = 最小化推理，medium = 平衡，high = 最大化推理
-                    if final_enable_thinking:
-                        extra_body["reasoning_effort"] = "medium"  # 或者 "high"
-                    else:
-                        extra_body["reasoning_effort"] = "low"  # 最小化推理
-                    logger.debug(f"{self.__class__.__name__} | {step_name}: OpenAI推理模型，reasoning_effort={extra_body['reasoning_effort']}")
+                    # 注：OpenAI Chat Completions 接口对 o-/gpt-5 系不回传 reasoning content，
+                    # 仅在 usage.reasoning_tokens 上报 token 消耗，无法通过该参数关闭。
+                    # SAGE_REASONING_EFFORT_OFF 仅在思考关闭时生效，可切换到 minimal/medium/high。
+                    effort = resolve_reasoning_effort(
+                        enable_thinking=final_enable_thinking,
+                        env_value=os.environ.get("SAGE_REASONING_EFFORT_OFF"),
+                        default_off="low",
+                    )
+                    extra_body["reasoning_effort"] = effort
+                    logger.debug(
+                        f"{self.__class__.__name__} | {step_name}: OpenAI推理模型，reasoning_effort={effort}"
+                    )
                 else:
                     # 其他模型使用 enable_thinking/thinking 参数
                     extra_body["chat_template_kwargs"] = {"enable_thinking": final_enable_thinking}

--- a/sagents/context/messages/message_manager.py
+++ b/sagents/context/messages/message_manager.py
@@ -755,6 +755,7 @@ class MessageManager:
             return []
 
         turn_ids: set[str] = set()
+        last_turn_id: Optional[str] = None
         for msg in messages:
             if msg.role != MessageRole.ASSISTANT.value or not msg.tool_calls:
                 continue
@@ -762,6 +763,7 @@ class MessageManager:
                 name, tid = MessageManager._tool_call_entry_name_and_id(tc)
                 if name == TURN_STATUS_TOOL_NAME and tid:
                     turn_ids.add(tid)
+                    last_turn_id = tid
 
         preserved_ids: set[str] = set()
         for msg in messages:
@@ -776,6 +778,11 @@ class MessageManager:
                 )
             ):
                 preserved_ids.add(msg.tool_call_id)
+
+        # 保留最后一条 turn_status pair（无论 status 类型），让 LLM 看到自己上一轮的状态决策，
+        # 避免反复刷 turn_status；历史 turn_status 仍按现策略剔除。
+        if last_turn_id is not None:
+            preserved_ids.add(last_turn_id)
 
         strip_ids = turn_ids - preserved_ids
 

--- a/sagents/llm/model_capabilities.py
+++ b/sagents/llm/model_capabilities.py
@@ -16,9 +16,58 @@ _TEST_IMAGE_URL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAA
 _COLOR_KEYWORDS = ["red", "红色", "红", "赤", "绯", "朱", "丹", "绛"]
 
 
+_REASONING_MODEL_PREFIXES: tuple[str, ...] = (
+    "o1-",
+    "o3-",
+    "o4-",
+    "gpt-5",  # gpt-5, gpt-5-, gpt-5.x, gpt-5-mini 等 reasoning 系
+)
+_REASONING_MODEL_EXACT: frozenset[str] = frozenset({"o1", "o3", "o4"})
+
+
+_VALID_REASONING_EFFORTS: frozenset[str] = frozenset({"minimal", "low", "medium", "high"})
+
+
+def is_openai_reasoning_model(model_name: str) -> bool:
+    """是否为 OpenAI / 兼容三方的 reasoning 系列模型。
+
+    判定基于显式前缀/精确名单，避免把 ``gpt-4o``/``gpt-4-turbo``/``gpt-3.5`` 这类
+    非 reasoning 模型误判进 reasoning 路径。
+    """
+    if not model_name:
+        return False
+    name = model_name.strip().lower()
+    if not name:
+        return False
+    if name in _REASONING_MODEL_EXACT:
+        return True
+    return any(name.startswith(prefix) for prefix in _REASONING_MODEL_PREFIXES)
+
+
+def resolve_reasoning_effort(
+    enable_thinking: bool,
+    env_value: Optional[str] = None,
+    default_off: str = "low",
+) -> str:
+    """根据是否启用思考与环境变量解析最终的 ``reasoning_effort``。
+
+    - ``enable_thinking=True`` → ``"medium"``
+    - ``enable_thinking=False`` → ``env_value`` 优先（小写），无效或为空时回退 ``default_off``
+    - 合法值：minimal / low / medium / high
+    """
+    if enable_thinking:
+        return "medium"
+    if env_value is None:
+        return default_off
+    candidate = env_value.strip().lower()
+    if candidate and candidate in _VALID_REASONING_EFFORTS:
+        return candidate
+    return default_off
+
+
 def _is_openai_reasoning_model(model_name: str) -> bool:
-    model = (model_name or "").lower()
-    return model.startswith("o3-") or model.startswith("o1-") or "gpt" in model or "gpt-5.1" in model
+    """旧名兼容的 thin wrapper。"""
+    return is_openai_reasoning_model(model_name)
 
 
 def _build_client(api_key: str, base_url: str, timeout: float) -> AsyncOpenAI:

--- a/tests/sagents/llm/test_model_capabilities.py
+++ b/tests/sagents/llm/test_model_capabilities.py
@@ -1,6 +1,96 @@
 import unittest
 
 from sagents.llm import model_capabilities
+from sagents.llm.model_capabilities import (
+    is_openai_reasoning_model,
+    resolve_reasoning_effort,
+)
+
+
+class TestResolveReasoningEffort(unittest.TestCase):
+    def test_thinking_enabled_uses_medium(self):
+        self.assertEqual(
+            resolve_reasoning_effort(enable_thinking=True, env_value=None),
+            "medium",
+        )
+        # 思考开启时即便环境变量给了别的值，也不应被覆盖
+        self.assertEqual(
+            resolve_reasoning_effort(enable_thinking=True, env_value="minimal"),
+            "medium",
+        )
+
+    def test_thinking_disabled_default_low(self):
+        self.assertEqual(
+            resolve_reasoning_effort(enable_thinking=False, env_value=None),
+            "low",
+        )
+        self.assertEqual(
+            resolve_reasoning_effort(enable_thinking=False, env_value=""),
+            "low",
+        )
+
+    def test_thinking_disabled_env_override(self):
+        for v in ["minimal", "low", "medium", "high", "MINIMAL", " High "]:
+            with self.subTest(env=v):
+                self.assertEqual(
+                    resolve_reasoning_effort(enable_thinking=False, env_value=v),
+                    v.strip().lower(),
+                )
+
+    def test_thinking_disabled_invalid_env_falls_back(self):
+        for v in ["foobar", "off", "none", "0"]:
+            with self.subTest(env=v):
+                self.assertEqual(
+                    resolve_reasoning_effort(enable_thinking=False, env_value=v),
+                    "low",
+                )
+
+    def test_custom_default_off(self):
+        self.assertEqual(
+            resolve_reasoning_effort(enable_thinking=False, env_value=None, default_off="minimal"),
+            "minimal",
+        )
+
+
+class TestIsOpenAIReasoningModel(unittest.TestCase):
+    def test_reasoning_models_recognized(self):
+        for name in [
+            "o1",
+            "o1-mini",
+            "o1-preview",
+            "o3",
+            "o3-mini",
+            "o3-pro",
+            "o4",
+            "o4-mini",
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-5.1",
+            "gpt-5.4-mini",
+            "gpt-5.4-mini-2026-03-17",
+            "GPT-5",  # 大小写无关
+        ]:
+            with self.subTest(model=name):
+                self.assertTrue(is_openai_reasoning_model(name))
+
+    def test_non_reasoning_models_not_recognized(self):
+        for name in [
+            "",
+            None,
+            "gpt-4",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-4-turbo",
+            "gpt-3.5-turbo",
+            "qwen-max",
+            "qwen2.5-7b",
+            "deepseek-chat",
+            "deepseek-r1",  # 非 OpenAI 系，走 enable_thinking 路径
+            "claude-3-5-sonnet",
+            "o100",  # 不应被宽匹配
+        ]:
+            with self.subTest(model=name):
+                self.assertFalse(is_openai_reasoning_model(name))
 
 
 class TestProbeLlmCapabilities(unittest.IsolatedAsyncioTestCase):

--- a/tests/sagents/messages/test_turn_status_llm_strip.py
+++ b/tests/sagents/messages/test_turn_status_llm_strip.py
@@ -14,30 +14,49 @@ def _tc(name: str, tc_id: str) -> dict:
     }
 
 
-def test_strip_removes_turn_status_pair_keeps_assistant_text():
-    assistant = MessageChunk(
+def test_strip_keeps_only_last_turn_status_pair():
+    """多条历史 turn_status：仅最后一条 pair 保留，其余历史剔除；assistant 文本独立保留。"""
+    a1 = MessageChunk(
         role=MessageRole.ASSISTANT.value,
-        content="阶段总结说明",
-        tool_calls=[_tc(TURN_STATUS_TOOL_NAME, "call_ts_1")],
+        content="阶段一总结",
+        tool_calls=[_tc(TURN_STATUS_TOOL_NAME, "old_1")],
         message_type=MessageType.TOOL_CALL.value,
     )
-    tool_msg = MessageChunk(
+    t1 = MessageChunk(
         role=MessageRole.TOOL.value,
-        content='{"turn_status":"task_done"}',
-        tool_call_id="call_ts_1",
+        content='{"success":true}',
+        tool_call_id="old_1",
         message_type=MessageType.TOOL_CALL_RESULT.value,
     )
-    out = MessageManager.strip_turn_status_from_llm_context([assistant, tool_msg])
-    assert len(out) == 1
+    a2 = MessageChunk(
+        role=MessageRole.ASSISTANT.value,
+        content="阶段二总结",
+        tool_calls=[_tc(TURN_STATUS_TOOL_NAME, "last_1")],
+        message_type=MessageType.TOOL_CALL.value,
+    )
+    t2 = MessageChunk(
+        role=MessageRole.TOOL.value,
+        content='{"success":true,"should_end":true}',
+        tool_call_id="last_1",
+        message_type=MessageType.TOOL_CALL_RESULT.value,
+    )
+    out = MessageManager.strip_turn_status_from_llm_context([a1, t1, a2, t2])
+    # a1 的 turn_status 被剔除（保留 content），a2 的 turn_status 是最后一条 → 整对保留
+    assert len(out) == 3
     assert out[0].role == MessageRole.ASSISTANT.value
-    assert out[0].content == "阶段总结说明"
+    assert out[0].content == "阶段一总结"
     assert out[0].tool_calls is None
+    assert out[1].role == MessageRole.ASSISTANT.value
+    assert out[1].tool_calls and out[1].tool_calls[0]["id"] == "last_1"
+    assert out[2].role == MessageRole.TOOL.value
+    assert out[2].tool_call_id == "last_1"
 
 
-def test_strip_drops_assistant_that_only_had_turn_status():
+def test_strip_keeps_single_turn_status_as_last():
+    """仅 1 条 turn_status 时，它就是最后一条，按新策略整对保留。"""
     assistant = MessageChunk(
         role=MessageRole.ASSISTANT.value,
-        content=None,
+        content="阶段总结",
         tool_calls=[_tc(TURN_STATUS_TOOL_NAME, "only_ts")],
         message_type=MessageType.TOOL_CALL.value,
     )
@@ -48,10 +67,13 @@ def test_strip_drops_assistant_that_only_had_turn_status():
         message_type=MessageType.TOOL_CALL_RESULT.value,
     )
     out = MessageManager.strip_turn_status_from_llm_context([assistant, tool_msg])
-    assert out == []
+    assert len(out) == 2
+    assert out[0].tool_calls and out[0].tool_calls[0]["id"] == "only_ts"
+    assert out[1].tool_call_id == "only_ts"
 
 
-def test_strip_keeps_other_tools():
+def test_strip_keeps_other_tools_and_last_turn_status():
+    """turn_status 与其他工具同条 assistant；当它是最后一条 turn_status，整条 assistant 与对应 tool 结果都保留。"""
     assistant = MessageChunk(
         role=MessageRole.ASSISTANT.value,
         content="执行中",
@@ -74,14 +96,64 @@ def test_strip_keeps_other_tools():
         message_type=MessageType.TOOL_CALL_RESULT.value,
     )
     out = MessageManager.strip_turn_status_from_llm_context([assistant, t1, t2])
-    assert len(out) == 2
+    assert len(out) == 3
     assert out[0].tool_calls is not None
-    assert len(out[0].tool_calls) == 1
-    assert out[0].tool_calls[0]["function"]["name"] == "grep"
+    names = [tc["function"]["name"] for tc in out[0].tool_calls]
+    assert names == ["grep", TURN_STATUS_TOOL_NAME]
     assert out[1].tool_call_id == "c1"
+    assert out[2].tool_call_id == "c2"
 
 
-def test_extract_messages_for_inference_strips_turn_status():
+def test_strip_historical_turn_status_inside_mixed_tool_calls():
+    """同条 assistant 里既有 turn_status 又有其他工具，且后续还有更新的 turn_status：
+    本条的 turn_status 视为历史，应从 tool_calls 里裁掉，其他工具与文本保留。"""
+    assistant_old = MessageChunk(
+        role=MessageRole.ASSISTANT.value,
+        content="进行中",
+        tool_calls=[
+            _tc("grep", "g1"),
+            _tc(TURN_STATUS_TOOL_NAME, "old_ts"),
+        ],
+        message_type=MessageType.TOOL_CALL.value,
+    )
+    tool_g = MessageChunk(
+        role=MessageRole.TOOL.value,
+        content="hits",
+        tool_call_id="g1",
+        message_type=MessageType.TOOL_CALL_RESULT.value,
+    )
+    tool_old = MessageChunk(
+        role=MessageRole.TOOL.value,
+        content='{"success":true}',
+        tool_call_id="old_ts",
+        message_type=MessageType.TOOL_CALL_RESULT.value,
+    )
+    assistant_new = MessageChunk(
+        role=MessageRole.ASSISTANT.value,
+        content="阶段二",
+        tool_calls=[_tc(TURN_STATUS_TOOL_NAME, "last_ts")],
+        message_type=MessageType.TOOL_CALL.value,
+    )
+    tool_new = MessageChunk(
+        role=MessageRole.TOOL.value,
+        content='{"success":true,"should_end":true}',
+        tool_call_id="last_ts",
+        message_type=MessageType.TOOL_CALL_RESULT.value,
+    )
+    out = MessageManager.strip_turn_status_from_llm_context(
+        [assistant_old, tool_g, tool_old, assistant_new, tool_new]
+    )
+    # assistant_old 的 turn_status 历史 → 被裁；grep 与文本保留；old_ts 的 tool 结果被剔除
+    # assistant_new 是最后一条 turn_status → 整对保留
+    assert len(out) == 4
+    names = [tc["function"]["name"] for tc in (out[0].tool_calls or [])]
+    assert names == ["grep"]
+    assert out[1].tool_call_id == "g1"
+    assert out[2].tool_calls and out[2].tool_calls[0]["id"] == "last_ts"
+    assert out[3].tool_call_id == "last_ts"
+
+
+def test_extract_messages_for_inference_keeps_last_turn_status():
     assistant = MessageChunk(
         role=MessageRole.ASSISTANT.value,
         content="hi",
@@ -93,8 +165,9 @@ def test_extract_messages_for_inference_strips_turn_status():
         tool_call_id="x",
     )
     out = MessageManager.extract_messages_for_inference([assistant, tool_msg])
-    assert len(out) == 1
-    assert out[0].tool_calls is None
+    # 仅 1 条 turn_status → 最后一条 → 保留
+    assert len(out) == 2
+    assert out[0].tool_calls and out[0].tool_calls[0]["id"] == "x"
 
 
 def test_strip_keeps_rejected_turn_status_pair():
@@ -122,46 +195,57 @@ def test_strip_keeps_rejected_turn_status_pair():
     assert out[1].tool_call_id == "rej_1"
 
 
-def test_strip_only_keeps_rejected_pair_when_mixed_with_success():
-    """rejected 与正常 turn_status 共存：仅保留 rejected pair，正常 pair 仍剔除。"""
-    assistant_ok = MessageChunk(
-        role=MessageRole.ASSISTANT.value,
-        content="先讲清楚再调。",
-        tool_calls=[_tc(TURN_STATUS_TOOL_NAME, "ok_1")],
-        message_type=MessageType.TOOL_CALL.value,
-    )
-    tool_ok = MessageChunk(
-        role=MessageRole.TOOL.value,
-        content='{"success":true,"should_end":true}',
-        tool_call_id="ok_1",
-        message_type=MessageType.TOOL_CALL_RESULT.value,
-    )
-    assistant_rej = MessageChunk(
+def test_strip_keeps_rejected_when_not_last():
+    """rejected 在中间，最后又有一条普通 turn_status：rejected 与最后一条都保留。"""
+    a_rej = MessageChunk(
         role=MessageRole.ASSISTANT.value,
         content=None,
-        tool_calls=[_tc(TURN_STATUS_TOOL_NAME, "rej_2")],
+        tool_calls=[_tc(TURN_STATUS_TOOL_NAME, "rej_x")],
         message_type=MessageType.TOOL_CALL.value,
     )
-    tool_rej = MessageChunk(
+    t_rej = MessageChunk(
         role=MessageRole.TOOL.value,
-        content="turn_status 调用被拒绝：本轮 assistant 还没有输出任何自然语言说明。",
-        tool_call_id="rej_2",
+        content="turn_status 调用被拒绝：先写说明。",
+        tool_call_id="rej_x",
         message_type=MessageType.TOOL_CALL_RESULT.value,
         metadata={"turn_status_rejected": True},
     )
-    out = MessageManager.strip_turn_status_from_llm_context(
-        [assistant_ok, tool_ok, assistant_rej, tool_rej]
+    a_mid = MessageChunk(
+        role=MessageRole.ASSISTANT.value,
+        content="中间普通一轮",
+        tool_calls=[_tc(TURN_STATUS_TOOL_NAME, "mid")],
+        message_type=MessageType.TOOL_CALL.value,
     )
-    # assistant_ok 仅含一个 turn_status，被剔除整段；其文本由 strip 规则保留
-    assert len(out) == 3
-    assert out[0].role == MessageRole.ASSISTANT.value
-    assert out[0].content == "先讲清楚再调。"
-    assert out[0].tool_calls is None
-    # rejected pair 整体保留
-    assert out[1].role == MessageRole.ASSISTANT.value
-    assert out[1].tool_calls and out[1].tool_calls[0]["id"] == "rej_2"
-    assert out[2].role == MessageRole.TOOL.value
-    assert out[2].tool_call_id == "rej_2"
+    t_mid = MessageChunk(
+        role=MessageRole.TOOL.value,
+        content='{"success":true}',
+        tool_call_id="mid",
+        message_type=MessageType.TOOL_CALL_RESULT.value,
+    )
+    a_last = MessageChunk(
+        role=MessageRole.ASSISTANT.value,
+        content="最后一轮",
+        tool_calls=[_tc(TURN_STATUS_TOOL_NAME, "last")],
+        message_type=MessageType.TOOL_CALL.value,
+    )
+    t_last = MessageChunk(
+        role=MessageRole.TOOL.value,
+        content='{"success":true,"should_end":true}',
+        tool_call_id="last",
+        message_type=MessageType.TOOL_CALL_RESULT.value,
+    )
+    out = MessageManager.strip_turn_status_from_llm_context(
+        [a_rej, t_rej, a_mid, t_mid, a_last, t_last]
+    )
+    kept_ids = [
+        m.tool_call_id
+        for m in out
+        if m.role == MessageRole.TOOL.value
+    ]
+    assert kept_ids == ["rej_x", "last"]
+    # 中间 mid 的 assistant 仅保留 content，tool_calls 被剔除
+    mids = [m for m in out if m.role == MessageRole.ASSISTANT.value and m.content == "中间普通一轮"]
+    assert mids and mids[0].tool_calls is None
 
 
 def test_strip_keeps_rejected_pair_inside_mixed_tool_calls():


### PR DESCRIPTION
## Summary
- `strip_turn_status_from_llm_context` 新增"保留最后一条 turn_status pair"逻辑，避免模型看不到上一轮状态决策反复刷 `turn_status`；rejected/coerced pair 仍按原策略保留。
- 新增白名单式 `is_openai_reasoning_model`（前缀 `o1-/o3-/o4-/gpt-5` + 精确名 `o1/o3/o4`），替换 `agent_base` 里 `"gpt" in name` 宽匹配，避免误把 `gpt-4o` 等当 reasoning。
- 抽出 `resolve_reasoning_effort`：思考关闭时默认仍 `low`（保持现网行为），新增 `SAGE_REASONING_EFFORT_OFF` 环境变量按需切 `minimal/medium/high`。
- 注释/changelog 说明 OpenAI Chat Completions 对 o-/gpt-5 系不回传 reasoning content，仅在 `usage.reasoning_tokens` 上报，是设计如此。

## Test plan
- [x] `pytest tests/sagents/messages/test_turn_status_llm_strip.py`
- [x] `pytest tests/sagents/llm/test_model_capabilities.py`
- [x] `pytest tests/sagents/test_sagents_run_stream_redact.py`


Made with [Cursor](https://cursor.com)