### PR TITLE
fix(chat): stream-safe todo_write args for collapsed task list

### DIFF
--- a/app/desktop/ui/src/components/chat/tools/TodoTaskMessage.vue
+++ b/app/desktop/ui/src/components/chat/tools/TodoTaskMessage.vue
@@ -95,6 +95,7 @@
 import { computed, ref } from 'vue'
 import { ListTodo, Check, Plus, RefreshCw, Circle, Loader2, ChevronDown, ChevronUp } from 'lucide-vue-next'
 import { useLanguage } from '@/utils/i18n.js'
+import { parseTodoWriteToolCallArguments } from '@/utils/parseTodoWriteToolArguments.js'
 
 const props = defineProps({
   toolCall: {
@@ -121,34 +122,12 @@ const { t } = useLanguage()
 
 const expanded = ref(false)
 
-const parsedToolArgs = computed(() => {
-  const raw = props.toolCall?.function?.arguments
-  if (raw == null) return {}
-  if (typeof raw === 'string') {
-    try {
-      return JSON.parse(raw)
-    } catch {
-      return {}
-    }
-  }
-  return typeof raw === 'object' ? raw : {}
-})
+/** 流式下 arguments 可能为未闭合 JSON；解析失败时仍从片段中提取 tasks[].id */
+const parsedToolArgs = computed(() =>
+  parseTodoWriteToolCallArguments(props.toolCall?.function?.arguments)
+)
 
-/** 本次工具入参中的任务 id 顺序（增量写入，与后端约定一致） */
-const touchedIdsOrdered = computed(() => {
-  const list = parsedToolArgs.value?.tasks
-  if (!Array.isArray(list)) return []
-  const out = []
-  const seen = new Set()
-  for (const item of list) {
-    if (!item || item.id == null || item.id === '') continue
-    const id = String(item.id)
-    if (seen.has(id)) continue
-    seen.add(id)
-    out.push(id)
-  }
-  return out
-})
+const touchedIdsOrdered = computed(() => parsedToolArgs.value.taskIdsOrdered)
 
 const parsedContent = computed(() => {
   if (!props.toolResult) return {}
@@ -177,7 +156,7 @@ const collapsedTasks = computed(() => {
   const full = tasks.value
   if (!touchedIdsOrdered.value.length) return full
   const byId = new Map(full.map((t) => [String(t.id), t]))
-  const argList = Array.isArray(parsedToolArgs.value?.tasks) ? parsedToolArgs.value.tasks : []
+  const argList = Array.isArray(parsedToolArgs.value.tasks) ? parsedToolArgs.value.tasks : []
   const out = []
   for (const id of touchedIdsOrdered.value) {
     const row = byId.get(id)

--- a/app/desktop/ui/src/utils/__tests__/parseTodoWriteToolArguments.spec.js
+++ b/app/desktop/ui/src/utils/__tests__/parseTodoWriteToolArguments.spec.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { parseTodoWriteToolCallArguments } from '../parseTodoWriteToolArguments.js'
+
+describe('parseTodoWriteToolCallArguments', () => {
+  it('parses complete JSON string', () => {
+    const raw = '{"tasks":[{"id":"a","content":"x"}],"session_id":"s1"}'
+    const { taskIdsOrdered, tasks } = parseTodoWriteToolCallArguments(raw)
+    expect(taskIdsOrdered).toEqual(['a'])
+    expect(tasks).toHaveLength(1)
+  })
+
+  it('extracts ids from incomplete JSON (streaming)', () => {
+    const raw = '{"tasks":[{"id":"t1","content":"等待用户'
+    const { taskIdsOrdered, tasks } = parseTodoWriteToolCallArguments(raw)
+    expect(taskIdsOrdered).toEqual(['t1'])
+    expect(tasks).toEqual([])
+  })
+
+  it('handles object arguments', () => {
+    const raw = { tasks: [{ id: 'u1', content: 'c' }] }
+    const { taskIdsOrdered } = parseTodoWriteToolCallArguments(raw)
+    expect(taskIdsOrdered).toEqual(['u1'])
+  })
+
+  it('dedupes ids in fragment', () => {
+    const raw = '"tasks":[{"id":"x"},{"id":"x","status"'
+    const { taskIdsOrdered } = parseTodoWriteToolCallArguments(raw)
+    expect(taskIdsOrdered).toEqual(['x'])
+  })
+})

--- a/app/desktop/ui/src/utils/parseTodoWriteToolArguments.js
+++ b/app/desktop/ui/src/utils/parseTodoWriteToolArguments.js
@@ -1,0 +1,64 @@
+/**
+ * 解析 todo_write 的 function.arguments（字符串或对象）。
+ * 流式增量下参数常为未闭合 JSON，JSON.parse 会失败；在 "tasks":[ 之后按顺序提取 "id" 字段供折叠 UI 使用。
+ */
+export function parseTodoWriteToolCallArguments (raw) {
+  const empty = { tasks: [], taskIdsOrdered: [] }
+  if (raw == null) return empty
+
+  if (typeof raw === 'object' && !Array.isArray(raw)) {
+    const tasks = Array.isArray(raw.tasks) ? raw.tasks : []
+    return { tasks, taskIdsOrdered: orderedIdsFromTaskObjects(tasks) }
+  }
+
+  if (typeof raw !== 'string') return empty
+
+  const s = raw.trim()
+  if (!s) return empty
+
+  try {
+    const o = JSON.parse(s)
+    if (o && typeof o === 'object' && Array.isArray(o.tasks)) {
+      return { tasks: o.tasks, taskIdsOrdered: orderedIdsFromTaskObjects(o.tasks) }
+    }
+  } catch (_) {
+    /* 流式未完成 */
+  }
+
+  const tasksRegionStart = s.search(/"tasks"\s*:\s*\[/i)
+  const scan = tasksRegionStart >= 0 ? s.slice(tasksRegionStart) : s
+  return { tasks: [], taskIdsOrdered: extractIdsFromJsonLikeFragment(scan) }
+}
+
+function orderedIdsFromTaskObjects (tasks) {
+  const out = []
+  const seen = new Set()
+  for (const item of tasks) {
+    if (!item || item.id == null || item.id === '') continue
+    const id = String(item.id)
+    if (seen.has(id)) continue
+    seen.add(id)
+    out.push(id)
+  }
+  return out
+}
+
+/** 在未闭合的 JSON 片段中顺序匹配 "id":"..."（限定在 tasks 数组段内以降低误匹配） */
+function extractIdsFromJsonLikeFragment (s) {
+  const taskIdsOrdered = []
+  const seen = new Set()
+  const re = /"id"\s*:\s*"((?:[^"\\]|\\.)*)"/g
+  let m
+  while ((m = re.exec(s)) !== null) {
+    const inner = m[1]
+    const id = inner.replace(/\\(.)/g, (_c, ch) => {
+      if (ch === '"' || ch === '\\') return ch
+      if (ch === 'n') return '\n'
+      return `\\${ch}`
+    })
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    taskIdsOrdered.push(id)
+  }
+  return taskIdsOrdered
+}

--- a/app/server/web/src/components/chat/tools/TodoTaskMessage.vue
+++ b/app/server/web/src/components/chat/tools/TodoTaskMessage.vue
@@ -80,6 +80,7 @@
 import { computed, ref } from 'vue'
 import { ListTodo, Check, Loader2, ChevronDown, ChevronUp } from 'lucide-vue-next'
 import { useLanguage } from '@/utils/i18n.js'
+import { parseTodoWriteToolCallArguments } from '@/utils/parseTodoWriteToolArguments.js'
 
 const props = defineProps({
   toolCall: {
@@ -100,33 +101,11 @@ const { t } = useLanguage()
 
 const expanded = ref(false)
 
-const parsedToolArgs = computed(() => {
-  const raw = props.toolCall?.function?.arguments
-  if (raw == null) return {}
-  if (typeof raw === 'string') {
-    try {
-      return JSON.parse(raw)
-    } catch {
-      return {}
-    }
-  }
-  return typeof raw === 'object' ? raw : {}
-})
+const parsedToolArgs = computed(() =>
+  parseTodoWriteToolCallArguments(props.toolCall?.function?.arguments)
+)
 
-const touchedIdsOrdered = computed(() => {
-  const list = parsedToolArgs.value?.tasks
-  if (!Array.isArray(list)) return []
-  const out = []
-  const seen = new Set()
-  for (const item of list) {
-    if (!item || item.id == null || item.id === '') continue
-    const id = String(item.id)
-    if (seen.has(id)) continue
-    seen.add(id)
-    out.push(id)
-  }
-  return out
-})
+const touchedIdsOrdered = computed(() => parsedToolArgs.value.taskIdsOrdered)
 
 const parsedContent = computed(() => {
   if (!props.toolResult) return {}
@@ -154,7 +133,7 @@ const collapsedTasks = computed(() => {
   const full = tasks.value
   if (!touchedIdsOrdered.value.length) return full
   const byId = new Map(full.map((t) => [String(t.id), t]))
-  const argList = Array.isArray(parsedToolArgs.value?.tasks) ? parsedToolArgs.value.tasks : []
+  const argList = Array.isArray(parsedToolArgs.value.tasks) ? parsedToolArgs.value.tasks : []
   const out = []
   for (const id of touchedIdsOrdered.value) {
     const row = byId.get(id)

--- a/app/server/web/src/utils/parseTodoWriteToolArguments.js
+++ b/app/server/web/src/utils/parseTodoWriteToolArguments.js
@@ -1,0 +1,63 @@
+/**
+ * 解析 todo_write 的 function.arguments（字符串或对象）。
+ * 流式增量下参数常为未闭合 JSON，JSON.parse 会失败；在 "tasks":[ 之后按顺序提取 "id" 字段供折叠 UI 使用。
+ */
+export function parseTodoWriteToolCallArguments (raw) {
+  const empty = { tasks: [], taskIdsOrdered: [] }
+  if (raw == null) return empty
+
+  if (typeof raw === 'object' && !Array.isArray(raw)) {
+    const tasks = Array.isArray(raw.tasks) ? raw.tasks : []
+    return { tasks, taskIdsOrdered: orderedIdsFromTaskObjects(tasks) }
+  }
+
+  if (typeof raw !== 'string') return empty
+
+  const s = raw.trim()
+  if (!s) return empty
+
+  try {
+    const o = JSON.parse(s)
+    if (o && typeof o === 'object' && Array.isArray(o.tasks)) {
+      return { tasks: o.tasks, taskIdsOrdered: orderedIdsFromTaskObjects(o.tasks) }
+    }
+  } catch (_) {
+    /* 流式未完成 */
+  }
+
+  const tasksRegionStart = s.search(/"tasks"\s*:\s*\[/i)
+  const scan = tasksRegionStart >= 0 ? s.slice(tasksRegionStart) : s
+  return { tasks: [], taskIdsOrdered: extractIdsFromJsonLikeFragment(scan) }
+}
+
+function orderedIdsFromTaskObjects (tasks) {
+  const out = []
+  const seen = new Set()
+  for (const item of tasks) {
+    if (!item || item.id == null || item.id === '') continue
+    const id = String(item.id)
+    if (seen.has(id)) continue
+    seen.add(id)
+    out.push(id)
+  }
+  return out
+}
+
+function extractIdsFromJsonLikeFragment (s) {
+  const taskIdsOrdered = []
+  const seen = new Set()
+  const re = /"id"\s*:\s*"((?:[^"\\]|\\.)*)"/g
+  let m
+  while ((m = re.exec(s)) !== null) {
+    const inner = m[1]
+    const id = inner.replace(/\\(.)/g, (_c, ch) => {
+      if (ch === '"' || ch === '\\') return ch
+      if (ch === 'n') return '\n'
+      return `\\${ch}`
+    })
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    taskIdsOrdered.push(id)
+  }
+  return taskIdsOrdered
+}

--- a/change_log.md
+++ b/change_log.md
@@ -1,8 +1,12 @@
+2026-04-29 todo_write 流式显示：parseTodoWriteToolArguments 在未闭合 JSON 下从 tasks 段提取 id，折叠与增量条与实时结果对齐（desktop/server TodoTaskMessage）。
+
 2026-04-29 单测覆盖 completed stdout 改造：bg_runner read_tail 截断丢首行 + get_log_size、_read_completed_output 完整/截断/shell-mode 兜底/启发式四分支、execute_shell_command + await_shell 完成态字段端到端验证（共 17 个新用例）。
 
 2026-04-29 execute_shell completed 分支返回完整 stdout：阈值 1MB 内整文件返回，超过取尾部并加显式截断标记 `...<truncated: showing last N of M bytes>...` + `stdout_truncated/stdout_total_bytes` 字段；新增 sandbox `get_background_output_size` + `_bg_runner.read_tail` 截断时丢首行碎片。
 
 2026-04-29 todo_write 卡片默认折叠：新建与历史会话进入时均为「仅本次变更」，点击展开见完整输出。
+
+2026-04-29 撤销 todo_write changed_task_ids 及前端优先读该字段；折叠仅依据 tool 入参 tasks。
 
 2026-04-29 前端 tool_calls 合并对齐 sagents/agent_base：`mergeToolFunctionArguments` 抽取至 utils；字符串增量与同 fibre 语义，禁止空 `{}` 覆盖已拼接参数（useChatPage + workbench，desktop/server 双端）。
 


### PR DESCRIPTION
## Summary
- Add `parseTodoWriteToolArguments` to extract task ids from incomplete JSON while SSE streams `function.arguments`.
- Wire desktop + server `TodoTaskMessage` to use it so real-time collapse matches incremental todo updates.
- Add Vitest coverage for the parser.

## Test plan
- `cd app/desktop/ui && npx vitest run src/utils/__tests__/parseTodoWriteToolArguments.spec.js`

Made with [Cursor](https://cursor.com)