### PR TITLE
Align server web model provider defaults & gate forced tool_choice=required

### DIFF
--- a/app/server/web/src/views/ModelProviderList.vue
+++ b/app/server/web/src/views/ModelProviderList.vue
@@ -349,23 +349,23 @@
                     <div class="grid gap-4 md:grid-cols-2">
                       <div class="grid gap-2">
                         <Label>{{ t('agent.maxTokens') }}</Label>
-                        <Input type="number" v-model.number="form.maxTokens" class="h-10 rounded-xl" placeholder="4096" />
+                        <Input type="number" v-model.number="form.maxTokens" class="h-10 rounded-xl" />
                       </div>
                       <div class="grid gap-2">
                         <Label>{{ t('agent.temperature') }}</Label>
-                        <Input type="number" v-model.number="form.temperature" class="h-10 rounded-xl" step="0.1" placeholder="0.7" />
+                        <Input type="number" v-model.number="form.temperature" class="h-10 rounded-xl" step="0.1" />
                       </div>
                       <div class="grid gap-2">
                         <Label>{{ t('agent.topP') }}</Label>
-                        <Input type="number" v-model.number="form.topP" class="h-10 rounded-xl" step="0.1" placeholder="0.9" />
+                        <Input type="number" v-model.number="form.topP" class="h-10 rounded-xl" step="0.1" />
                       </div>
                       <div class="grid gap-2">
                         <Label>{{ t('agent.presencePenalty') }}</Label>
-                        <Input type="number" v-model.number="form.presencePenalty" class="h-10 rounded-xl" step="0.1" placeholder="0.0" />
+                        <Input type="number" v-model.number="form.presencePenalty" class="h-10 rounded-xl" step="0.1" />
                       </div>
                       <div class="grid gap-2 md:col-span-2">
                         <Label>{{ t('agent.maxModelLen') }}</Label>
-                        <Input type="number" v-model.number="form.maxModelLen" class="h-10 rounded-xl" placeholder="64000" />
+                        <Input type="number" v-model.number="form.maxModelLen" class="h-10 rounded-xl" />
                       </div>
                     </div>
                   </div>
@@ -460,10 +460,10 @@ const form = reactive({
   api_keys_str: '',
   model: '',
   maxTokens: null,
-  temperature: 0.7,
-  topP: 0.95,
-  presencePenalty: 0,
-  maxModelLen: 64000,
+  temperature: null,
+  topP: null,
+  presencePenalty: null,
+  maxModelLen: null,
   supportsMultimodal: false,
   supportsStructuredOutput: false
 })
@@ -547,12 +547,15 @@ const verifyButtonLabel = computed(() => {
   return capabilityChecked.value ? t('modelProvider.reverifyCapabilities') : t('modelProvider.verifyCapabilities')
 })
 
-const buildApiKeys = () => {
-  return form.api_keys_str
-    .trim()
-    .split(/[\n,]+/)
-    .map((key) => key.trim())
-    .filter(Boolean)
+const buildApiKeys = () => form.api_keys_str.trim().split(/[\n,]+/).map(k => k.trim()).filter(Boolean)
+
+// 输入为有效数字则下发，置空（null/''/NaN）显式以 null 形式下发，
+// 让后端 update 流程可以区分"未提供"和"用户主动清空"，从而把 DB 中的旧值清掉。
+// 同时后端 sanitize_model_request_kwargs 会把 None 字段从 OpenAI SDK 调用里丢弃。
+const optionalNumber = (value) => {
+  if (value === null || value === undefined || value === '') return null
+  const num = Number(value)
+  return Number.isFinite(num) ? num : null
 }
 
 const buildProviderPayload = () => ({
@@ -560,14 +563,11 @@ const buildProviderPayload = () => ({
   base_url: form.base_url,
   api_keys: buildApiKeys(),
   model: form.model,
-  ...(() => {
-    const maxTokensValue = Number(form.maxTokens)
-    return Number.isFinite(maxTokensValue) ? { max_tokens: maxTokensValue } : {}
-  })(),
-  temperature: form.temperature,
-  top_p: form.topP,
-  presence_penalty: form.presencePenalty,
-  max_model_len: form.maxModelLen,
+  max_tokens: optionalNumber(form.maxTokens),
+  temperature: optionalNumber(form.temperature),
+  top_p: optionalNumber(form.topP),
+  presence_penalty: optionalNumber(form.presencePenalty),
+  max_model_len: optionalNumber(form.maxModelLen),
   supports_multimodal: form.supportsMultimodal,
   supports_structured_output: form.supportsStructuredOutput
 })
@@ -658,10 +658,10 @@ const handleCreate = () => {
   form.api_keys_str = ''
   form.model = ''
   form.maxTokens = null
-  form.temperature = 0.7
-  form.topP = 0.95
-  form.presencePenalty = 0
-  form.maxModelLen = 64000
+  form.temperature = null
+  form.topP = null
+  form.presencePenalty = null
+  form.maxModelLen = null
   form.supportsMultimodal = false
   form.supportsStructuredOutput = false
   verified.value = false
@@ -698,10 +698,10 @@ const handleEdit = (provider) => {
   form.api_keys_str = keys.join(',')
   form.model = provider.model
   form.maxTokens = provider.max_tokens ?? null
-  form.temperature = provider.temperature ?? 0.7
-  form.topP = provider.top_p ?? 0.9
-  form.presencePenalty = provider.presence_penalty ?? 0.0
-  form.maxModelLen = provider.max_model_len ?? 64000
+  form.temperature = provider.temperature ?? null
+  form.topP = provider.top_p ?? null
+  form.presencePenalty = provider.presence_penalty ?? null
+  form.maxModelLen = provider.max_model_len ?? null
   form.supportsMultimodal = provider.supports_multimodal ?? false
   form.supportsStructuredOutput = provider.supports_structured_output ?? false
 

--- a/change_log.md
+++ b/change_log.md
@@ -1,3 +1,7 @@
+2026-04-29 SimpleAgent tool_choice=required 改为环境变量 SAGE_FORCE_TOOL_CHOICE_REQUIRED 控制（默认关闭，避免不支持的模型报错），调用方传入参数仍优先生效。
+
+2026-04-29 server web ModelProviderList 与 desktop 对齐：采样参数（temperature/top_p/presence_penalty/max_tokens/max_model_len）默认 null，提交走 optionalNumber 显式 null 下发；后端 sanitize_model_request_kwargs 会丢弃 None 字段，OpenAI SDK 不会收到空值。
+
 2026-04-29 单测覆盖 completed stdout 改造：bg_runner read_tail 截断丢首行 + get_log_size、_read_completed_output 完整/截断/shell-mode 兜底/启发式四分支、execute_shell_command + await_shell 完成态字段端到端验证（共 17 个新用例）。
 
 2026-04-29 execute_shell completed 分支返回完整 stdout：阈值 1MB 内整文件返回，超过取尾部并加显式截断标记 `...<truncated: showing last N of M bytes>...` + `stdout_truncated/stdout_total_bytes` 字段；新增 sandbox `get_background_output_size` + `_bg_runner.read_tail` 截断时丢首行碎片。

--- a/docs/en/ENV_VARS.md
+++ b/docs/en/ENV_VARS.md
@@ -86,6 +86,7 @@ ref: env_vars
 | `SAGE_AUTO_LINT` | `true` | Auto-run ruff/eslint/tsc after `file_write` / `file_update` and inline diagnostics |
 | `SAGE_EMIT_TOOL_CALL_ON_COMPLETE` | `true` | Re-emit tool_call chunks once the LLM stream completes |
 | `SAGE_ECHO_SHELL_OUTPUT` | `false` | Echo background-shell stdout/stderr into the main stream |
+| `SAGE_FORCE_TOOL_CHOICE_REQUIRED` | `false` | Force `tool_choice=required` on every LLM call that carries `tools`. Off by default to avoid `unsupported_parameter` errors on models such as OpenAI o1/o3; enable explicitly with `1/true/yes/on` |
 
 ## 6. Memory
 

--- a/docs/zh/ENV_VARS.md
+++ b/docs/zh/ENV_VARS.md
@@ -85,6 +85,7 @@ ref: env_vars
 | `SAGE_AUTO_LINT` | `true` | `file_write/file_update` 完成后是否自动 lint 并 inline 返回诊断 |
 | `SAGE_EMIT_TOOL_CALL_ON_COMPLETE` | `true` | LLM 完整产出后是否补发 tool_call chunk |
 | `SAGE_ECHO_SHELL_OUTPUT` | `false` | 后台 shell 输出是否回显到主流 |
+| `SAGE_FORCE_TOOL_CHOICE_REQUIRED` | `false` | 是否对所有带 tools 的 LLM 调用强制 `tool_choice=required`。默认关闭，避免 OpenAI o1/o3 等不支持该参数的模型报错；显式设为 `1/true/yes/on` 后启用 |
 
 ## 6. Memory
 

--- a/sagents/agent/simple_agent.py
+++ b/sagents/agent/simple_agent.py
@@ -854,9 +854,12 @@ class SimpleAgent(AgentBase):
 
         if len(tools_json) > 0:
             model_config_override['tools'] = tools_json
-            # if force_tool_choice_required:
-            model_config_override['tool_choice'] = 'required'
-
+            # 通过环境变量 SAGE_FORCE_TOOL_CHOICE_REQUIRED 控制是否强制 tool_choice=required。
+            # 默认关闭：部分模型（如 OpenAI o1/o3、部分国产模型）不支持 tool_choice=required，
+            # 显式启用后才下发给 LLM。调用方传入的 force_tool_choice_required 仍优先生效。
+            env_force_required = os.getenv("SAGE_FORCE_TOOL_CHOICE_REQUIRED", "").strip().lower() in ("1", "true", "yes", "on")
+            if force_tool_choice_required or env_force_required:
+                model_config_override['tool_choice'] = 'required'
         response = self._call_llm_streaming(
             messages=cast(List[Union[MessageChunk, Dict[str, Any]]], clean_message_input),
             session_id=session_id,

--- a/sagents/agent/simple_agent.py
+++ b/sagents/agent/simple_agent.py
@@ -854,8 +854,8 @@ class SimpleAgent(AgentBase):
 
         if len(tools_json) > 0:
             model_config_override['tools'] = tools_json
-            if force_tool_choice_required:
-                model_config_override['tool_choice'] = 'required'
+            # if force_tool_choice_required:
+            model_config_override['tool_choice'] = 'required'
 
         response = self._call_llm_streaming(
             messages=cast(List[Union[MessageChunk, Dict[str, Any]]], clean_message_input),


### PR DESCRIPTION
## Summary
- Align `app/server/web` ModelProviderList sampling-param defaults with desktop (default `null`, submit via `optionalNumber`, drop misleading placeholders). Empty values reach `sanitize_model_request_kwargs` and are stripped before being sent to the OpenAI SDK, matching desktop behavior.
- Gate the always-on `tool_choice=required` in `SimpleAgent._call_llm_and_process_response` behind a new env var `SAGE_FORCE_TOOL_CHOICE_REQUIRED` (default off) so models that do not support it (e.g. OpenAI o1/o3) keep working. Caller-passed `force_tool_choice_required=True` still wins.
- Document the new env var in `docs/en/ENV_VARS.md` and `docs/zh/ENV_VARS.md` (section 5, Agent main loop).

## Test plan
- [ ] Server web: create / edit a provider with empty advanced fields, confirm payload sends `null` and OpenAI calls succeed without `invalid_request_error`.
- [ ] Run a SimpleAgent flow with default env (no `SAGE_FORCE_TOOL_CHOICE_REQUIRED`) on an o1/o3 model; verify no `unsupported_parameter` error.
- [ ] Set `SAGE_FORCE_TOOL_CHOICE_REQUIRED=1`, verify `tool_choice=required` is sent in the LLM request log.
