### PR TITLE
# 修复 AnyTool 隐藏上下文参数导致的 MCP 输入校验问题

### DIFF
--- a/mcp_servers/anytool/anytool_server.py
+++ b/mcp_servers/anytool/anytool_server.py
@@ -1,11 +1,24 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any, Dict, List
 
 from mcp import types
 from mcp.server import Server
 
 from .anytool_runtime import generate_anytool_result, normalize_anytool_tools
+
+
+_HIDDEN_CONTEXT_PARAM_SCHEMAS: Dict[str, Dict[str, Any]] = {
+    "session_id": {
+        "type": "string",
+        "description": "Hidden Sage session id. Auto-injected by the backend.",
+    },
+    "user_id": {
+        "type": "string",
+        "description": "Hidden Sage user id. Auto-injected by the backend.",
+    },
+}
 
 
 def _ensure_object_schema(schema: Any, *, allow_any_properties: bool = False) -> Dict[str, Any]:
@@ -30,6 +43,15 @@ def _ensure_object_schema(schema: Any, *, allow_any_properties: bool = False) ->
     if not isinstance(normalized.get("required"), list):
         normalized["required"] = []
     normalized.setdefault("additionalProperties", allow_any_properties if not normalized["properties"] else False)
+    return normalized
+
+
+def _ensure_anytool_input_schema(schema: Any) -> Dict[str, Any]:
+    """Build the runtime AnyTool input schema with hidden Sage context fields."""
+    normalized = _ensure_object_schema(deepcopy(schema), allow_any_properties=True)
+    properties = normalized.setdefault("properties", {})
+    for key, param_schema in _HIDDEN_CONTEXT_PARAM_SCHEMAS.items():
+        properties.setdefault(key, dict(param_schema))
     return normalized
 
 
@@ -58,7 +80,7 @@ def _build_tool_schema(tool_def: Dict[str, Any]) -> types.Tool:
         name=str(tool_def.get("name", "")).strip(),
         title=str(tool_def.get("title", "")).strip() or None,
         description=str(tool_def.get("description", "")).strip() or None,
-        inputSchema=_ensure_object_schema(tool_def.get("parameters"), allow_any_properties=True),
+        inputSchema=_ensure_anytool_input_schema(tool_def.get("parameters")),
         outputSchema=output_schema,
     )
 

--- a/sagents/tool/tool_schema.py
+++ b/sagents/tool/tool_schema.py
@@ -173,8 +173,8 @@ def convert_spec_to_openai_format(
 
     # In strict mode, ALL properties must be in required, and every nested object
     # must also have additionalProperties: false with a complete required array.
-    # session_id at the top level is always auto-injected and must not be exposed to the LLM.
-    _AUTO_INJECT_PARAMS = {"session_id"}
+    # These top-level context fields are auto-injected and must not be exposed to the LLM.
+    _AUTO_INJECT_PARAMS = {"session_id", "user_id"}
 
     def _enforce_strict_schema(node: Any) -> None:
         """Recursively enforce OpenAI strict-mode constraints on all nested object schemas.

--- a/tests/app/server/core/test_tool_routes.py
+++ b/tests/app/server/core/test_tool_routes.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from app.server.routers.mcp import mcp_router
 from app.server.routers.tool import tool_router
 from common.services.tool_service import _normalize_tool_result
+from mcp_servers.anytool.anytool_server import _build_tool_schema
 from mcp_servers.anytool.anytool_runtime import generate_anytool_result
 from mcp_servers.anytool.anytool_http import resolve_anytool_server_name
 
@@ -31,6 +32,31 @@ class TestToolRoutes(unittest.TestCase):
         self.assertEqual(normalized["parsed"], {"value": 1})
         self.assertIn('"value": 1', normalized["formatted_text"])
         self.assertEqual(normalized["content"], {"value": 1})
+
+    def test_anytool_schema_adds_hidden_context_params(self):
+        tool = _build_tool_schema(
+            {
+                "name": "customer_send_message_whatsapp",
+                "description": "Send WhatsApp message",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "phone": {"type": "string"},
+                        "message": {"type": "string"},
+                    },
+                    "required": ["phone", "message"],
+                    "additionalProperties": False,
+                },
+            }
+        )
+
+        properties = tool.inputSchema["properties"]
+        self.assertIn("phone", properties)
+        self.assertIn("message", properties)
+        self.assertIn("session_id", properties)
+        self.assertIn("user_id", properties)
+        self.assertEqual(tool.inputSchema["required"], ["phone", "message"])
+        self.assertFalse(tool.inputSchema["additionalProperties"])
 
     def test_exec_tool_route_uses_shared_tool_execution_api(self):
         app = _build_app()

--- a/tests/sagents/tool/test_tool_context_injection.py
+++ b/tests/sagents/tool/test_tool_context_injection.py
@@ -11,6 +11,7 @@ from sagents.tool.tool_schema import (
     SageMcpToolSpec,
     StreamableHttpServerParameters,
     ToolSpec,
+    convert_spec_to_openai_format,
 )
 
 
@@ -161,6 +162,28 @@ class TestToolContextInjection(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(call_kwargs["foo"], "bar")
         self.assertEqual(call_kwargs["session_id"], "session-4")
         self.assertEqual(call_kwargs["user_id"], "user-4")
+
+    def test_auto_injected_params_are_hidden_from_openai_schema(self):
+        tool = McpToolSpec(
+            name="remote_echo",
+            description="echo",
+            description_i18n={},
+            func=None,
+            parameters={
+                "foo": {"type": "string"},
+                "session_id": {"type": "string"},
+                "user_id": {"type": "string"},
+            },
+            required=["foo"],
+            server_name="remote",
+            server_params=StreamableHttpServerParameters(url="http://example.invalid"),
+        )
+
+        openai_tool = convert_spec_to_openai_format(tool)
+        params = openai_tool["function"]["parameters"]
+
+        self.assertEqual(set(params["properties"].keys()), {"foo"})
+        self.assertEqual(params["required"], ["foo"])
 
     async def test_tool_service_passes_user_id_to_tool_manager(self):
         fake_manager = type("FakeManager", (), {})()


### PR DESCRIPTION
# 修复 AnyTool 隐藏上下文参数导致的 MCP 输入校验问题

## 背景

AnyTool 执行时需要拿到当前会话和用户上下文，也就是 `session_id` 和 `user_id`。

但这两个字段属于系统自动注入的上下文参数，不应该要求用户在前端 AnyTool 编辑器里手动配置，也不应该展示给模型作为普通业务参数。

此前如果用户新建一个 AnyTool，只配置自己的业务参数，没有配置 `session_id` / `user_id`，实际调用时可能出现 MCP 输入校验错误：

```json
{
  "error": true,
  "error_type": "EXECUTION_ERROR",
  "message": "Tool 'customer_send_message_whatsapp' failed after 0.03s: Input validation error: Additional properties are not allowed ('session_id', 'user_id' were unexpected)",
  "tool_name": "customer_send_message_whatsapp",
  "exception_detail": "Input validation error: Additional properties are not allowed ('session_id', 'user_id' were unexpected)"
}
```

## 问题原因

AnyTool 的业务参数 schema 由用户在前端配置。

当用户只配置业务参数时，AnyTool 暴露给 MCP 的 inputSchema 中不包含 `session_id` 和 `user_id`。

但运行时系统又需要把这两个上下文参数注入到工具调用里。

在 MCP 严格校验下，如果 inputSchema 设置了 `additionalProperties: false`，未声明的字段会被拒绝，所以 `session_id` 和 `user_id` 会触发：

```text
Additional properties are not allowed
```

## 本次修改

本次改动的目标是：

- `session_id` 和 `user_id` 继续由后端自动注入
- 用户不需要在前端手动配置这两个参数
- 前端工具参数列表不展示这两个隐藏参数
- 模型调用工具时也不需要生成这两个参数
- MCP 输入校验能够接受后端注入的 `session_id` 和 `user_id`

具体修改如下：

### `mcp_servers/anytool/anytool_server.py`

新增 AnyTool 运行时隐藏上下文参数 schema：

- `session_id`
- `user_id`

在构建 AnyTool 的 MCP `inputSchema` 时，后端会自动把这两个字段拼入 schema。

这样 MCP 在执行前做输入校验时，会认为 `session_id` 和 `user_id` 是合法字段，不再把它们当作额外参数拒绝。

同时，这两个字段只是在后端运行时 schema 中补入，不要求用户在前端配置。

### `sagents/tool/tool_schema.py`

更新自动注入参数过滤逻辑。

之前只把 `session_id` 从 OpenAI 工具 schema 中隐藏。

现在同时隐藏：

- `session_id`
- `user_id`

这样模型和前端看到的工具参数仍然只包含用户定义的业务参数，不会展示系统上下文字段。

### `tests/app/server/core/test_tool_routes.py`

新增测试，验证 AnyTool MCP schema 会自动包含隐藏上下文字段：

- 用户参数仍然保留
- `session_id` 自动补入
- `user_id` 自动补入
- 原有 `required` 不被污染
- `additionalProperties: false` 仍然保持

### `tests/sagents/tool/test_tool_context_injection.py`

新增测试，验证自动注入参数不会暴露给 OpenAI 工具 schema。

即使工具内部 schema 包含：

- `session_id`
- `user_id`

最终暴露给模型的参数中也只会保留业务参数。

## 影响范围

本次改动主要影响 AnyTool MCP 工具的参数 schema 构建和工具参数展示逻辑。

不受影响：

- 普通内置工具
- 普通外部 MCP 工具
- AnyTool 用户自定义业务参数
- AnyTool 的实际业务参数校验
- `session_id` / `user_id` 的后端自动注入能力

修复后：

- 用户无需在前端配置 `session_id` 和 `user_id`
- 前端不会展示 `session_id` 和 `user_id`
- 模型不会被要求生成 `session_id` 和 `user_id`
- 后端仍然可以把 `session_id` 和 `user_id` 注入到 AnyTool 调用中
- MCP 严格输入校验不会再因为这两个隐藏字段报错

## 提交内容

本次 PR 修改了以下文件：

```text
mcp_servers/anytool/anytool_server.py
sagents/tool/tool_schema.py
tests/app/server/core/test_tool_routes.py
tests/sagents/tool/test_tool_context_injection.py
```

## 验证说明

本地已做 Python 语法编译检查。

按提交要求，本次最终推送前没有继续运行完整测试套件。

