### PR TITLE
修复anytool的session_id 和 user_id

### DIFF
--- a/sagents/tool/mcp_proxy.py
+++ b/sagents/tool/mcp_proxy.py
@@ -80,14 +80,9 @@ class McpProxy:
         """Run an MCP tool asynchronously"""
         if not session_id:
             session_id = "default"
-        # 只有当工具参数定义中包含 session_id / user_id 时才传递
+        # Only pass context fields when the MCP tool schema explicitly declares them.
+        # Otherwise strict MCP input validation rejects them as unexpected properties.
         tool_params = getattr(tool, 'parameters', {}) or {}
-        is_anytool_server = getattr(tool, "server_name", "") == "AnyTool"
-        if is_anytool_server:
-            if session_id and "session_id" not in kwargs:
-                kwargs["session_id"] = session_id
-            if user_id and "user_id" not in kwargs:
-                kwargs["user_id"] = user_id
         if 'session_id' in tool_params:
             kwargs["session_id"] = session_id
         if user_id and 'user_id' in tool_params and 'user_id' not in kwargs:


### PR DESCRIPTION
# 修复 AnyTool 上下文参数注入导致的 MCP 校验失败

## 摘要

本 PR 修复了 AnyTool MCP 工具执行时的参数校验失败问题。

问题原因是：系统会在调用 AnyTool 时自动注入 `session_id` 和 `user_id`，即使该 AnyTool 的输入 schema 并没有声明这两个字段。对于开启严格输入校验的 MCP 工具来说，这两个未声明字段会被认为是额外参数，从而导致执行失败。

## 解决的问题

当用户新建一个 AnyTool，只定义了业务所需参数，例如 3 个默认参数，而没有定义 `session_id` / `user_id` 时，工具调用可能失败：

```json
{
  "error": true,
  "error_type": "EXECUTION_ERROR",
  "message": "Tool 'customer_send_message_whatsapp' failed after 0.03s: Input validation error: Additional properties are not allowed ('session_id', 'user_id' were unexpected)"
}
```

根因在 `sagents/tool/mcp_proxy.py`：

- 之前代码对 `server_name == "AnyTool"` 做了特殊处理
- AnyTool 工具调用会被无条件加入 `session_id` 和 `user_id`
- 但 AnyTool 暴露给 MCP 的 inputSchema 如果没有声明这两个字段，并且 `additionalProperties` 为 `false`，MCP 会在真正执行工具前拒绝这些额外字段

因此，工具的实际执行逻辑还没进入，就已经被 MCP 输入校验拦截。

## 本次改动

修改了 `McpProxy.run_mcp_tool()` 的上下文参数注入逻辑：

- 删除 AnyTool 专属的无条件 `session_id` / `user_id` 注入分支
- 仅当 MCP 工具 schema 明确声明 `session_id` 时，才注入 `session_id`
- 仅当 MCP 工具 schema 明确声明 `user_id` 时，才注入 `user_id`

也就是说，工具收到哪些参数，应该以它自己的 inputSchema 为准。

## 影响范围

本次改动范围很小，只影响 MCP 工具调用时的上下文参数注入行为。

不受影响：

- 非 MCP 的内置工具
- 已经在 schema 中显式声明 `session_id` 的 MCP 工具
- 已经在 schema 中显式声明 `user_id` 的 MCP 工具
- 显式声明了 `session_id` / `user_id` 的 AnyTool 工具
- AnyTool 草稿预览流程

可能受影响：

- 如果某些 AnyTool 之前没有在 schema 中声明 `session_id` / `user_id`，但依赖系统偷偷传入这两个字段，那么本次修改后不会再收到它们

这是符合 MCP schema 语义的行为：如果工具需要 `session_id` 或 `user_id`，应该在 inputSchema 中显式声明。

## 验证

已运行语法检查：

```bash
python -m py_compile sagents/tool/mcp_proxy.py
```

结果：通过。

同时检查 diff，确认本次代码提交只修改了：

```text
sagents/tool/mcp_proxy.py
```