### PR TITLE
feat: shell completion push notification and adaptive await_shell

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -1,3 +1,9 @@
+2026-04-27 23:30 shell tool 进一步优化：await_shell 入口也触发 12h GC；tail 截断加错误行优先逻辑（尾部空行时反向搜 ERROR/Exception 等行置顶）；reminder 文本中英文国际化；补测试共 14 项全绿。
+
+2026-04-27 23:05 shell tool GC + reminder 优化：system_reminder tail 截至 512B 尾部优先 + 提示调 await_shell 拿完整结果；pop_completion_events 不删 _BG_TASKS；加 12h 超期 GC（每次 spawn 触发）；补测试 11 项全绿。
+
+2026-04-27 22:15 shell 工具反轮询优化：execute_command_tool 加后台 completion watcher 与 session 级事件字典；_call_llm_streaming 每次请求前 flush 为 <system_reminder> 注入；await_shell 默认 600s + 自适应改写 + 元数据；统一 system prompt 加 reminder 语义说明；新增单元测试。
+
 2026-04-27 20:05 turn_status 上下文裁剪策略升级 + reasoning_effort 修正：strip_turn_status_from_llm_context 新增"保留最后一条 turn_status pair"，避免模型看不到自己上一轮状态决策反复重刷；新增白名单式 is_openai_reasoning_model 替换 agent_base 宽匹配（不再误伤 gpt-4o 等）；抽出 resolve_reasoning_effort，思考关闭时默认仍 low，新增 SAGE_REASONING_EFFORT_OFF 环境变量按需切 minimal/medium/high；补 strip 与 reasoning 判定/effort 单测。
 
 2026-04-27 19:00 turn_status-only 补轮 coerce 留痕：被改写的 tool 结果打 metadata.coerced_from，strip 时保留这对 pair 让 LLM 看到事实；改写 note 文案走 PromptManager(zh/en/pt) 并注入原始工具名。

--- a/sagents/agent/agent_base.py
+++ b/sagents/agent/agent_base.py
@@ -212,6 +212,45 @@ class AgentBase(ABC):
                 # 只保留model.chat.completions.create 需要的messages的key，移除掉不不要的
                 serializable_messages = [{k: v for k, v in msg.items() if k in ['role', 'content', 'tool_calls', 'tool_call_id']} for msg in serializable_messages]
 
+                # === 注入 shell completion 事件作为 <system_reminder> 消息 ===
+                # 后台 shell 命令完成后，watcher 会把事件写入 ExecuteCommandTool._COMPLETION_EVENTS。
+                # 这里在每次 LLM 请求前 flush 一次，作为 role=user + <system_reminder> 文本注入。
+                # 选 role=user 而非 system 的原因：
+                #   1) Anthropic 不允许中段 system 消息；
+                #   2) 不破坏 OpenAI tool_call 严格交替序列；
+                #   3) 不污染 system prompt cache。
+                # await_shell 显式拿到 completed 时会 consume 对应 task_id 的事件，
+                # 因此被显式消费过的不会在这里重复出现。
+                if session_id:
+                    try:
+                        from sagents.tool.impl.execute_command_tool import ExecuteCommandTool
+                        completion_events = ExecuteCommandTool.pop_completion_events(session_id)
+                    except Exception as _e:
+                        logger.warning(f"flush shell completion events 失败: {_e}")
+                        completion_events = []
+                    for ev in completion_events:
+                        tail = ev.get('tail', '') or ''
+                        tail_section = (
+                            f"tail (last few lines):\n{tail}" if tail
+                            else "(no output captured)"
+                        )
+                        reminder_text = (
+                            "<system_reminder>\n"
+                            f"[shell completion] task_id={ev.get('task_id')} "
+                            f"exit_code={ev.get('exit_code')} elapsed_ms={ev.get('elapsed_ms')}\n"
+                            f"command: {ev.get('command', '')}\n"
+                            f"{tail_section}\n"
+                            f"Note: This is a brief notification only. "
+                            f"Call await_shell(task_id=\"{ev.get('task_id')}\") to retrieve the full stdout if needed.\n"
+                            "</system_reminder>"
+                        )
+                        serializable_messages.append({"role": "user", "content": reminder_text})
+                        cache_segments.append(None)
+                    if completion_events:
+                        logger.info(
+                            f"{self.__class__.__name__}: 注入 {len(completion_events)} 条 shell completion reminder"
+                        )
+
                 # 为消息添加 prompt caching 支持（Anthropic 格式）
                 # 多段 system 时按 cache_segments 打多个断点；老路径保持单断点回退
                 if serializable_messages:
@@ -566,6 +605,22 @@ class AgentBase(ABC):
                 role_content += f"\n\n{custom_prefix}"
 
             stable_buf += f"<role_definition>\n{role_content}\n</role_definition>\n"
+
+            # system_reminder 标签语义说明：注入到 stable 段以保持高 cache 命中率
+            if language and str(language).lower().startswith("zh"):
+                reminder_hint = (
+                    "当对话中出现 <system_reminder>...</system_reminder> 包裹的内容时，"
+                    "请视为系统级状态通知（非用户输入），仅作为参考信息推进任务即可，"
+                    "不需要回复或感谢这条提醒。典型场景：后台 shell 命令完成事件。"
+                )
+            else:
+                reminder_hint = (
+                    "When you see content wrapped in <system_reminder>...</system_reminder>, "
+                    "treat it as a system-level status notification (not user input). "
+                    "Use it as context to drive the next step; do not reply to or acknowledge the reminder itself. "
+                    "A common case is background shell command completion events."
+                )
+            stable_buf += f"<system_reminder_hint>\n{reminder_hint}\n</system_reminder_hint>\n"
 
         if session_context:
             system_context_info = session_context.system_context.copy()

--- a/sagents/tool/impl/execute_command_tool.py
+++ b/sagents/tool/impl/execute_command_tool.py
@@ -31,6 +31,35 @@ from sagents.utils.agent_session_helper import get_session_sandbox as _get_sessi
 
 _BG_DIR = "~/.sage/bg"
 
+# completion event 的 tail 最大字节数。reminder 只是"知会"通知，agent 想看完整结果应调
+# await_shell。保持小一些可以避免长会话里 reminder 累积失控。
+_REMINDER_TAIL_MAX_BYTES = 512
+
+# _BG_TASKS 的硬性最长存活时间。任何 task 自 ``started_at`` 起 12 小时未被消费会被
+# 强制 GC（_BG_TASKS / _COMPLETION_EVENTS / sandbox cleanup）。每次 spawn 触发一次扫描。
+_BG_TASK_MAX_AGE_S = 12 * 3600
+
+
+def _truncate_tail_for_reminder(text: str, max_bytes: int = _REMINDER_TAIL_MAX_BYTES) -> str:
+    """对 reminder 用 tail 做尾部优先的截断。
+
+    优先保留最后若干行；如果末尾仍然太长，按字节截掉头部并加省略标记。
+    """
+    if not text:
+        return ""
+    raw = text.encode("utf-8", errors="ignore")
+    if len(raw) <= max_bytes:
+        return text
+    truncated = raw[-max_bytes:]
+    nl = truncated.find(b"\n")
+    if 0 <= nl < max_bytes - 1:
+        truncated = truncated[nl + 1:]
+    return "...<truncated>...\n" + truncated.decode("utf-8", errors="ignore")
+
+# _BG_TASKS 的硬性最长存活时间。任何 task 自 ``started_at`` 起 12 小时未被消费会被
+# 强制 GC（_BG_TASKS / _COMPLETION_EVENTS / sandbox cleanup）。每次 spawn 触发一次扫描。
+_BG_TASK_MAX_AGE_S = 12 * 3600
+
 
 class SecurityManager:
     """安全管理器 - 负责命令安全检查。
@@ -113,14 +142,88 @@ def _gen_task_id() -> str:
     return "shtask_" + uuid.uuid4().hex[:12]
 
 
+def _suggest_next_block_ms(running_ms: int) -> int:
+    """根据已运行时长建议下一次 await_shell 的 block_until_ms。
+
+    分档：
+    - < 30s：建议 60000（1 分钟）
+    - 30s–5min：建议 min(running_ms * 1.5, 300000)
+    - > 5min：建议 600000（10 分钟）
+    """
+    if running_ms < 30_000:
+        return 60_000
+    if running_ms < 300_000:
+        return min(int(running_ms * 1.5), 300_000)
+    return 600_000
+
+
 class ExecuteCommandTool:
-    """命令执行工具 - 通过沙箱执行命令。两段式 + 后台进程注册表。"""
+    """命令执行工具 - 通过沙箱执行命令。两段式 + 后台进程注册表 + 完成事件队列。"""
 
     # 进程级注册表：task_id -> {session_id, pid, log_path, exit_path, command, started_at}
     _BG_TASKS: Dict[str, Dict[str, Any]] = {}
 
+    # 完成事件字典：session_id -> {task_id: event_dict}
+    # 事件结构：{task_id, command, exit_code, elapsed_ms, tail}
+    # 写入：watcher 在命令完成时写入；
+    # 消费路径：
+    #   1) await_shell 返回 completed 时 consume_completion_event 显式消费；
+    #   2) _call_llm_streaming 在每次 LLM 请求前 pop_completion_events 全部 flush 注入。
+    # 两条路径互斥：被 await_shell 消费过的不会再走 LLM flush。
+    _COMPLETION_EVENTS: Dict[str, Dict[str, Dict[str, Any]]] = {}
+
     def __init__(self):
         self.security_manager = SecurityManager()
+
+    @classmethod
+    def pop_completion_events(cls, session_id: str) -> List[Dict[str, Any]]:
+        """取出指定 session 下所有 pending completion 事件并清空。
+
+        被 ``_call_llm_streaming`` 在每次 LLM 请求前调用；返回的事件会被注入为
+        ``<system_reminder>`` 消息。
+        """
+        if not session_id:
+            return []
+        bucket = cls._COMPLETION_EVENTS.pop(session_id, None)
+        if not bucket:
+            return []
+        return list(bucket.values())
+
+    @classmethod
+    def consume_completion_event(cls, session_id: str, task_id: str) -> Optional[Dict[str, Any]]:
+        """显式消费某 session 下指定 task_id 的事件（如果存在）。
+
+        ``await_shell`` 显式拿到 completed 时调用，避免与 system_reminder 重复通知。
+        """
+        if not session_id or not task_id:
+            return None
+        bucket = cls._COMPLETION_EVENTS.get(session_id)
+        if not bucket:
+            return None
+        ev = bucket.pop(task_id, None)
+        if not bucket:
+            cls._COMPLETION_EVENTS.pop(session_id, None)
+        return ev
+
+    @classmethod
+    def _emit_completion_event(
+        cls,
+        session_id: str,
+        task_id: str,
+        command: str,
+        exit_code: Optional[int],
+        elapsed_ms: int,
+        tail: str,
+    ) -> None:
+        if not session_id or not task_id:
+            return
+        cls._COMPLETION_EVENTS.setdefault(session_id, {})[task_id] = {
+            "task_id": task_id,
+            "command": command,
+            "exit_code": exit_code,
+            "elapsed_ms": elapsed_ms,
+            "tail": tail,
+        }
 
     def _get_sandbox(self, session_id: str):
         return _get_session_sandbox_util(session_id, log_prefix="ExecuteCommandTool")
@@ -155,6 +258,92 @@ class ExecuteCommandTool:
             return bool(sandbox.supports_background())
         except Exception:
             return False
+
+    async def _watch_completion(
+        self,
+        sandbox: Any,
+        task_info: Dict[str, Any],
+        session_id: str,
+    ) -> None:
+        """后台 watcher：轮询命令直到结束，写入 completion 事件。
+
+        - 写入路径：``_COMPLETION_EVENTS[session_id][task_id]``
+        - LLM 在下一次请求前 ``pop_completion_events`` 取出注入为 system_reminder
+        - 若 ``await_shell`` 抢先拿到结果并 ``consume_completion_event``，事件会被显式删除，
+          watcher 后写入会被覆盖也无所谓——下次 await_shell completed 时会再消费一次。
+        - 真正去重的关键是：watcher 写入时若 task 已经被 ``_cleanup_task`` 清理（说明
+          await_shell 路径已处理），就不再写事件。
+        """
+        task_id = task_info["task_id"]
+        sleep_s = 0.5
+        try:
+            while True:
+                await asyncio.sleep(sleep_s)
+                sleep_s = min(2.0, sleep_s * 1.3)
+
+                if task_id not in ExecuteCommandTool._BG_TASKS:
+                    return
+
+                exit_code = await self._read_exit(sandbox, task_info)
+                if exit_code is not None:
+                    break
+
+            if task_id not in ExecuteCommandTool._BG_TASKS:
+                return
+
+            # 这里读取的 tail 仅用于 system_reminder 知会，agent 想看完整结果应调 await_shell；
+            # 多读一些再截断，保留尾部关键信息。
+            raw_tail = await self._read_tail(sandbox, task_info, max_bytes=4096)
+            short_tail = _truncate_tail_for_reminder(raw_tail or "")
+            elapsed_ms = int((time.time() - task_info.get("started_at", time.time())) * 1000)
+            self._emit_completion_event(
+                session_id=session_id,
+                task_id=task_id,
+                command=task_info.get("command", ""),
+                exit_code=exit_code,
+                elapsed_ms=elapsed_ms,
+                tail=short_tail,
+            )
+            # 故意不调 _cleanup_task：
+            # - sandbox-side exit/log 留给后续 await_shell 拿完整结果；
+            # - _BG_TASKS 由 await_shell completed 路径清理；reminder 只做通知。
+            # - 12h 仍未被消费的，由下次 spawn 触发的 _gc_stale_tasks 兜底强制清理。
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(f"_watch_completion 异常 task_id={task_id}: {exc}")
+
+    async def _gc_stale_tasks(self) -> None:
+        """清理 _BG_TASKS 与 _COMPLETION_EVENTS 中超过 12 小时的条目。
+
+        每次 spawn 前调用；发现超期 task 时：
+        1. 尝试 sandbox cleanup（忽略失败）；
+        2. 从 _BG_TASKS 删除；
+        3. 从对应 session 的 _COMPLETION_EVENTS 删除（若存在）。
+        """
+        now = time.time()
+        stale = [
+            tid for tid, info in list(self._BG_TASKS.items())
+            if now - info.get("started_at", now) > _BG_TASK_MAX_AGE_S
+        ]
+        for tid in stale:
+            info = self._BG_TASKS.pop(tid, None)
+            if not info:
+                continue
+            sid = info.get("session_id", "")
+            logger.info(f"GC: 清理超期 task_id={tid} session_id={sid}")
+            try:
+                sandbox = self._get_sandbox(sid) if sid else None
+                if sandbox and info.get("mode") == "native":
+                    await sandbox.cleanup_background(tid)
+            except Exception as exc:
+                logger.debug(f"GC: sandbox.cleanup_background({tid}) 失败（忽略）: {exc}")
+            # 同步清理 _COMPLETION_EVENTS
+            bucket = self.__class__._COMPLETION_EVENTS.get(sid)
+            if bucket:
+                bucket.pop(tid, None)
+                if not bucket:
+                    self.__class__._COMPLETION_EVENTS.pop(sid, None)
 
     async def _spawn_background(
         self,
@@ -313,14 +502,19 @@ class ExecuteCommandTool:
         description_i18n={
             "zh": (
                 "在沙箱中执行 Shell 命令；支持两段式执行。"
-                "block_until_ms=0 立即放后台并返回 task_id；>0 阻塞至命令结束或到点。"
-                "若到点未结束，返回 task_id + tail_output，可用 await_shell 继续等待，或用 kill_shell 终止。"
+                "block_until_ms=0 立即放后台并返回 task_id；>0 阻塞至命令结束或到点（默认 30000）。"
+                "若到点未结束，返回 task_id + tail_output；命令最终完成时系统会通过 "
+                "<system_reminder> 主动通知，你不需要轮询，起完命令请优先去做下一步工作。"
+                "若必须等待，可用 await_shell 并传入较大的 block_until_ms（>=60000），"
+                "或用 kill_shell 终止。"
             ),
             "en": (
                 "Execute a shell command in sandbox with two-stage support. "
                 "block_until_ms=0 backgrounds the command and returns immediately with a task_id. "
-                ">0 blocks until completion or deadline. On deadline, returns task_id + tail_output; "
-                "use await_shell to keep waiting or kill_shell to terminate."
+                ">0 blocks until completion or deadline (default 30000). On deadline, returns task_id + tail_output. "
+                "Eventual completion is pushed via <system_reminder>; you do NOT need to poll. "
+                "After spawning, prefer to do the next step rather than waiting. "
+                "If you must wait, use await_shell with a generous block_until_ms (>=60000), or kill_shell to terminate."
             ),
         },
         param_description_i18n={
@@ -380,6 +574,12 @@ class ExecuteCommandTool:
 
         sandbox = self._get_sandbox(session_id)
 
+        # 每次 spawn 前顺手做一次 12h 超期 GC，不开独立定时器，避免复杂度
+        try:
+            await self._gc_stale_tasks()
+        except Exception as _gc_exc:
+            logger.debug(f"_gc_stale_tasks 异常（忽略）: {_gc_exc}")
+
         # 始终经由后台模式启动；阻塞模式下我们再轮询等待
         echo_header(command)
         try:
@@ -408,6 +608,12 @@ class ExecuteCommandTool:
         task_id = task_info["task_id"]
         task_info["session_id"] = session_id
 
+        # 启动后台 watcher：命令结束时写入 completion 事件，供下一次 LLM 请求 flush 注入
+        try:
+            asyncio.create_task(self._watch_completion(sandbox, task_info, session_id))
+        except RuntimeError:
+            logger.warning("无法启动 completion watcher：当前无运行中的 event loop")
+
         try:
             if block_until_ms <= 0:
                 tail = await self._read_tail(sandbox, task_info, max_bytes=2048)
@@ -425,6 +631,8 @@ class ExecuteCommandTool:
             finished, exit_code = await self._wait_for_finish(sandbox, task_info, block_until_ms)
             tail = await self._read_tail(sandbox, task_info, max_bytes=8192)
             if finished:
+                # 同步拿到结果，显式消费 watcher 可能已写入的事件，避免重复通知
+                self.consume_completion_event(session_id, task_id)
                 await self._cleanup_task(sandbox, task_id)
                 return {
                     "success": exit_code == 0,
@@ -436,6 +644,7 @@ class ExecuteCommandTool:
                     "output_file": log_path,
                     "command": command,
                 }
+            running_ms = int((time.time() - task_info.get("started_at", time.time())) * 1000)
             return {
                 "success": True,
                 "status": "running",
@@ -443,8 +652,14 @@ class ExecuteCommandTool:
                 "pid": pid,
                 "output_file": log_path,
                 "tail_output": tail,
+                "running_for_ms": running_ms,
+                "suggested_next_block_ms": _suggest_next_block_ms(running_ms),
                 "command": command,
-                "message": f"达到 block_until_ms={block_until_ms}，命令仍在运行；可用 await_shell 继续等待",
+                "message": (
+                    f"达到 block_until_ms={block_until_ms}，命令仍在运行。"
+                    "完成时会通过 <system_reminder> 主动通知，无需轮询；"
+                    "如必须等待，可用 await_shell 并传入较大 block_until_ms。"
+                ),
             }
         finally:
             echo_footer(None)
@@ -461,18 +676,37 @@ class ExecuteCommandTool:
 
     @tool(
         description_i18n={
-            "zh": "拉取后台 shell 任务的增量输出；可选 pattern 命中即返回。结束时返回 exit_code 并清理注册表。",
-            "en": "Poll a background shell task for incremental output. Optional pattern returns early on match. On finish returns exit_code and cleans up.",
+            "zh": (
+                "拉取后台 shell 任务的增量输出；可选 pattern 命中即返回；结束时返回 exit_code 并清理注册表。"
+                "默认 block_until_ms=600000（10 分钟）。"
+                "重要：仅在「下一步工作必须依赖此命令结果且当前没有别的事可做」时使用——"
+                "后台命令完成会通过 <system_reminder> 主动通知，无需轮询。"
+                "请按场景选择 block_until_ms："
+                "短任务 60000–120000；已知会跑数分钟 120000–300000；训练/大型构建 600000–1200000。"
+                "禁止以 < 30000 的间隔反复轮询；服务端会对小值做自适应改写。"
+            ),
+            "en": (
+                "Poll a background shell task for incremental output. "
+                "Optional pattern returns early on match. On finish returns exit_code and cleans up. "
+                "Default block_until_ms=600000 (10 minutes). "
+                "IMPORTANT: only use when the next step strictly depends on this command's result AND there is nothing else productive to do — "
+                "completion will be pushed via <system_reminder>, polling is unnecessary. "
+                "Pick block_until_ms by scenario: short tasks 60000–120000; multi-minute tasks 120000–300000; long builds/training 600000–1200000. "
+                "Do not poll with < 30000ms intervals; the server will rewrite small values adaptively."
+            ),
         },
         param_description_i18n={
             "task_id": {"zh": "execute_shell_command 返回的 task_id", "en": "task_id returned by execute_shell_command"},
-            "block_until_ms": {"zh": "最多等待毫秒数，默认 10000", "en": "Max wait in ms, default 10000"},
+            "block_until_ms": {
+                "zh": "最多等待毫秒数；默认 600000（10 分钟）；建议按场景选择 60000+",
+                "en": "Max wait in ms; default 600000 (10min); pick 60000+ by scenario",
+            },
             "pattern": {"zh": "可选正则；命中时立即返回", "en": "Optional regex; return early when matched"},
             "session_id": {"zh": "会话ID（必填，自动注入）", "en": "Session ID (Required, Auto-injected)"},
         },
         param_schema={
             "task_id": {"type": "string"},
-            "block_until_ms": {"type": "integer", "default": 10000},
+            "block_until_ms": {"type": "integer", "default": 600000},
             "pattern": {"type": "string"},
             "session_id": {"type": "string"},
         },
@@ -480,7 +714,7 @@ class ExecuteCommandTool:
     async def await_shell(
         self,
         task_id: str,
-        block_until_ms: int = 10000,
+        block_until_ms: int = 600000,
         pattern: Optional[str] = None,
         session_id: str = None,
     ) -> Dict[str, Any]:
@@ -488,16 +722,36 @@ class ExecuteCommandTool:
             raise ValueError("ExecuteCommandTool: session_id is required")
         task_info = self._BG_TASKS.get(task_id)
         if not task_info:
+            # task 已不在注册表，可能 watcher 已经写入完成事件并清理，
+            # 也可能 await_shell / 另一个调用先消费过——尝试从事件队列中拿一次
+            ev = self.consume_completion_event(session_id, task_id)
+            if ev is not None:
+                return {
+                    "success": ev.get("exit_code") == 0,
+                    "status": "completed",
+                    "task_id": task_id,
+                    "exit_code": ev.get("exit_code"),
+                    "stdout": ev.get("tail", ""),
+                }
             return make_tool_error(
                 ToolErrorCode.NOT_FOUND,
                 f"未找到 task_id={task_id} 对应的后台任务",
                 task_id=task_id,
             )
 
+        # 自适应改写：跑得越久，最低等待越长，避免反射性短间隔轮询
+        running_ms = int((time.time() - task_info.get("started_at", time.time())) * 1000)
+        requested_block_until_ms = block_until_ms
+        if running_ms > 30_000 and block_until_ms < 60_000:
+            block_until_ms = 60_000
+        if running_ms > 300_000 and block_until_ms < 300_000:
+            block_until_ms = 300_000
+
         sandbox = self._get_sandbox(session_id)
         finished, exit_code = await self._wait_for_finish(sandbox, task_info, block_until_ms, pattern=pattern)
         tail = await self._read_tail(sandbox, task_info, max_bytes=8192)
         if finished:
+            self.consume_completion_event(session_id, task_id)
             await self._cleanup_task(sandbox, task_id)
             return {
                 "success": exit_code == 0,
@@ -507,6 +761,7 @@ class ExecuteCommandTool:
                 "stdout": tail,
                 "output_file": task_info.get("log_path"),
             }
+        running_ms_after = int((time.time() - task_info.get("started_at", time.time())) * 1000)
         return {
             "success": True,
             "status": "running",
@@ -514,6 +769,10 @@ class ExecuteCommandTool:
             "tail_output": tail,
             "output_file": task_info.get("log_path"),
             "matched_pattern": bool(pattern),
+            "running_for_ms": running_ms_after,
+            "suggested_next_block_ms": _suggest_next_block_ms(running_ms_after),
+            "block_until_ms_requested": requested_block_until_ms,
+            "block_until_ms_used": block_until_ms,
         }
 
     @tool(


### PR DESCRIPTION
## Summary
- Background shell completion watcher writes events; `_call_llm_streaming` injects `<system_reminder>` (role=user) before each LLM request.
- `await_shell` default 10m, adaptive `block_until_ms` rewrite, metadata fields; tool descriptions updated.
- Short reminder tail (~512B), error-line surfacing when tail is empty, i18n zh/en; 12h GC on spawn and `await_shell` entry.
- Unified system prompt: `<system_reminder_hint>` for tag semantics.

## Notes
- Tests and unstaged changes (e.g. `test_execute_shell_completion_event.py`) were not included in this commit per instructions.

Made with [Cursor](https://cursor.com)