### PR TITLE
Align terminal with CLI runtime contracts

### DIFF
--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -269,6 +269,11 @@ def build_argument_parser() -> argparse.ArgumentParser:
     sessions_inspect_parser.add_argument("--json", action="store_true", help="Print session details as JSON")
     sessions_inspect_parser.add_argument("--verbose", action="store_true", help="Show runtime logs")
 
+    agents_parser = subparsers.add_parser("agents", help="List visible CLI agents")
+    agents_parser.add_argument("--user-id", dest="user_id", default=default_user_id)
+    agents_parser.add_argument("--json", action="store_true", help="Print agents as JSON")
+    agents_parser.add_argument("--verbose", action="store_true", help="Show runtime logs")
+
     skills_parser = subparsers.add_parser("skills", help="List available CLI skills")
     skills_parser.add_argument("--user-id", dest="user_id", default=default_user_id)
     skills_parser.add_argument("--agent-id", dest="agent_id", help="Show the skills currently available to a specific agent")
@@ -457,7 +462,16 @@ def _empty_stats(*, request, workspace: Optional[str]) -> Dict[str, Any]:
         "completion_tokens": None,
         "total_tokens": None,
         "per_step_info": [],
+        "tool_steps": [],
+        "phase_timings": [],
+        "_active_tool_steps": {},
+        "_next_tool_step": 1,
         "_tool_tag_buffer": "",
+        "_phase_totals": {},
+        "_phase_order": [],
+        "_active_phase": None,
+        "_active_phase_started_at": None,
+        "_last_event_timestamp": None,
     }
 
 
@@ -545,6 +559,128 @@ def _collect_event_file_paths(event: Dict[str, Any], *, content_buffer: str = ""
 
 
 def _record_stats_event(stats: Dict[str, Any], event: Dict[str, Any], start_time: float) -> None:
+    def _event_timestamp() -> float:
+        timestamp = event.get("timestamp")
+        if isinstance(timestamp, (int, float)):
+            return float(timestamp)
+        return round(time.time(), 3)
+
+    def _finalize_active_phase(until_timestamp: float) -> None:
+        phase = stats.get("_active_phase")
+        started_at = stats.get("_active_phase_started_at")
+        if not phase or not isinstance(started_at, (int, float)):
+            return
+
+        totals = stats["_phase_totals"].setdefault(
+            phase,
+            {
+                "phase": phase,
+                "started_at": float(started_at),
+                "finished_at": float(until_timestamp),
+                "duration_ms": 0.0,
+                "segment_count": 0,
+            },
+        )
+        totals["started_at"] = min(float(totals.get("started_at") or started_at), float(started_at))
+        totals["finished_at"] = max(
+            float(totals.get("finished_at") or until_timestamp),
+            float(until_timestamp),
+        )
+        totals["duration_ms"] = float(totals.get("duration_ms") or 0.0) + max(
+            0.0,
+            (float(until_timestamp) - float(started_at)) * 1000.0,
+        )
+        totals["segment_count"] = int(totals.get("segment_count") or 0) + 1
+        stats["_active_phase"] = None
+        stats["_active_phase_started_at"] = None
+
+    def _start_phase(phase: str, timestamp: float) -> None:
+        if stats.get("_active_phase") == phase:
+            return
+        _finalize_active_phase(timestamp)
+        stats["_active_phase"] = phase
+        stats["_active_phase_started_at"] = timestamp
+        if phase not in stats["_phase_totals"]:
+            stats["_phase_totals"][phase] = {
+                "phase": phase,
+                "started_at": timestamp,
+                "finished_at": timestamp,
+                "duration_ms": 0.0,
+                "segment_count": 0,
+            }
+            stats["_phase_order"].append(phase)
+
+    def _start_tool_step(tool_name: str, tool_call_id: Optional[str]) -> None:
+        key = tool_call_id or f"synthetic:{tool_name}:{stats['_next_tool_step']}"
+        if key in stats["_active_tool_steps"]:
+            return
+        step = {
+            "step": stats["_next_tool_step"],
+            "tool_name": tool_name or "unknown",
+            "tool_call_id": tool_call_id,
+            "status": "running",
+            "started_at": _event_timestamp(),
+            "finished_at": None,
+            "duration_ms": None,
+        }
+        stats["_next_tool_step"] += 1
+        stats["_active_tool_steps"][key] = step
+        stats["tool_steps"].append(step)
+
+    def _finish_tool_step(tool_call_id: Optional[str], tool_name: Optional[str]) -> None:
+        key = tool_call_id or ""
+        step = stats["_active_tool_steps"].get(key) if key else None
+        if step is None and tool_name:
+            for candidate in reversed(stats["tool_steps"]):
+                if candidate.get("tool_name") == tool_name and candidate.get("status") == "running":
+                    step = candidate
+                    break
+        if step is None:
+            _start_tool_step(tool_name or "unknown", tool_call_id)
+            step = stats["tool_steps"][-1]
+        finished_at = _event_timestamp()
+        step["status"] = "completed"
+        step["finished_at"] = finished_at
+        started_at = step.get("started_at")
+        if isinstance(started_at, (int, float)):
+            step["duration_ms"] = max(0.0, (finished_at - float(started_at)) * 1000.0)
+        if key:
+            stats["_active_tool_steps"].pop(key, None)
+
+    def _event_phase(tool_names: List[str]) -> Optional[str]:
+        event_type = str(event.get("type") or "").strip()
+        role = str(event.get("role") or "").strip()
+        content = event.get("content")
+
+        if event_type in {"token_usage", "stream_end", "start", "done", "cli_stats"}:
+            return None
+        if event_type in {
+            "thinking",
+            "reasoning_content",
+            "task_analysis",
+            "analysis",
+            "plan",
+            "observation",
+        }:
+            return "planning"
+        if event_type in {"tool_call", "tool_result"} or role == "tool" or tool_names:
+            return "tool"
+        if (
+            content
+            and isinstance(content, str)
+            and (
+                event_type in {"text", "assistant", "message", "do_subtask_result"}
+                or role in {"assistant", "agent"}
+            )
+        ):
+            return "assistant_text"
+        if event_type in {"error", "cli_error"}:
+            return "error"
+        return None
+
+    event_timestamp = _event_timestamp()
+    stats["_last_event_timestamp"] = event_timestamp
+
     session_id = event.get("session_id")
     if session_id and not stats["session_id"]:
         stats["session_id"] = session_id
@@ -573,12 +709,92 @@ def _record_stats_event(stats: Dict[str, Any], event: Dict[str, Any], start_time
     if has_visible_output and stats["first_output_seconds"] is None:
         stats["first_output_seconds"] = round(time.monotonic() - start_time, 3)
 
+    phase = _event_phase(tool_names)
+    if phase:
+        _start_phase(phase, event_timestamp)
+
+    if event.get("type") == "tool_call":
+        for tool_call in event.get("tool_calls") or []:
+            if not isinstance(tool_call, dict):
+                continue
+            function = tool_call.get("function") or {}
+            tool_name = function.get("name")
+            tool_call_id = tool_call.get("id")
+            if isinstance(tool_name, str) and tool_name.strip():
+                _start_tool_step(tool_name.strip(), str(tool_call_id).strip() or None)
+
+    event_type = event.get("type")
+    role = event.get("role")
+    if event_type == "tool_result" or role == "tool":
+        tool_call_id = event.get("tool_call_id")
+        tool_name = None
+        metadata = event.get("metadata") or {}
+        if isinstance(metadata.get("tool_name"), str):
+            tool_name = metadata.get("tool_name")
+        if not tool_name and isinstance(event.get("tool_name"), str):
+            tool_name = event.get("tool_name")
+        _finish_tool_step(
+            str(tool_call_id).strip() or None if tool_call_id else None,
+            str(tool_name).strip() if isinstance(tool_name, str) and tool_name.strip() else None,
+        )
+
     if event.get("type") == "token_usage":
-        token_usage = (event.get("metadata") or {}).get("token_usage") or {}
-        stats["prompt_tokens"] = token_usage.get("prompt_tokens")
-        stats["completion_tokens"] = token_usage.get("completion_tokens")
-        stats["total_tokens"] = token_usage.get("total_tokens")
+        metadata = event.get("metadata") or {}
+        token_usage = metadata.get("token_usage") or {}
+        total_info = token_usage.get("total_info") or {}
+        stats["prompt_tokens"] = total_info.get("prompt_tokens")
+        stats["completion_tokens"] = total_info.get("completion_tokens")
+        stats["total_tokens"] = total_info.get("total_tokens")
         stats["per_step_info"] = token_usage.get("per_step_info") or []
+        tool_steps = metadata.get("tool_steps") or []
+        if isinstance(tool_steps, list) and tool_steps:
+            stats["tool_steps"] = tool_steps
+        phase_timings = metadata.get("phase_timings") or []
+        if isinstance(phase_timings, list) and phase_timings:
+            stats["phase_timings"] = phase_timings
+
+
+def _finalize_stats(stats: Dict[str, Any], finished_at: Optional[float] = None) -> None:
+    active_phase = stats.get("_active_phase")
+    active_started_at = stats.get("_active_phase_started_at")
+    if active_phase and isinstance(active_started_at, (int, float)):
+        last_event_timestamp = stats.get("_last_event_timestamp")
+        end_timestamp = finished_at
+        if not isinstance(end_timestamp, (int, float)):
+            end_timestamp = last_event_timestamp
+        if isinstance(end_timestamp, (int, float)):
+            totals = stats["_phase_totals"].setdefault(
+                active_phase,
+                {
+                    "phase": active_phase,
+                    "started_at": float(active_started_at),
+                    "finished_at": float(end_timestamp),
+                    "duration_ms": 0.0,
+                    "segment_count": 0,
+                },
+            )
+            totals["started_at"] = min(
+                float(totals.get("started_at") or active_started_at),
+                float(active_started_at),
+            )
+            totals["finished_at"] = max(
+                float(totals.get("finished_at") or end_timestamp),
+                float(end_timestamp),
+            )
+            totals["duration_ms"] = float(totals.get("duration_ms") or 0.0) + max(
+                0.0,
+                (float(end_timestamp) - float(active_started_at)) * 1000.0,
+            )
+            totals["segment_count"] = int(totals.get("segment_count") or 0) + 1
+            stats["_active_phase"] = None
+            stats["_active_phase_started_at"] = None
+
+    if not stats.get("phase_timings"):
+        stats["phase_timings"] = [
+            stats["_phase_totals"][phase]
+            for phase in stats.get("_phase_order") or []
+            if phase in stats["_phase_totals"]
+        ]
 
 
 def _print_stats(stats: Dict[str, Any], *, json_output: bool) -> None:
@@ -601,6 +817,8 @@ def _print_stats(stats: Dict[str, Any], *, json_output: bool) -> None:
                     "completion_tokens": stats.get("completion_tokens"),
                     "total_tokens": stats.get("total_tokens"),
                     "per_step_info": stats.get("per_step_info") or [],
+                    "tool_steps": stats.get("tool_steps") or [],
+                    "phase_timings": stats.get("phase_timings") or [],
                 },
                 ensure_ascii=False,
             )
@@ -653,8 +871,90 @@ def _print_stats(stats: Dict[str, Any], *, json_output: bool) -> None:
                 f"total={usage.get('total_tokens')}"
             )
 
+    tool_steps = stats.get("tool_steps") or []
+    if tool_steps:
+        output_lines.append("tool_steps:")
+        for step in tool_steps:
+            duration_ms = step.get("duration_ms")
+            duration_text = (
+                f"{duration_ms:.0f}ms"
+                if isinstance(duration_ms, (int, float))
+                else str(step.get("status") or "unknown")
+            )
+            output_lines.append(
+                "  - "
+                f"#{step.get('step')} {step.get('tool_name')} ({duration_text})"
+            )
+
+    phase_timings = stats.get("phase_timings") or []
+    if phase_timings:
+        output_lines.append("phase_timings:")
+        for phase in phase_timings:
+            duration_ms = phase.get("duration_ms")
+            duration_text = (
+                f"{duration_ms:.0f}ms"
+                if isinstance(duration_ms, (int, float))
+                else "unknown"
+            )
+            output_lines.append(
+                "  - "
+                f"{phase.get('phase')} ({duration_text}, segments={phase.get('segment_count', 0)})"
+            )
+
     sys.stdout.write("\n".join(output_lines) + "\n")
     sys.stdout.flush()
+
+
+def _tool_step_event_key(step: Dict[str, Any]) -> str:
+    tool_call_id = step.get("tool_call_id")
+    if isinstance(tool_call_id, str) and tool_call_id.strip():
+        return tool_call_id.strip()
+    return f"step:{step.get('step')}"
+
+
+def _snapshot_tool_steps(stats: Dict[str, Any]) -> Dict[str, str]:
+    snapshot: Dict[str, str] = {}
+    for step in stats.get("tool_steps") or []:
+        if not isinstance(step, dict):
+            continue
+        snapshot[_tool_step_event_key(step)] = str(step.get("status") or "")
+    return snapshot
+
+
+def _emit_json_tool_events(
+    previous_steps: Dict[str, str],
+    current_steps: List[Dict[str, Any]],
+) -> None:
+    for step in current_steps:
+        if not isinstance(step, dict):
+            continue
+        key = _tool_step_event_key(step)
+        previous_status = previous_steps.get(key)
+        current_status = str(step.get("status") or "")
+        if current_status == previous_status:
+            continue
+
+        action = None
+        if current_status == "running" and previous_status is None:
+            action = "started"
+        elif previous_status == "running" and current_status in {"completed", "failed"}:
+            action = "finished"
+        if not action:
+            continue
+
+        print(
+            json.dumps(
+                {
+                    "type": "cli_tool",
+                    "action": action,
+                    "step": step.get("step"),
+                    "tool_name": step.get("tool_name"),
+                    "tool_call_id": step.get("tool_call_id"),
+                    "status": current_status,
+                },
+                ensure_ascii=False,
+            )
+        )
 
 
 def _emit_stream_idle_notice(idle_seconds: float) -> None:
@@ -751,8 +1051,26 @@ async def _stream_request(request, json_output: bool, stats_output: bool, worksp
 
             last_event_time = time.monotonic()
             last_notice_time = None
+            previous_phase = stats.get("_active_phase")
+            previous_tool_steps = _snapshot_tool_steps(stats)
             _record_stats_event(stats, event, start_time)
             if json_output:
+                next_phase = stats.get("_active_phase")
+                if (
+                    isinstance(next_phase, str)
+                    and next_phase
+                    and next_phase != previous_phase
+                ):
+                    print(
+                        json.dumps(
+                            {
+                                "type": "cli_phase",
+                                "phase": next_phase,
+                            },
+                            ensure_ascii=False,
+                        )
+                    )
+                _emit_json_tool_events(previous_tool_steps, stats.get("tool_steps") or [])
                 print(json.dumps(event, ensure_ascii=False))
             else:
                 _print_plain_event(event, render_state)
@@ -762,6 +1080,7 @@ async def _stream_request(request, json_output: bool, stats_output: bool, worksp
         with suppress(asyncio.CancelledError):
             await producer_task
     stats["elapsed_seconds"] = round(time.monotonic() - start_time, 3)
+    _finalize_stats(stats)
     if stats_output:
         _print_stats(stats, json_output=json_output)
     return 0
@@ -1121,6 +1440,35 @@ async def _skills_command(args: argparse.Namespace) -> int:
     return 0
 
 
+async def _agents_command(args: argparse.Namespace) -> int:
+    from app.cli.service import cli_db_runtime, list_cli_agents
+
+    async with cli_db_runtime(verbose=args.verbose):
+        result = await list_cli_agents(user_id=args.user_id)
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+
+    print(f"user_id: {result['user_id']}")
+    print(f"total: {result['total']}")
+    agents = result.get("list") or []
+    if not agents:
+        print("agents:\n  (none)")
+        return 0
+
+    print("agents:")
+    for item in agents:
+        print(
+            f"  - {item.get('agent_id')} | {item.get('name')} | "
+            f"mode={item.get('agent_mode')} | default={item.get('is_default')}"
+        )
+        updated_at = item.get("updated_at")
+        if updated_at:
+            print(f"    updated_at: {updated_at}")
+    return 0
+
+
 def _config_show_command(args: argparse.Namespace) -> int:
     from app.cli.service import collect_config_info
 
@@ -1280,6 +1628,8 @@ async def _main_async(args: argparse.Namespace) -> int:
             return await _doctor_command(args)
         if args.command == "sessions":
             return await _sessions_command(args)
+        if args.command == "agents":
+            return await _agents_command(args)
         if args.command == "skills":
             return await _skills_command(args)
         if args.command == "config" and args.config_command == "show":

--- a/app/cli/service.py
+++ b/app/cli/service.py
@@ -1044,6 +1044,52 @@ async def list_sessions(
     }
 
 
+def _resolve_agent_mode_from_config(agent_config: Dict[str, Any]) -> str:
+    raw_value = str(
+        agent_config.get("agentMode")
+        or agent_config.get("agent_mode")
+        or ""
+    ).strip().lower()
+    if raw_value in {"simple", "multi", "fibre"}:
+        return raw_value
+    return "simple"
+
+
+async def list_cli_agents(
+    *,
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    from common.services.agent_service import list_agents
+
+    resolved_user_id = user_id or get_default_cli_user_id()
+    agents = await list_agents(user_id=resolved_user_id)
+    items: List[Dict[str, Any]] = []
+    for agent in agents:
+        agent_config = agent.config if isinstance(agent.config, dict) else {}
+        items.append(
+            {
+                "agent_id": agent.agent_id,
+                "name": agent.name,
+                "agent_mode": _resolve_agent_mode_from_config(agent_config),
+                "is_default": bool(agent.is_default),
+                "updated_at": agent.updated_at.isoformat() if agent.updated_at else "",
+            }
+        )
+
+    items.sort(
+        key=lambda item: (
+            not bool(item.get("is_default")),
+            item.get("name") or "",
+            item.get("agent_id") or "",
+        )
+    )
+    return {
+        "user_id": resolved_user_id,
+        "total": len(items),
+        "list": items,
+    }
+
+
 async def list_available_skills(
     *,
     user_id: Optional[str] = None,

--- a/app/terminal/README.md
+++ b/app/terminal/README.md
@@ -56,6 +56,8 @@ Currently supported startup forms:
 
 ```bash
 sage-terminal
+sage-terminal --agent-id agent_demo
+sage-terminal --agent-id agent_demo --agent-mode fibre
 sage-terminal run "inspect this repo"
 sage-terminal chat "hello"
 sage-terminal config init
@@ -79,6 +81,8 @@ sage-terminal --help
 Common slash commands:
 
 - `/help`
+- `/agent`
+- `/mode`
 - `/new`
 - `/sessions`
 - `/resume`
@@ -99,5 +103,6 @@ Common slash commands:
 - This preview is intended for local development and dogfooding.
 - Packaging and one-command installation are not included yet.
 - The TUI currently relies on the Sage CLI/backend behavior, so CLI runtime configuration must be valid first.
+- Agent selection is still lightweight: the TUI can override `agent_id` and `agent_mode`, but the actual agent configuration remains owned by the Sage CLI/runtime and its stored agent config.
 - Runtime lookup now supports explicit CLI/Python overrides, bundled `sage` / Python fallbacks, and packaged-layout state roots as a first distribution step.
 - The repo now also includes a minimal launcher wrapper at `scripts/run-sage-terminal.sh` and a distribution smoke script at `scripts/smoke-runtime-distribution.sh`.

--- a/app/terminal/src/app/commands.rs
+++ b/app/terminal/src/app/commands.rs
@@ -1,3 +1,5 @@
+#[path = "commands/agent.rs"]
+pub(crate) mod agent;
 #[path = "commands/dispatch.rs"]
 mod dispatch;
 #[path = "commands/model.rs"]

--- a/app/terminal/src/app/commands/agent.rs
+++ b/app/terminal/src/app/commands/agent.rs
@@ -1,0 +1,69 @@
+use crate::app::{App, MessageKind};
+
+const VALID_AGENT_MODES: &[&str] = &["simple", "multi", "fibre"];
+
+impl App {
+    pub fn apply_startup_agent_options(
+        &mut self,
+        agent_id: Option<String>,
+        agent_mode: Option<String>,
+    ) {
+        self.selected_agent_id = agent_id.filter(|value| !value.trim().is_empty());
+        if let Some(mode) = agent_mode {
+            self.agent_mode = mode;
+        }
+    }
+
+    pub fn set_selected_agent_id(&mut self, agent_id: String) {
+        let normalized = agent_id.trim().to_string();
+        self.selected_agent_id = Some(normalized.clone());
+        self.clear_agent_catalog();
+        self.skill_catalog = None;
+        self.backend_restart_requested = true;
+        self.queue_message(MessageKind::Tool, format!("agent set: {normalized}"));
+        self.status = format!("agent  {}", self.session_id);
+    }
+
+    pub fn clear_selected_agent_id(&mut self) {
+        match self.selected_agent_id.take() {
+            Some(agent_id) => {
+                self.clear_agent_catalog();
+                self.skill_catalog = None;
+                self.backend_restart_requested = true;
+                self.queue_message(MessageKind::Tool, format!("cleared agent: {agent_id}"));
+            }
+            None => {
+                self.queue_message(MessageKind::System, "no agent override is active");
+            }
+        }
+        self.status = format!("agent  {}", self.session_id);
+    }
+
+    pub fn set_agent_mode_selection(&mut self, mode: String) {
+        self.agent_mode = mode.clone();
+        self.backend_restart_requested = true;
+        self.queue_message(MessageKind::Tool, format!("agent mode set: {mode}"));
+        self.status = format!("mode  {}", self.session_id);
+    }
+
+    pub fn queue_agent_status(&mut self) {
+        self.queue_message(
+            MessageKind::System,
+            format!(
+                "agent_id: {}\nagent_mode: {}",
+                self.selected_agent_id
+                    .clone()
+                    .unwrap_or_else(|| "(default)".to_string()),
+                self.agent_mode
+            ),
+        );
+        self.status = format!("agent  {}", self.session_id);
+    }
+}
+
+pub(crate) fn normalize_agent_mode(value: &str) -> Option<String> {
+    let normalized = value.trim().to_lowercase();
+    VALID_AGENT_MODES
+        .contains(&normalized.as_str())
+        .then_some(normalized)
+}

--- a/app/terminal/src/app/commands/dispatch.rs
+++ b/app/terminal/src/app/commands/dispatch.rs
@@ -2,6 +2,8 @@ use crate::app::{App, MessageKind, SubmitAction};
 use crate::app_preview::provider_help_text;
 use crate::slash_command;
 
+use super::agent::normalize_agent_mode;
+
 impl App {
     pub(crate) fn handle_command(&mut self, command: &str) -> SubmitAction {
         let mut parts = command.split_whitespace();
@@ -216,13 +218,71 @@ impl App {
                     SubmitAction::Handled
                 }
             },
+            "/agent" => match (parts.next(), parts.next(), parts.next()) {
+                (None, None, None) | (Some("show"), None, None) => {
+                    self.queue_agent_status();
+                    SubmitAction::Handled
+                }
+                (Some("list"), None, None) => SubmitAction::ListAgents,
+                (Some("set"), Some(agent_id), None) => {
+                    self.set_selected_agent_id(agent_id.to_string());
+                    SubmitAction::Handled
+                }
+                (Some("clear"), None, None) => {
+                    self.clear_selected_agent_id();
+                    SubmitAction::Handled
+                }
+                _ => {
+                    self.queue_message(
+                        MessageKind::System,
+                        "Usage: /agent | /agent show | /agent list | /agent set <agent_id> | /agent clear",
+                    );
+                    self.status = format!("invalid command  {}", self.session_id);
+                    SubmitAction::Handled
+                }
+            },
+            "/mode" => match (parts.next(), parts.next(), parts.next()) {
+                (None, None, None) | (Some("show"), None, None) => {
+                    self.queue_message(
+                        MessageKind::System,
+                        format!("agent_mode: {}", self.agent_mode),
+                    );
+                    self.status = format!("mode  {}", self.session_id);
+                    SubmitAction::Handled
+                }
+                (Some("set"), Some(mode), None) => match normalize_agent_mode(mode) {
+                    Some(mode) => {
+                        self.set_agent_mode_selection(mode);
+                        SubmitAction::Handled
+                    }
+                    None => {
+                        self.queue_message(
+                            MessageKind::System,
+                            "Usage: /mode | /mode show | /mode set <simple|multi|fibre>",
+                        );
+                        self.status = format!("invalid command  {}", self.session_id);
+                        SubmitAction::Handled
+                    }
+                },
+                _ => {
+                    self.queue_message(
+                        MessageKind::System,
+                        "Usage: /mode | /mode show | /mode set <simple|multi|fibre>",
+                    );
+                    self.status = format!("invalid command  {}", self.session_id);
+                    SubmitAction::Handled
+                }
+            },
             "/status" => {
                 self.queue_message(
                     MessageKind::System,
                     format!(
-                        "session: {}\nbusy: {}\nagent_mode: {}\nmax_loop_count: {}\nskills: {}\nmodel_override: {}\ninput: {} chars",
+                        "session: {}\nbusy: {}\nagent_id: {}\nagent_mode: {}\nmax_loop_count: {}\nskills: {}\nmodel_override: {}\ninput: {} chars",
                         self.session_id,
                         self.busy,
+                        self.selected_agent_id
+                            .clone()
+                            .unwrap_or_else(|| "(default)".to_string()),
                         self.agent_mode,
                         self.max_loop_count,
                         if self.selected_skills.is_empty() {

--- a/app/terminal/src/app/input.rs
+++ b/app/terminal/src/app/input.rs
@@ -21,6 +21,7 @@ impl App {
         self.request_started_at = Some(std::time::Instant::now());
         self.first_output_latency = None;
         self.last_request_duration = None;
+        self.active_phase = None;
         self.active_tools.clear();
         self.status = format!("running  {}", self.session_id);
         SubmitAction::RunTask(text)

--- a/app/terminal/src/app/mod.rs
+++ b/app/terminal/src/app/mod.rs
@@ -3,12 +3,16 @@ use std::time::{Duration, Instant};
 
 use ratatui::text::Line;
 
+use crate::backend::BackendStats;
+
 mod commands;
 mod input;
 mod runtime;
 mod surfaces;
 #[cfg(test)]
 mod tests;
+
+pub(crate) use commands::agent::normalize_agent_mode;
 
 #[derive(Debug)]
 pub enum SubmitAction {
@@ -22,6 +26,7 @@ pub enum SubmitAction {
     ResumeLatest,
     ResumeSession(String),
     ShowSession(String),
+    ListAgents,
     ListSkills,
     EnableSkill(String),
     DisableSkill(String),
@@ -99,6 +104,20 @@ struct ProviderCandidate {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AgentPopupMode {
+    Set,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct AgentCandidate {
+    id: String,
+    name: String,
+    agent_mode: String,
+    is_default: bool,
+    updated_at: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ProviderPopupMode {
     Inspect,
     Default,
@@ -132,6 +151,7 @@ pub struct App {
     pub session_seq: u32,
     pub session_id: String,
     pub user_id: String,
+    pub selected_agent_id: Option<String>,
     pub agent_mode: String,
     pub max_loop_count: u32,
     pub workspace_label: String,
@@ -148,7 +168,10 @@ pub struct App {
     first_output_latency: Option<Duration>,
     last_request_duration: Option<Duration>,
     last_first_output_latency: Option<Duration>,
-    active_tools: BTreeMap<String, Instant>,
+    pending_backend_stats: Option<BackendStats>,
+    active_phase: Option<String>,
+    active_tools: BTreeMap<String, ActiveToolRecord>,
+    tool_step_seq: u32,
     pending_welcome_banner: bool,
     clear_requested: bool,
     backend_restart_requested: bool,
@@ -157,8 +180,15 @@ pub struct App {
     help_overlay_topic: Option<String>,
     session_picker: Option<SessionPickerState>,
     transcript_overlay: Option<TranscriptOverlayState>,
+    agent_catalog: Option<Vec<AgentCandidate>>,
     provider_catalog: Option<Vec<ProviderCandidate>>,
     skill_catalog: Option<Vec<SkillCandidate>>,
+}
+
+#[derive(Clone, Debug)]
+struct ActiveToolRecord {
+    step: u32,
+    started_at: Instant,
 }
 
 impl App {
@@ -169,6 +199,7 @@ impl App {
             session_seq: 1,
             session_id: String::new(),
             user_id: "default_user".to_string(),
+            selected_agent_id: None,
             agent_mode: "simple".to_string(),
             max_loop_count: 50,
             workspace_label: current_workspace_label(),
@@ -185,7 +216,10 @@ impl App {
             first_output_latency: None,
             last_request_duration: None,
             last_first_output_latency: None,
+            pending_backend_stats: None,
+            active_phase: None,
             active_tools: BTreeMap::new(),
+            tool_step_seq: 0,
             pending_welcome_banner: false,
             clear_requested: false,
             backend_restart_requested: false,
@@ -194,6 +228,7 @@ impl App {
             help_overlay_topic: None,
             session_picker: None,
             transcript_overlay: None,
+            agent_catalog: None,
             provider_catalog: None,
             skill_catalog: None,
         };
@@ -214,7 +249,10 @@ impl App {
         self.first_output_latency = None;
         self.last_request_duration = None;
         self.last_first_output_latency = None;
+        self.pending_backend_stats = None;
+        self.active_phase = None;
         self.active_tools.clear();
+        self.tool_step_seq = 0;
         self.pending_history_lines.clear();
         self.committed_history_lines.clear();
         self.pending_welcome_banner = false;
@@ -225,6 +263,7 @@ impl App {
         self.help_overlay_topic = None;
         self.session_picker = None;
         self.transcript_overlay = None;
+        self.agent_catalog = None;
         self.provider_catalog = None;
         self.skill_catalog = None;
         self.status = format!("ready  {}", self.session_id);

--- a/app/terminal/src/app/runtime.rs
+++ b/app/terminal/src/app/runtime.rs
@@ -2,7 +2,8 @@ use std::time::{Duration, Instant};
 
 use ratatui::text::Line;
 
-use crate::app::{App, MessageKind};
+use crate::app::{ActiveToolRecord, App, MessageKind};
+use crate::backend::{BackendStats, BackendToolStep};
 use crate::app_render::{format_message, format_message_continuation, welcome_lines};
 
 impl App {
@@ -23,25 +24,82 @@ impl App {
         self.status = status.into();
     }
 
+    pub fn set_active_phase(&mut self, phase: impl Into<String>) {
+        let phase = phase.into();
+        let normalized = normalize_phase_label(&phase);
+        if normalized.is_empty() {
+            return;
+        }
+        self.active_phase = Some(normalized.clone());
+    }
+
     pub fn complete_request(&mut self) {
         self.busy = false;
-        self.last_request_duration = self.request_started_at.map(|started| started.elapsed());
-        self.last_first_output_latency = self.first_output_latency;
+        let backend_stats = self.pending_backend_stats.take();
+        self.last_request_duration = backend_stats
+            .as_ref()
+            .and_then(|stats| duration_from_seconds(stats.elapsed_seconds))
+            .or_else(|| self.request_started_at.map(|started| started.elapsed()));
+        self.last_first_output_latency = backend_stats
+            .as_ref()
+            .and_then(|stats| duration_from_seconds(stats.first_output_seconds))
+            .or(self.first_output_latency);
+        let completion_summary = request_timing_summary(
+            self.last_request_duration,
+            self.last_first_output_latency,
+            backend_stats.as_ref(),
+        );
         self.request_started_at = None;
         self.first_output_latency = None;
+        self.active_phase = None;
         self.active_tools.clear();
         self.flush_live_message();
+        if let Some(stats) = backend_stats.as_ref() {
+            if let Some(tool_summary) = backend_tool_step_summary(&stats.tool_steps) {
+                self.queue_message(MessageKind::Tool, tool_summary);
+            }
+            if let Some(phase_summary) = backend_phase_timing_summary(&stats.phase_timings) {
+                self.queue_message(MessageKind::Process, phase_summary);
+            }
+        }
+        if let Some(summary) = completion_summary {
+            self.queue_message(MessageKind::Process, format!("completed  {summary}"));
+        }
         self.status = format!("ready  {}", self.session_id);
     }
 
     pub fn fail_request(&mut self, message: impl Into<String>) {
         self.busy = false;
-        self.last_request_duration = self.request_started_at.map(|started| started.elapsed());
-        self.last_first_output_latency = self.first_output_latency;
+        let backend_stats = self.pending_backend_stats.take();
+        self.last_request_duration = backend_stats
+            .as_ref()
+            .and_then(|stats| duration_from_seconds(stats.elapsed_seconds))
+            .or_else(|| self.request_started_at.map(|started| started.elapsed()));
+        self.last_first_output_latency = backend_stats
+            .as_ref()
+            .and_then(|stats| duration_from_seconds(stats.first_output_seconds))
+            .or(self.first_output_latency);
+        let completion_summary = request_timing_summary(
+            self.last_request_duration,
+            self.last_first_output_latency,
+            backend_stats.as_ref(),
+        );
         self.request_started_at = None;
         self.first_output_latency = None;
+        self.active_phase = None;
         self.active_tools.clear();
         self.flush_live_message();
+        if let Some(stats) = backend_stats.as_ref() {
+            if let Some(tool_summary) = backend_tool_step_summary(&stats.tool_steps) {
+                self.queue_message(MessageKind::Tool, tool_summary);
+            }
+            if let Some(phase_summary) = backend_phase_timing_summary(&stats.phase_timings) {
+                self.queue_message(MessageKind::Process, phase_summary);
+            }
+        }
+        if let Some(summary) = completion_summary {
+            self.queue_message(MessageKind::Process, format!("failed  {summary}"));
+        }
         self.queue_message(MessageKind::System, message.into());
         self.status = format!("error  {}", self.session_id);
     }
@@ -68,6 +126,7 @@ impl App {
         welcome_lines(
             width,
             &self.session_id,
+            self.selected_agent_id.as_deref(),
             &self.agent_mode,
             self.max_loop_count,
             &self.workspace_label,
@@ -120,30 +179,58 @@ impl App {
     }
 
     pub fn active_tool_status(&self) -> Option<String> {
-        let (name, started) = self.active_tools.iter().next()?;
-        let elapsed = format_duration(started.elapsed());
+        let (name, record) = self.active_tools.iter().next()?;
+        let elapsed = format_duration(record.started_at.elapsed());
         if self.active_tools.len() == 1 {
-            Some(format!("{name}  {elapsed}"))
+            Some(format!("#{} {name}  {elapsed}", record.step))
         } else {
             Some(format!(
-                "{name} +{}  {elapsed}",
+                "#{} {name} +{}  {elapsed}",
+                record.step,
                 self.active_tools.len().saturating_sub(1)
             ))
         }
     }
 
+    pub fn active_phase_label(&self) -> Option<&str> {
+        self.active_phase.as_deref()
+    }
+
     pub fn start_tool(&mut self, name: String) {
-        self.active_tools.insert(name.clone(), Instant::now());
-        self.queue_message(MessageKind::Tool, format!("running {}", name));
+        self.tool_step_seq = self.tool_step_seq.saturating_add(1);
+        let step = self.tool_step_seq;
+        let started_at = Instant::now();
+        self.active_tools.insert(
+            name.clone(),
+            ActiveToolRecord {
+                step,
+                started_at,
+            },
+        );
+        let since_request = self
+            .request_started_at
+            .map(|started| format!(" • +{}", format_duration(started.elapsed())))
+            .unwrap_or_default();
+        self.queue_message(
+            MessageKind::Tool,
+            format!("step {step}  running {name}{since_request}"),
+        );
     }
 
     pub fn finish_tool(&mut self, name: String) {
-        let elapsed = self
+        let detail = self
             .active_tools
             .remove(&name)
-            .map(|started| format!(" ({})", format_duration(started.elapsed())))
-            .unwrap_or_default();
-        self.queue_message(MessageKind::Tool, format!("completed {name}{elapsed}"));
+            .map(|record| {
+                format!(
+                    "step {}  completed {} • {}",
+                    record.step,
+                    name,
+                    format_duration(record.started_at.elapsed())
+                )
+            })
+            .unwrap_or_else(|| format!("completed {name}"));
+        self.queue_message(MessageKind::Tool, detail);
     }
 
     pub(crate) fn materialize_pending_ui(&mut self, width: u16) {
@@ -154,6 +241,7 @@ impl App {
         let mut lines = welcome_lines(
             width,
             &self.session_id,
+            self.selected_agent_id.as_deref(),
             &self.agent_mode,
             self.max_loop_count,
             &self.workspace_label,
@@ -232,6 +320,10 @@ impl App {
             self.first_output_latency = Some(started.elapsed());
         }
     }
+
+    pub fn apply_backend_stats(&mut self, stats: crate::backend::BackendStats) {
+        self.pending_backend_stats = Some(stats);
+    }
 }
 
 fn format_duration(duration: Duration) -> String {
@@ -246,6 +338,34 @@ fn format_duration(duration: Duration) -> String {
     } else {
         format!("{}ms", duration.as_millis())
     }
+}
+
+fn request_timing_summary(
+    total: Option<Duration>,
+    ttft: Option<Duration>,
+    backend_stats: Option<&BackendStats>,
+) -> Option<String> {
+    let mut parts = Vec::new();
+    if let Some(total) = total {
+        parts.push(format!("total {}", format_duration(total)));
+    }
+    if let Some(ttft) = ttft {
+        parts.push(format!("ttft {}", format_duration(ttft)));
+    }
+    if let Some(total_tokens) = backend_stats.and_then(|stats| stats.total_tokens) {
+        parts.push(format!("tokens {total_tokens}"));
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(" • "))
+    }
+}
+
+fn duration_from_seconds(value: Option<f64>) -> Option<Duration> {
+    value
+        .filter(|seconds| seconds.is_finite() && *seconds >= 0.0)
+        .map(Duration::from_secs_f64)
 }
 
 fn flush_completed_live_lines(
@@ -272,4 +392,66 @@ fn flush_completed_live_lines(
 
     *text = remainder;
     !completed.trim().is_empty()
+}
+
+fn backend_tool_step_summary(tool_steps: &[BackendToolStep]) -> Option<String> {
+    if tool_steps.is_empty() {
+        return None;
+    }
+
+    let mut lines = Vec::with_capacity(tool_steps.len() + 1);
+    lines.push("tool steps".to_string());
+    for step in tool_steps {
+        let mut detail = format!(
+            "step {}  {} {}",
+            step.step,
+            normalize_tool_status(&step.status),
+            step.tool_name
+        );
+        if let Some(duration_ms) = duration_from_millis(step.duration_ms) {
+            detail.push_str(&format!(" • {}", format_duration(duration_ms)));
+        }
+        lines.push(detail);
+    }
+    Some(lines.join("\n"))
+}
+
+fn backend_phase_timing_summary(phase_timings: &[crate::backend::BackendPhaseTiming]) -> Option<String> {
+    if phase_timings.is_empty() {
+        return None;
+    }
+
+    let mut lines = Vec::with_capacity(phase_timings.len() + 1);
+    lines.push("phase timings".to_string());
+    for phase in phase_timings {
+        let mut detail = phase.phase.replace('_', " ");
+        if let Some(duration_ms) = duration_from_millis(phase.duration_ms) {
+            detail.push_str(&format!(" • {}", format_duration(duration_ms)));
+        }
+        if phase.segment_count > 1 {
+            detail.push_str(&format!(" • {} segments", phase.segment_count));
+        }
+        lines.push(detail);
+    }
+    Some(lines.join("\n"))
+}
+
+fn normalize_tool_status(status: &str) -> &str {
+    match status {
+        "completed" => "completed",
+        "running" => "running",
+        "failed" => "failed",
+        other if other.trim().is_empty() => "completed",
+        other => other,
+    }
+}
+
+fn normalize_phase_label(phase: &str) -> String {
+    phase.trim().replace('_', " ")
+}
+
+fn duration_from_millis(value: Option<f64>) -> Option<Duration> {
+    value
+        .filter(|millis| millis.is_finite() && *millis >= 0.0)
+        .map(|millis| Duration::from_secs_f64(millis / 1000.0))
 }

--- a/app/terminal/src/app/surfaces/popup.rs
+++ b/app/terminal/src/app/surfaces/popup.rs
@@ -1,3 +1,5 @@
+#[path = "popup/agent.rs"]
+mod agent;
 #[path = "popup/core.rs"]
 mod core;
 #[path = "popup/provider.rs"]

--- a/app/terminal/src/app/surfaces/popup/agent.rs
+++ b/app/terminal/src/app/surfaces/popup/agent.rs
@@ -1,0 +1,104 @@
+use crate::app::{AgentCandidate, AgentPopupMode, App};
+use crate::bottom_pane::command_popup;
+
+impl App {
+    pub fn set_agent_catalog(
+        &mut self,
+        agents: Vec<(String, String, String, bool, String)>,
+    ) {
+        self.agent_catalog = Some(
+            agents
+                .into_iter()
+                .map(|(id, name, agent_mode, is_default, updated_at)| AgentCandidate {
+                    id,
+                    name,
+                    agent_mode,
+                    is_default,
+                    updated_at,
+                })
+                .collect(),
+        );
+        self.sync_slash_popup_selection();
+    }
+
+    pub fn clear_agent_catalog(&mut self) {
+        self.agent_catalog = None;
+    }
+
+    pub(super) fn agent_popup_context(&self) -> Option<(AgentPopupMode, &str)> {
+        let line = self.input.lines().next().unwrap_or("");
+        if let Some(query) = line.strip_prefix("/agent set ") {
+            if query.split_whitespace().count() <= 1 {
+                return Some((AgentPopupMode::Set, query.trim()));
+            }
+        }
+        None
+    }
+
+    pub(super) fn agent_popup_matches(
+        &self,
+        mode: AgentPopupMode,
+        query: &str,
+    ) -> Vec<command_popup::CommandMatch> {
+        let Some(catalog) = self.agent_catalog.as_ref() else {
+            return Vec::new();
+        };
+
+        let query = query.to_lowercase();
+        let mut exact = Vec::new();
+        let mut prefix = Vec::new();
+        let mut contains = Vec::new();
+
+        for agent in catalog {
+            let id = agent.id.to_lowercase();
+            let name = agent.name.to_lowercase();
+            let matches = if query.is_empty() {
+                1
+            } else if id == query || name == query {
+                3
+            } else if id.starts_with(&query) || name.starts_with(&query) {
+                2
+            } else if id.contains(&query)
+                || name.contains(&query)
+                || agent.agent_mode.to_lowercase().contains(&query)
+            {
+                1
+            } else {
+                0
+            };
+            if matches == 0 {
+                continue;
+            }
+
+            let item = command_popup::CommandMatch {
+                command: agent.id.clone(),
+                description: format!(
+                    "{}  •  {}{}",
+                    agent.name,
+                    agent.agent_mode,
+                    if agent.is_default { "  •  default" } else { "" }
+                ),
+                preview_lines: vec![
+                    format!("name: {}", agent.name),
+                    format!("mode: {}", agent.agent_mode),
+                    format!("updated: {}", agent.updated_at),
+                ],
+                autocomplete: match mode {
+                    AgentPopupMode::Set => format!("/agent set {}", agent.id),
+                },
+                action: command_popup::PopupAction::HandleCommand(match mode {
+                    AgentPopupMode::Set => format!("/agent set {}", agent.id),
+                }),
+            };
+            match matches {
+                3 => exact.push(item),
+                2 => prefix.push(item),
+                _ => contains.push(item),
+            }
+        }
+
+        exact.extend(prefix);
+        exact.extend(contains);
+        exact
+    }
+}

--- a/app/terminal/src/app/surfaces/popup/core.rs
+++ b/app/terminal/src/app/surfaces/popup/core.rs
@@ -4,6 +4,9 @@ use crate::slash_command;
 
 impl App {
     pub fn popup_matches(&self) -> Vec<command_popup::CommandMatch> {
+        if let Some((mode, query)) = self.agent_popup_context() {
+            return self.agent_popup_matches(mode, query);
+        }
         if let Some((mode, query)) = self.provider_popup_context() {
             return self.provider_popup_matches(mode, query);
         }
@@ -23,6 +26,10 @@ impl App {
 
     pub fn needs_provider_catalog(&self) -> bool {
         self.provider_popup_context().is_some() && self.provider_catalog.is_none()
+    }
+
+    pub fn needs_agent_catalog(&self) -> bool {
+        self.agent_popup_context().is_some() && self.agent_catalog.is_none()
     }
 
     pub fn needs_skill_catalog(&self) -> bool {

--- a/app/terminal/src/app/tests.rs
+++ b/app/terminal/src/app/tests.rs
@@ -1,3 +1,5 @@
+#[path = "tests/agent.rs"]
+mod agent;
 #[path = "tests/popup.rs"]
 mod popup;
 #[path = "tests/sessions.rs"]

--- a/app/terminal/src/app/tests/agent.rs
+++ b/app/terminal/src/app/tests/agent.rs
@@ -1,0 +1,39 @@
+use crate::app::{App, SubmitAction};
+
+#[test]
+fn agent_command_sets_selected_agent_and_requests_restart() {
+    let mut app = App::new();
+
+    assert!(matches!(app.handle_command("/agent set agent_demo"), SubmitAction::Handled));
+    assert_eq!(app.selected_agent_id.as_deref(), Some("agent_demo"));
+    assert!(app.take_backend_restart_request());
+}
+
+#[test]
+fn agent_list_command_returns_list_action() {
+    let mut app = App::new();
+
+    assert!(matches!(
+        app.handle_command("/agent list"),
+        SubmitAction::ListAgents
+    ));
+}
+
+#[test]
+fn mode_command_updates_agent_mode_and_requests_restart() {
+    let mut app = App::new();
+
+    assert!(matches!(app.handle_command("/mode set fibre"), SubmitAction::Handled));
+    assert_eq!(app.agent_mode, "fibre");
+    assert!(app.take_backend_restart_request());
+}
+
+#[test]
+fn startup_agent_options_apply_without_emitting_messages() {
+    let mut app = App::new();
+
+    app.apply_startup_agent_options(Some("agent_demo".to_string()), Some("multi".to_string()));
+
+    assert_eq!(app.selected_agent_id.as_deref(), Some("agent_demo"));
+    assert_eq!(app.agent_mode, "multi");
+}

--- a/app/terminal/src/app/tests/popup.rs
+++ b/app/terminal/src/app/tests/popup.rs
@@ -126,6 +126,38 @@ fn provider_popup_matches_catalog_entries() {
 }
 
 #[test]
+fn agent_popup_matches_catalog_entries() {
+    let mut app = App::new();
+    app.set_agent_catalog(vec![
+        (
+            "agent-123".to_string(),
+            "Research Agent".to_string(),
+            "fibre".to_string(),
+            true,
+            "2026-04-28T10:00:00".to_string(),
+        ),
+        (
+            "agent-456".to_string(),
+            "Ops Agent".to_string(),
+            "simple".to_string(),
+            false,
+            "2026-04-27T09:00:00".to_string(),
+        ),
+    ]);
+    app.input = "/agent set agent".to_string();
+    app.input_cursor = app.input.len();
+
+    let matches = app.popup_matches();
+    assert_eq!(matches[0].command, "agent-123");
+    assert!(matches[0].description.contains("fibre"));
+    assert!(matches[0].description.contains("default"));
+    assert!(matches[0]
+        .preview_lines
+        .iter()
+        .any(|line| line.contains("updated: 2026-04-28T10:00:00")));
+}
+
+#[test]
 fn skill_add_popup_matches_catalog_entries() {
     let mut app = App::new();
     app.set_skill_catalog(vec![
@@ -217,4 +249,22 @@ fn submit_selected_skill_popup_returns_skill_action() {
         action,
         Some(super::super::SubmitAction::EnableSkill(skill)) if skill == "github"
     ));
+}
+
+#[test]
+fn submit_selected_agent_popup_executes_agent_command() {
+    let mut app = App::new();
+    app.set_agent_catalog(vec![(
+        "agent-123".to_string(),
+        "Research Agent".to_string(),
+        "multi".to_string(),
+        false,
+        "2026-04-28T10:00:00".to_string(),
+    )]);
+    app.input = "/agent set ag".to_string();
+    app.input_cursor = app.input.len();
+
+    let action = app.submit_selected_popup();
+    assert!(matches!(action, Some(super::super::SubmitAction::Handled)));
+    assert_eq!(app.selected_agent_id.as_deref(), Some("agent-123"));
 }

--- a/app/terminal/src/app/tests/transcript.rs
+++ b/app/terminal/src/app/tests/transcript.rs
@@ -1,6 +1,8 @@
 use crate::app_render::render_assistant_body;
+use std::time::{Duration, Instant};
 
 use super::super::{App, MessageKind};
+use crate::backend::{BackendPhaseTiming, BackendStats, BackendToolStep};
 
 #[test]
 fn transcript_messages_render_with_role_headers() {
@@ -106,4 +108,157 @@ fn transcript_overlay_scrolls_for_long_history() {
     assert!(app.scroll_transcript_overlay_down(5));
     let props = app.transcript_overlay_props(90).expect("transcript props");
     assert!(props.scroll > 0);
+}
+
+#[test]
+fn tool_messages_include_step_number_and_duration() {
+    let mut app = App::new();
+    app.request_started_at = Some(Instant::now() - Duration::from_secs(2));
+    app.start_tool("read_file".to_string());
+    std::thread::sleep(Duration::from_millis(5));
+    app.finish_tool("read_file".to_string());
+
+    let rendered = app
+        .pending_history_lines
+        .iter()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("step 1  running read_file"));
+    assert!(rendered.contains("step 1  completed read_file"));
+}
+
+#[test]
+fn completed_request_queues_timing_summary_into_transcript() {
+    let mut app = App::new();
+    app.busy = true;
+    app.request_started_at = Some(Instant::now() - Duration::from_millis(1500));
+    app.first_output_latency = Some(Duration::from_millis(320));
+    app.append_assistant_chunk("done");
+    app.complete_request();
+
+    let rendered = app
+        .pending_history_lines
+        .iter()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("completed"));
+    assert!(rendered.contains("total 1.5s"));
+    assert!(rendered.contains("ttft 320ms"));
+}
+
+#[test]
+fn completed_request_prefers_backend_stats_for_summary() {
+    let mut app = App::new();
+    app.busy = true;
+    app.request_started_at = Some(Instant::now() - Duration::from_secs(9));
+    app.first_output_latency = Some(Duration::from_secs(2));
+    app.apply_backend_stats(BackendStats {
+        elapsed_seconds: Some(1.25),
+        first_output_seconds: Some(0.18),
+        prompt_tokens: Some(10),
+        completion_tokens: Some(20),
+        total_tokens: Some(30),
+        tool_steps: Vec::new(),
+        phase_timings: Vec::new(),
+    });
+    app.complete_request();
+
+    let rendered = app
+        .pending_history_lines
+        .iter()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("total 1.2s"));
+    assert!(rendered.contains("ttft 180ms"));
+    assert!(rendered.contains("tokens 30"));
+    assert!(!rendered.contains("total 9.0s"));
+}
+
+#[test]
+fn completed_request_renders_backend_tool_step_summary() {
+    let mut app = App::new();
+    app.busy = true;
+    app.apply_backend_stats(BackendStats {
+        elapsed_seconds: Some(1.25),
+        first_output_seconds: Some(0.18),
+        prompt_tokens: Some(10),
+        completion_tokens: Some(20),
+        total_tokens: Some(30),
+        tool_steps: vec![
+            BackendToolStep {
+                step: 1,
+                tool_name: "read_file".to_string(),
+                tool_call_id: Some("call_1".to_string()),
+                status: "completed".to_string(),
+                started_at: Some(10.0),
+                finished_at: Some(10.12),
+                duration_ms: Some(120.0),
+            },
+            BackendToolStep {
+                step: 2,
+                tool_name: "grep".to_string(),
+                tool_call_id: Some("call_2".to_string()),
+                status: "completed".to_string(),
+                started_at: Some(10.2),
+                finished_at: Some(10.284),
+                duration_ms: Some(84.0),
+            },
+        ],
+        phase_timings: vec![
+            BackendPhaseTiming {
+                phase: "planning".to_string(),
+                started_at: Some(9.8),
+                finished_at: Some(10.3),
+                duration_ms: Some(500.0),
+                segment_count: 1,
+            },
+            BackendPhaseTiming {
+                phase: "assistant_text".to_string(),
+                started_at: Some(11.1),
+                finished_at: Some(11.5),
+                duration_ms: Some(400.0),
+                segment_count: 2,
+            },
+        ],
+    });
+    app.complete_request();
+
+    let rendered = app
+        .pending_history_lines
+        .iter()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("tool steps"));
+    assert!(rendered.contains("step 1  completed read_file"));
+    assert!(rendered.contains("step 2  completed grep"));
+    assert!(rendered.contains("120ms"));
+    assert!(rendered.contains("84ms"));
+    assert!(rendered.contains("phase timings"));
+    assert!(rendered.contains("planning"));
+    assert!(rendered.contains("assistant text"));
+    assert!(rendered.contains("2 segments"));
 }

--- a/app/terminal/src/app_render/welcome.rs
+++ b/app/terminal/src/app_render/welcome.rs
@@ -11,6 +11,7 @@ const SESSION_HEADER_MAX_INNER_WIDTH: usize = 56;
 pub(crate) fn welcome_lines(
     width: u16,
     session_id: &str,
+    agent_id: Option<&str>,
     agent_mode: &str,
     max_loop_count: u32,
     workspace_label: &str,
@@ -40,6 +41,12 @@ pub(crate) fn welcome_lines(
             Span::styled(
                 agent_mode.to_string(),
                 Style::default().fg(Color::Rgb(236, 240, 231)),
+            ),
+            Span::raw("   "),
+            Span::styled("agent: ", dim),
+            Span::styled(
+                truncate_middle(agent_id.unwrap_or("(default)"), 18),
+                accent_style(),
             ),
             Span::raw("   "),
             Span::styled("session: ", dim),

--- a/app/terminal/src/backend/api/agents.rs
+++ b/app/terminal/src/backend/api/agents.rs
@@ -1,0 +1,21 @@
+use anyhow::Result;
+
+use crate::backend::contract::{expect_array_field, optional_bool_field, optional_str_field, run_cli_command, CliJsonCommand};
+use crate::backend::AgentInfo;
+
+pub(crate) fn list_agents(user_id: &str) -> Result<Vec<AgentInfo>> {
+    let value = run_cli_command(CliJsonCommand::AgentsList { user_id })?;
+    let items = expect_array_field(&value, "list", "agents.list")?;
+    Ok(items.iter().map(parse_agent).collect())
+}
+
+fn parse_agent(value: &serde_json::Value) -> AgentInfo {
+    AgentInfo {
+        agent_id: optional_str_field(value, "agent_id").unwrap_or_default(),
+        name: optional_str_field(value, "name").unwrap_or_default(),
+        agent_mode: optional_str_field(value, "agent_mode")
+            .unwrap_or_else(|| "simple".to_string()),
+        is_default: optional_bool_field(value, "is_default"),
+        updated_at: optional_str_field(value, "updated_at").unwrap_or_default(),
+    }
+}

--- a/app/terminal/src/backend/api/mod.rs
+++ b/app/terminal/src/backend/api/mod.rs
@@ -1,9 +1,11 @@
+mod agents;
 mod config;
 mod doctor;
 mod providers;
 mod sessions;
 mod skills;
 
+pub(crate) use agents::list_agents;
 pub(crate) use config::{init_config, read_config};
 pub(crate) use doctor::read_doctor_info;
 pub(crate) use providers::{

--- a/app/terminal/src/backend/api/sessions.rs
+++ b/app/terminal/src/backend/api/sessions.rs
@@ -7,24 +7,44 @@ use crate::backend::contract::{
 };
 use crate::backend::{SessionDetail, SessionMessage, SessionSummary};
 
-pub(crate) fn list_sessions(user_id: &str, limit: usize) -> Result<Vec<SessionSummary>> {
-    let value = run_cli_command(CliJsonCommand::SessionsList { user_id, limit })?;
+pub(crate) fn list_sessions(
+    user_id: &str,
+    agent_id: Option<&str>,
+    limit: usize,
+) -> Result<Vec<SessionSummary>> {
+    let value = run_cli_command(CliJsonCommand::SessionsList {
+        user_id,
+        agent_id,
+        limit,
+    })?;
     let items = expect_array_field(&value, "list", "sessions.list")?;
     Ok(items.iter().map(parse_session_summary).collect::<Vec<_>>())
 }
 
-pub(crate) fn inspect_latest_session(user_id: &str) -> Result<Option<SessionDetail>> {
-    inspect_session_impl("latest", user_id)
+pub(crate) fn inspect_latest_session(
+    user_id: &str,
+    agent_id: Option<&str>,
+) -> Result<Option<SessionDetail>> {
+    inspect_session_impl("latest", user_id, agent_id)
 }
 
-pub(crate) fn inspect_session(session_id: &str, user_id: &str) -> Result<Option<SessionDetail>> {
-    inspect_session_impl(session_id, user_id)
+pub(crate) fn inspect_session(
+    session_id: &str,
+    user_id: &str,
+    agent_id: Option<&str>,
+) -> Result<Option<SessionDetail>> {
+    inspect_session_impl(session_id, user_id, agent_id)
 }
 
-fn inspect_session_impl(session_id: &str, user_id: &str) -> Result<Option<SessionDetail>> {
+fn inspect_session_impl(
+    session_id: &str,
+    user_id: &str,
+    agent_id: Option<&str>,
+) -> Result<Option<SessionDetail>> {
     let value = run_cli_command(CliJsonCommand::SessionInspect {
         session_id,
         user_id,
+        agent_id,
     })?;
 
     if value.is_null() {

--- a/app/terminal/src/backend/api/skills.rs
+++ b/app/terminal/src/backend/api/skills.rs
@@ -7,8 +7,16 @@ use crate::backend::contract::{
 };
 use crate::backend::SkillInfo;
 
-pub(crate) fn list_skills(user_id: &str, workspace: Option<&Path>) -> Result<Vec<SkillInfo>> {
-    let value = run_cli_command(CliJsonCommand::SkillsList { user_id, workspace })?;
+pub(crate) fn list_skills(
+    user_id: &str,
+    agent_id: Option<&str>,
+    workspace: Option<&Path>,
+) -> Result<Vec<SkillInfo>> {
+    let value = run_cli_command(CliJsonCommand::SkillsList {
+        user_id,
+        agent_id,
+        workspace,
+    })?;
     let items = expect_array_field(&value, "list", "skills.list")?;
 
     Ok(items

--- a/app/terminal/src/backend/contract/agents.rs
+++ b/app/terminal/src/backend/contract/agents.rs
@@ -1,0 +1,8 @@
+pub(super) fn agents_list_args(user_id: &str) -> Vec<String> {
+    vec![
+        "agents".into(),
+        "--json".into(),
+        "--user-id".into(),
+        user_id.into(),
+    ]
+}

--- a/app/terminal/src/backend/contract/common.rs
+++ b/app/terminal/src/backend/contract/common.rs
@@ -47,6 +47,10 @@ pub(crate) fn optional_u64_field(value: &Value, key: &str) -> u64 {
     value.get(key).and_then(Value::as_u64).unwrap_or(0)
 }
 
+pub(crate) fn optional_f64_field(value: &Value, key: &str) -> Option<f64> {
+    value.get(key).and_then(Value::as_f64)
+}
+
 pub(crate) fn optional_bool_field(value: &Value, key: &str) -> bool {
     value.get(key).and_then(Value::as_bool).unwrap_or(false)
 }

--- a/app/terminal/src/backend/contract/mod.rs
+++ b/app/terminal/src/backend/contract/mod.rs
@@ -1,3 +1,4 @@
+mod agents;
 mod common;
 mod config;
 mod doctor;
@@ -13,8 +14,8 @@ use std::path::Path;
 use crate::backend::runtime::run_cli_json_owned;
 use crate::backend::ProviderMutation;
 pub(crate) use common::{
-    expect_array_field, expect_object_field, optional_bool_field, optional_str_field,
-    optional_u64_field, required_str_field,
+    expect_array_field, expect_object_field, optional_bool_field, optional_f64_field,
+    optional_str_field, optional_u64_field, required_str_field,
 };
 pub(crate) use stream::{parse_stream_event, CliStreamEvent};
 
@@ -29,14 +30,20 @@ pub(crate) enum CliJsonCommand<'a> {
     },
     SessionsList {
         user_id: &'a str,
+        agent_id: Option<&'a str>,
         limit: usize,
+    },
+    AgentsList {
+        user_id: &'a str,
     },
     SessionInspect {
         session_id: &'a str,
         user_id: &'a str,
+        agent_id: Option<&'a str>,
     },
     SkillsList {
         user_id: &'a str,
+        agent_id: Option<&'a str>,
         workspace: Option<&'a Path>,
     },
     ProvidersList {
@@ -75,6 +82,7 @@ impl CliJsonCommand<'_> {
             Self::ConfigInit { .. } => "config.init",
             Self::Doctor { .. } => "doctor",
             Self::SessionsList { .. } => "sessions.list",
+            Self::AgentsList { .. } => "agents.list",
             Self::SessionInspect { .. } => "sessions.inspect",
             Self::SkillsList { .. } => "skills.list",
             Self::ProvidersList { .. } => "provider.list",
@@ -92,13 +100,23 @@ impl CliJsonCommand<'_> {
             Self::ConfigShow => config::config_show_args(),
             Self::ConfigInit { path, force } => config::config_init_args(*path, *force),
             Self::Doctor { probe_provider } => doctor::doctor_args(*probe_provider),
-            Self::SessionsList { user_id, limit } => sessions::sessions_list_args(user_id, *limit),
+            Self::SessionsList {
+                user_id,
+                agent_id,
+                limit,
+            } => sessions::sessions_list_args(user_id, *agent_id, *limit),
+            Self::AgentsList { user_id } => agents::agents_list_args(user_id),
             Self::SessionInspect {
                 session_id,
                 user_id,
-            } => sessions::session_inspect_args(session_id, user_id),
-            Self::SkillsList { user_id, workspace } => {
-                skills::skills_list_args(user_id, *workspace)
+                agent_id,
+            } => sessions::session_inspect_args(session_id, user_id, *agent_id),
+            Self::SkillsList {
+                user_id,
+                agent_id,
+                workspace,
+            } => {
+                skills::skills_list_args(user_id, *agent_id, *workspace)
             }
             Self::ProvidersList { user_id } => providers::providers_list_args(user_id),
             Self::ProviderInspect {

--- a/app/terminal/src/backend/contract/sessions.rs
+++ b/app/terminal/src/backend/contract/sessions.rs
@@ -1,21 +1,35 @@
-pub(super) fn sessions_list_args(user_id: &str, limit: usize) -> Vec<String> {
-    vec![
+pub(super) fn sessions_list_args(user_id: &str, agent_id: Option<&str>, limit: usize) -> Vec<String> {
+    let mut args = vec![
         "sessions".into(),
         "--json".into(),
         "--user-id".into(),
         user_id.into(),
         "--limit".into(),
         limit.max(1).to_string(),
-    ]
+    ];
+    if let Some(agent_id) = agent_id {
+        args.push("--agent-id".into());
+        args.push(agent_id.into());
+    }
+    args
 }
 
-pub(super) fn session_inspect_args(session_id: &str, user_id: &str) -> Vec<String> {
-    vec![
+pub(super) fn session_inspect_args(
+    session_id: &str,
+    user_id: &str,
+    agent_id: Option<&str>,
+) -> Vec<String> {
+    let mut args = vec![
         "sessions".into(),
         "inspect".into(),
         session_id.into(),
         "--json".into(),
         "--user-id".into(),
         user_id.into(),
-    ]
+    ];
+    if let Some(agent_id) = agent_id {
+        args.push("--agent-id".into());
+        args.push(agent_id.into());
+    }
+    args
 }

--- a/app/terminal/src/backend/contract/skills.rs
+++ b/app/terminal/src/backend/contract/skills.rs
@@ -1,12 +1,20 @@
 use std::path::Path;
 
-pub(super) fn skills_list_args(user_id: &str, workspace: Option<&Path>) -> Vec<String> {
+pub(super) fn skills_list_args(
+    user_id: &str,
+    agent_id: Option<&str>,
+    workspace: Option<&Path>,
+) -> Vec<String> {
     let mut args = vec![
         "skills".into(),
         "--json".into(),
         "--user-id".into(),
         user_id.into(),
     ];
+    if let Some(agent_id) = agent_id {
+        args.push("--agent-id".into());
+        args.push(agent_id.into());
+    }
     if let Some(path) = workspace {
         args.push("--workspace".into());
         args.push(path.display().to_string());

--- a/app/terminal/src/backend/contract/stream.rs
+++ b/app/terminal/src/backend/contract/stream.rs
@@ -1,12 +1,23 @@
 use serde_json::Value;
 
+use super::optional_f64_field;
+
 pub(crate) struct CliStreamEvent {
     pub(crate) event_type: String,
     pub(crate) role: String,
     pub(crate) content: String,
+    pub(crate) phase: Option<String>,
+    pub(crate) action: Option<String>,
     pub(crate) tool_calls: Vec<CliToolCall>,
     pub(crate) metadata: Option<CliEventMetadata>,
     pub(crate) tool_name: Option<String>,
+    pub(crate) elapsed_seconds: Option<f64>,
+    pub(crate) first_output_seconds: Option<f64>,
+    pub(crate) prompt_tokens: Option<u64>,
+    pub(crate) completion_tokens: Option<u64>,
+    pub(crate) total_tokens: Option<u64>,
+    pub(crate) tool_steps: Vec<CliToolStep>,
+    pub(crate) phase_timings: Vec<CliPhaseTiming>,
 }
 
 pub(crate) struct CliToolCall {
@@ -21,6 +32,26 @@ pub(crate) struct CliToolFunction {
 #[derive(Debug)]
 pub(crate) struct CliEventMetadata {
     pub(crate) tool_name: Option<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct CliToolStep {
+    pub(crate) step: u64,
+    pub(crate) tool_name: String,
+    pub(crate) tool_call_id: Option<String>,
+    pub(crate) status: String,
+    pub(crate) started_at: Option<f64>,
+    pub(crate) finished_at: Option<f64>,
+    pub(crate) duration_ms: Option<f64>,
+}
+
+#[derive(Debug)]
+pub(crate) struct CliPhaseTiming {
+    pub(crate) phase: String,
+    pub(crate) started_at: Option<f64>,
+    pub(crate) finished_at: Option<f64>,
+    pub(crate) duration_ms: Option<f64>,
+    pub(crate) segment_count: u64,
 }
 
 pub(crate) fn parse_stream_event(line: &str) -> Option<CliStreamEvent> {
@@ -55,6 +86,55 @@ pub(crate) fn parse_stream_event(line: &str) -> Option<CliStreamEvent> {
                 .and_then(Value::as_str)
                 .map(ToString::to_string),
         });
+    let tool_steps = object
+        .get("tool_steps")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .map(|item| CliToolStep {
+                    step: item.get("step").and_then(Value::as_u64).unwrap_or(0),
+                    tool_name: item
+                        .get("tool_name")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                    tool_call_id: item
+                        .get("tool_call_id")
+                        .and_then(Value::as_str)
+                        .map(ToString::to_string),
+                    status: item
+                        .get("status")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                    started_at: item.get("started_at").and_then(Value::as_f64),
+                    finished_at: item.get("finished_at").and_then(Value::as_f64),
+                    duration_ms: item.get("duration_ms").and_then(Value::as_f64),
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let phase_timings = object
+        .get("phase_timings")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .map(|item| CliPhaseTiming {
+                    phase: item
+                        .get("phase")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                    started_at: item.get("started_at").and_then(Value::as_f64),
+                    finished_at: item.get("finished_at").and_then(Value::as_f64),
+                    duration_ms: item.get("duration_ms").and_then(Value::as_f64),
+                    segment_count: item.get("segment_count").and_then(Value::as_u64).unwrap_or(0),
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
 
     Some(CliStreamEvent {
         event_type: object
@@ -72,11 +152,26 @@ pub(crate) fn parse_stream_event(line: &str) -> Option<CliStreamEvent> {
             .and_then(Value::as_str)
             .unwrap_or_default()
             .to_string(),
+        phase: object
+            .get("phase")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        action: object
+            .get("action")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
         tool_calls,
         metadata,
         tool_name: object
             .get("tool_name")
             .and_then(Value::as_str)
             .map(ToString::to_string),
+        elapsed_seconds: optional_f64_field(&value, "elapsed_seconds"),
+        first_output_seconds: optional_f64_field(&value, "first_output_seconds"),
+        prompt_tokens: object.get("prompt_tokens").and_then(Value::as_u64),
+        completion_tokens: object.get("completion_tokens").and_then(Value::as_u64),
+        total_tokens: object.get("total_tokens").and_then(Value::as_u64),
+        tool_steps,
+        phase_timings,
     })
 }

--- a/app/terminal/src/backend/handle.rs
+++ b/app/terminal/src/backend/handle.rs
@@ -25,6 +25,7 @@ pub struct BackendHandle {
 struct BackendConfig {
     session_id: String,
     user_id: String,
+    agent_id: Option<String>,
     agent_mode: String,
     max_loop_count: u32,
     workspace: PathBuf,
@@ -67,8 +68,6 @@ impl BackendHandle {
             .arg(&request.session_id)
             .arg("--user-id")
             .arg(&request.user_id)
-            .arg("--agent-mode")
-            .arg(&request.agent_mode)
             .arg("--max-loop-count")
             .arg(request.max_loop_count.to_string())
             .arg("--workspace")
@@ -76,6 +75,10 @@ impl BackendHandle {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        if let Some(agent_id) = &request.agent_id {
+            command.arg("--agent-id").arg(agent_id);
+        }
+        command.arg("--agent-mode").arg(&request.agent_mode);
         for skill in &request.skills {
             command.arg("--skill").arg(skill);
         }
@@ -185,6 +188,7 @@ impl BackendHandle {
             config: BackendConfig {
                 session_id: request.session_id.clone(),
                 user_id: request.user_id.clone(),
+                agent_id: request.agent_id.clone(),
                 agent_mode: request.agent_mode.clone(),
                 max_loop_count: request.max_loop_count,
                 workspace,
@@ -227,6 +231,7 @@ impl BackendHandle {
     pub fn matches(&self, request: &BackendRequest) -> bool {
         self.config.session_id == request.session_id
             && self.config.user_id == request.user_id
+            && self.config.agent_id == request.agent_id
             && self.config.agent_mode == request.agent_mode
             && self.config.max_loop_count == request.max_loop_count
             && self.config.workspace

--- a/app/terminal/src/backend/mod.rs
+++ b/app/terminal/src/backend/mod.rs
@@ -9,11 +9,12 @@ mod types;
 
 pub(crate) use api::{
     create_provider, delete_provider, init_config, inspect_latest_session, inspect_provider,
-    inspect_session, list_providers, list_sessions, list_skills, read_config, read_doctor_info,
-    set_default_provider, update_provider, verify_provider,
+    inspect_session, list_agents, list_providers, list_sessions, list_skills, read_config,
+    read_doctor_info, set_default_provider, update_provider, verify_provider,
 };
 pub(crate) use handle::BackendHandle;
 pub use types::{
-    BackendEvent, BackendRequest, ConfigInfo, ConfigInitInfo, ProviderInfo, ProviderMutation,
-    ProviderVerifyInfo, SessionDetail, SessionMessage, SessionSummary, SkillInfo,
+    AgentInfo, BackendEvent, BackendPhaseTiming, BackendRequest, BackendStats, BackendToolStep,
+    ConfigInfo, ConfigInitInfo, ProviderInfo, ProviderMutation, ProviderVerifyInfo, SessionDetail,
+    SessionMessage, SessionSummary, SkillInfo,
 };

--- a/app/terminal/src/backend/protocol.rs
+++ b/app/terminal/src/backend/protocol.rs
@@ -2,6 +2,7 @@ use std::sync::mpsc;
 
 use crate::app::MessageKind;
 use crate::backend::contract::{parse_stream_event, CliStreamEvent};
+use crate::backend::{BackendPhaseTiming, BackendStats, BackendToolStep};
 
 use super::BackendEvent;
 
@@ -33,20 +34,56 @@ pub(crate) fn parse_backend_line(line: &str) -> Vec<BackendEvent> {
     let event_type = event.event_type.as_str();
     let role = event.role.as_str();
     let tool_names = collect_tool_names(&event);
-    let content = event.content;
+    let content = event.content.clone();
 
     if event_type == "cli_stats" {
+        events.push(BackendEvent::Stats(BackendStats {
+            elapsed_seconds: event.elapsed_seconds,
+            first_output_seconds: event.first_output_seconds,
+            prompt_tokens: event.prompt_tokens,
+            completion_tokens: event.completion_tokens,
+            total_tokens: event.total_tokens,
+            tool_steps: event
+                .tool_steps
+                .into_iter()
+                .map(|step| BackendToolStep {
+                    step: step.step,
+                    tool_name: step.tool_name,
+                    tool_call_id: step.tool_call_id,
+                    status: step.status,
+                    started_at: step.started_at,
+                    finished_at: step.finished_at,
+                    duration_ms: step.duration_ms,
+                })
+                .collect(),
+            phase_timings: event
+                .phase_timings
+                .into_iter()
+                .map(|phase| BackendPhaseTiming {
+                    phase: phase.phase,
+                    started_at: phase.started_at,
+                    finished_at: phase.finished_at,
+                    duration_ms: phase.duration_ms,
+                    segment_count: phase.segment_count,
+                })
+                .collect(),
+        }));
         events.push(BackendEvent::Finished);
+    } else if event_type == "cli_phase" {
+        if let Some(phase) = event.phase.filter(|value| !value.trim().is_empty()) {
+            events.push(BackendEvent::PhaseChanged(phase));
+        }
+    } else if event_type == "cli_tool" {
+        let tool_name = collect_tool_names(&event).into_iter().next();
+        if let Some(tool_name) = tool_name {
+            match event.action.as_deref() {
+                Some("started") => events.push(BackendEvent::ToolStarted(tool_name)),
+                Some("finished") => events.push(BackendEvent::ToolFinished(tool_name)),
+                _ => {}
+            }
+        }
     } else if let Some(kind) = live_message_kind(event_type, role, &content) {
         events.push(BackendEvent::LiveChunk(kind, content));
-    } else if matches!(event_type, "tool_call" | "tool_result") && !tool_names.is_empty() {
-        for name in &tool_names {
-            events.push(if event_type == "tool_call" {
-                BackendEvent::ToolStarted(name.clone())
-            } else {
-                BackendEvent::ToolFinished(name.clone())
-            });
-        }
     } else if !content.is_empty() {
         match event_type {
             "tool_call" => events.push(BackendEvent::Message(
@@ -58,7 +95,7 @@ pub(crate) fn parse_backend_line(line: &str) -> Vec<BackendEvent> {
                 format!("completed {}", summarize_tool_event(&tool_names, &content)),
             )),
             "error" | "cli_error" => events.push(BackendEvent::Error(content)),
-            "cli_stats" | "token_usage" | "start" | "done" => {}
+            "cli_stats" | "cli_phase" | "cli_tool" | "token_usage" | "start" | "done" => {}
             _ => events.push(BackendEvent::Message(
                 MessageKind::Process,
                 truncate(&clean_single_line(&content), 180),
@@ -68,10 +105,6 @@ pub(crate) fn parse_backend_line(line: &str) -> Vec<BackendEvent> {
 
     for name in tool_names {
         events.push(BackendEvent::Status(format!("tool  {}", name)));
-    }
-
-    if event_type == "stream_end" {
-        events.push(BackendEvent::Finished);
     }
 
     events
@@ -89,6 +122,8 @@ fn live_message_kind(event_type: &str, role: &str, content: &str) -> Option<Mess
             | "tool_call"
             | "tool_result"
             | "cli_stats"
+            | "cli_phase"
+            | "cli_tool"
             | "token_usage"
             | "start"
             | "done"

--- a/app/terminal/src/backend/tests/contract.rs
+++ b/app/terminal/src/backend/tests/contract.rs
@@ -41,6 +41,106 @@ fn parse_stream_event_collects_tool_fields_from_multiple_locations() {
 }
 
 #[test]
+fn parse_backend_line_turns_cli_stats_into_stats_then_finished() {
+    let events = parse_backend_line(
+        r#"{
+            "type":"cli_stats",
+            "elapsed_seconds":1.25,
+            "first_output_seconds":0.18,
+            "prompt_tokens":10,
+            "completion_tokens":20,
+            "total_tokens":30,
+            "tool_steps":[{"step":1,"tool_name":"read_file","tool_call_id":"call_1","status":"completed","duration_ms":120.0}],
+            "phase_timings":[{"phase":"tool","duration_ms":120.0,"segment_count":1}]
+        }"#,
+    );
+
+    assert!(matches!(
+        events.first(),
+        Some(BackendEvent::Stats(stats))
+            if stats.elapsed_seconds == Some(1.25)
+                && stats.first_output_seconds == Some(0.18)
+                && stats.total_tokens == Some(30)
+                && stats.tool_steps.len() == 1
+                && stats.tool_steps[0].tool_name == "read_file"
+                && stats.phase_timings.len() == 1
+                && stats.phase_timings[0].phase == "tool"
+    ));
+    assert!(matches!(events.get(1), Some(BackendEvent::Finished)));
+}
+
+#[test]
+fn parse_backend_line_turns_cli_phase_into_phase_event() {
+    let events = parse_backend_line(r#"{"type":"cli_phase","phase":"planning"}"#);
+
+    assert!(matches!(
+        events.first(),
+        Some(BackendEvent::PhaseChanged(phase)) if phase == "planning"
+    ));
+}
+
+#[test]
+fn parse_backend_line_turns_cli_tool_into_tool_events() {
+    let started = parse_backend_line(
+        r#"{"type":"cli_tool","action":"started","tool_name":"read_file","tool_call_id":"call_1","status":"running"}"#,
+    );
+    let finished = parse_backend_line(
+        r#"{"type":"cli_tool","action":"finished","tool_name":"read_file","tool_call_id":"call_1","status":"completed"}"#,
+    );
+
+    assert!(matches!(
+        started.first(),
+        Some(BackendEvent::ToolStarted(name)) if name == "read_file"
+    ));
+    assert!(matches!(
+        finished.first(),
+        Some(BackendEvent::ToolFinished(name)) if name == "read_file"
+    ));
+}
+
+#[test]
+fn parse_stream_contract_fixture_round_trip_sequence() {
+    let fixture = include_str!("../../../../../tests/app/cli/fixtures/stream_contract_round_trip.jsonl");
+    let mut saw_phase = false;
+    let mut saw_tool_started = false;
+    let mut saw_tool_finished = false;
+    let mut saw_assistant = false;
+    let mut saw_stats = false;
+    let mut saw_finished = false;
+
+    for line in fixture.lines().filter(|line| !line.trim().is_empty()) {
+        for event in parse_backend_line(line) {
+            match event {
+                BackendEvent::PhaseChanged(phase) if phase == "planning" => saw_phase = true,
+                BackendEvent::ToolStarted(name) if name == "read_file" => saw_tool_started = true,
+                BackendEvent::ToolFinished(name) if name == "read_file" => saw_tool_finished = true,
+                BackendEvent::LiveChunk(crate::app::MessageKind::Assistant, content)
+                    if content.contains("Here is the answer.") =>
+                {
+                    saw_assistant = true
+                }
+                BackendEvent::Stats(stats)
+                    if stats.total_tokens == Some(30)
+                        && stats.phase_timings.len() == 3
+                        && stats.tool_steps.len() == 1 =>
+                {
+                    saw_stats = true
+                }
+                BackendEvent::Finished => saw_finished = true,
+                _ => {}
+            }
+        }
+    }
+
+    assert!(saw_phase);
+    assert!(saw_tool_started);
+    assert!(saw_tool_finished);
+    assert!(saw_assistant);
+    assert!(saw_stats);
+    assert!(saw_finished);
+}
+
+#[test]
 fn contract_array_field_reports_shape_errors() {
     let payload = json!({"list": {"not": "an array"}});
     let err = expect_array_field(&payload, "list", "sessions.list").expect_err("should fail");
@@ -76,4 +176,14 @@ fn contract_builds_provider_verify_args_without_user_id() {
             "--unset-default",
         ]
     );
+}
+
+#[test]
+fn contract_builds_agents_list_args() {
+    let args = CliJsonCommand::AgentsList {
+        user_id: "terminal-user",
+    }
+    .args();
+
+    assert_eq!(args, vec!["agents", "--json", "--user-id", "terminal-user"]);
 }

--- a/app/terminal/src/backend/tests/handle.rs
+++ b/app/terminal/src/backend/tests/handle.rs
@@ -19,6 +19,7 @@ fn backend_handle_supports_two_round_trips_without_respawn() {
     let request = BackendRequest {
         session_id: "local-0001".to_string(),
         user_id: "terminal-test".to_string(),
+        agent_id: None,
         agent_mode: "simple".to_string(),
         max_loop_count: 3,
         workspace: Some(temp_dir.clone()),

--- a/app/terminal/src/backend/tests/mod.rs
+++ b/app/terminal/src/backend/tests/mod.rs
@@ -76,7 +76,9 @@ pub(super) fn collect_round_trip(handle: &BackendHandle) -> Vec<String> {
             Some(BackendEvent::LiveChunk(_, _))
             | Some(BackendEvent::Message(_, _))
             | Some(BackendEvent::Status(_))
+            | Some(BackendEvent::PhaseChanged(_))
             | Some(BackendEvent::ToolStarted(_))
+            | Some(BackendEvent::Stats(_))
             | Some(BackendEvent::ToolFinished(_)) => {}
             Some(BackendEvent::Finished) => return assistant_chunks,
             Some(BackendEvent::Error(message)) => {
@@ -121,11 +123,23 @@ for raw in sys.stdin:
         with open(log_path, "a", encoding="utf-8") as handle:
             handle.write(prompt + "\n")
     print(json.dumps({
+        "type": "cli_phase",
+        "phase": "planning",
+    }), flush=True)
+    print(json.dumps({
         "type": "assistant",
         "role": "assistant",
         "content": f"round {count}: {prompt}",
     }), flush=True)
     print(json.dumps({"type": "stream_end"}), flush=True)
+    print(json.dumps({
+        "type": "cli_stats",
+        "elapsed_seconds": 0.001,
+        "first_output_seconds": 0.001,
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    }), flush=True)
 "#,
     )
     .expect("script should be written");

--- a/app/terminal/src/backend/types.rs
+++ b/app/terminal/src/backend/types.rs
@@ -29,6 +29,14 @@ pub struct SkillInfo {
     pub source: String,
 }
 
+pub struct AgentInfo {
+    pub agent_id: String,
+    pub name: String,
+    pub agent_mode: String,
+    pub is_default: bool,
+    pub updated_at: String,
+}
+
 pub struct ConfigInfo {
     pub default_model_name: String,
     pub default_api_base_url: String,
@@ -71,6 +79,7 @@ pub struct ProviderMutation {
 pub struct BackendRequest {
     pub session_id: String,
     pub user_id: String,
+    pub agent_id: Option<String>,
     pub agent_mode: String,
     pub max_loop_count: u32,
     pub workspace: Option<PathBuf>,
@@ -79,12 +88,45 @@ pub struct BackendRequest {
     pub task: String,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct BackendStats {
+    pub elapsed_seconds: Option<f64>,
+    pub first_output_seconds: Option<f64>,
+    pub prompt_tokens: Option<u64>,
+    pub completion_tokens: Option<u64>,
+    pub total_tokens: Option<u64>,
+    pub tool_steps: Vec<BackendToolStep>,
+    pub phase_timings: Vec<BackendPhaseTiming>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct BackendToolStep {
+    pub step: u64,
+    pub tool_name: String,
+    pub tool_call_id: Option<String>,
+    pub status: String,
+    pub started_at: Option<f64>,
+    pub finished_at: Option<f64>,
+    pub duration_ms: Option<f64>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct BackendPhaseTiming {
+    pub phase: String,
+    pub started_at: Option<f64>,
+    pub finished_at: Option<f64>,
+    pub duration_ms: Option<f64>,
+    pub segment_count: u64,
+}
+
 pub enum BackendEvent {
     LiveChunk(MessageKind, String),
     Message(MessageKind, String),
     Status(String),
+    PhaseChanged(String),
     ToolStarted(String),
     ToolFinished(String),
+    Stats(BackendStats),
     Error(String),
     Finished,
     Exited,

--- a/app/terminal/src/main.rs
+++ b/app/terminal/src/main.rs
@@ -22,14 +22,15 @@ use startup::{parse_startup_action, print_usage, StartupBehavior};
 use terminal::{restore_terminal, run, run_with_startup_action, setup_terminal};
 
 fn main() -> Result<()> {
-    let startup_action = match parse_startup_action(env::args().skip(1))? {
-        StartupBehavior::Run(action) => action,
+    let (startup_action, startup_options) = match parse_startup_action(env::args().skip(1))? {
+        StartupBehavior::Run { action, options } => (action, options),
         StartupBehavior::PrintHelp => {
             print_usage();
             return Ok(());
         }
     };
     let mut app = App::new();
+    app.apply_startup_agent_options(startup_options.agent_id, startup_options.agent_mode);
     let mut terminal = setup_terminal(&app)?;
     let result = match startup_action {
         Some(action) => run_with_startup_action(&mut terminal, &mut app, Some(action)),

--- a/app/terminal/src/slash_command.rs
+++ b/app/terminal/src/slash_command.rs
@@ -6,7 +6,7 @@ pub(crate) struct SlashCommandDef {
     pub(crate) example: &'static str,
 }
 
-const COMMANDS: [SlashCommandDef; 16] = [
+const COMMANDS: [SlashCommandDef; 18] = [
     SlashCommandDef {
         command: "/help",
         description: "Show available commands",
@@ -78,6 +78,18 @@ const COMMANDS: [SlashCommandDef; 16] = [
         description: "Show or override the current model",
         usage: "/model | /model show | /model set <name> | /model clear",
         example: "/model set gpt-5",
+    },
+    SlashCommandDef {
+        command: "/agent",
+        description: "Show or override the current agent",
+        usage: "/agent | /agent show | /agent list | /agent set <agent_id> | /agent clear",
+        example: "/agent set agent_demo",
+    },
+    SlashCommandDef {
+        command: "/mode",
+        description: "Show or override the current agent mode",
+        usage: "/mode | /mode show | /mode set <simple|multi|fibre>",
+        example: "/mode set fibre",
     },
     SlashCommandDef {
         command: "/status",

--- a/app/terminal/src/startup/help.rs
+++ b/app/terminal/src/startup/help.rs
@@ -4,17 +4,17 @@ pub(crate) fn print_usage() {
 
 pub(crate) fn usage_text() -> &'static str {
     "Usage:
-  sage-terminal
-  sage-terminal run <prompt>
-  sage-terminal chat <prompt>
-  sage-terminal config init [path] [--force]
-  sage-terminal doctor
-  sage-terminal doctor probe-provider
-  sage-terminal provider verify [key=value...]
-  sage-terminal sessions
-  sage-terminal sessions <limit>
-  sage-terminal sessions inspect <latest|session_id>
-  sage-terminal resume
-  sage-terminal resume latest
-  sage-terminal resume <session_id>"
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>]
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] run <prompt>
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] chat <prompt>
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] config init [path] [--force]
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] doctor
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] doctor probe-provider
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] provider verify [key=value...]
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] sessions
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] sessions <limit>
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] sessions inspect <latest|session_id>
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] resume
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] resume latest
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] resume <session_id>"
 }

--- a/app/terminal/src/startup/mod.rs
+++ b/app/terminal/src/startup/mod.rs
@@ -3,9 +3,18 @@ mod parse;
 #[cfg(test)]
 mod tests;
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct StartupOptions {
+    pub(crate) agent_id: Option<String>,
+    pub(crate) agent_mode: Option<String>,
+}
+
 #[derive(Debug)]
 pub(crate) enum StartupBehavior {
-    Run(Option<crate::app::SubmitAction>),
+    Run {
+        action: Option<crate::app::SubmitAction>,
+        options: StartupOptions,
+    },
     PrintHelp,
 }
 

--- a/app/terminal/src/startup/parse.rs
+++ b/app/terminal/src/startup/parse.rs
@@ -1,7 +1,8 @@
 use anyhow::{anyhow, Result};
 
-use crate::app::{SessionPickerMode, SubmitAction};
+use crate::app::{normalize_agent_mode, SessionPickerMode, SubmitAction};
 
+use super::StartupOptions;
 use super::help::usage_text;
 use super::StartupBehavior;
 
@@ -9,8 +10,12 @@ pub(crate) fn parse_startup_action(
     args: impl IntoIterator<Item = String>,
 ) -> Result<StartupBehavior> {
     let args = args.into_iter().collect::<Vec<_>>();
+    let (options, args) = parse_global_options(&args)?;
     match args.as_slice() {
-        [] => Ok(StartupBehavior::Run(None)),
+        [] => Ok(StartupBehavior::Run {
+            action: None,
+            options,
+        }),
         [flag] if matches!(flag.as_str(), "-h" | "--help" | "help") => {
             Ok(StartupBehavior::PrintHelp)
         }
@@ -18,38 +23,47 @@ pub(crate) fn parse_startup_action(
             if prompt.is_empty() {
                 return Err(anyhow!("{command} requires a prompt"));
             }
-            Ok(StartupBehavior::Run(Some(SubmitAction::RunTask(
-                prompt.join(" "),
-            ))))
+            Ok(StartupBehavior::Run {
+                action: Some(SubmitAction::RunTask(prompt.join(" "))),
+                options,
+            })
         }
         [command, subcommand, rest @ ..] if command == "config" && subcommand == "init" => {
             let (path, force) = parse_config_init_args(rest)?;
-            Ok(StartupBehavior::Run(Some(SubmitAction::InitConfig {
-                path,
-                force,
-            })))
+            Ok(StartupBehavior::Run {
+                action: Some(SubmitAction::InitConfig { path, force }),
+                options,
+            })
         }
-        [command] if command == "doctor" => {
-            Ok(StartupBehavior::Run(Some(SubmitAction::ShowDoctor {
+        [command] if command == "doctor" => Ok(StartupBehavior::Run {
+            action: Some(SubmitAction::ShowDoctor {
                 probe_provider: false,
-            })))
-        }
+            }),
+            options,
+        }),
         [command, probe]
             if command == "doctor"
                 && matches!(probe.as_str(), "probe-provider" | "--probe-provider") =>
         {
-            Ok(StartupBehavior::Run(Some(SubmitAction::ShowDoctor {
-                probe_provider: true,
-            })))
+            Ok(StartupBehavior::Run {
+                action: Some(SubmitAction::ShowDoctor {
+                    probe_provider: true,
+                }),
+                options,
+            })
         }
-        [command] if command == "sessions" => Ok(StartupBehavior::Run(Some(
-            SubmitAction::OpenSessionPicker {
+        [command] if command == "sessions" => Ok(StartupBehavior::Run {
+            action: Some(SubmitAction::OpenSessionPicker {
                 mode: SessionPickerMode::Browse,
                 limit: 10,
-            },
-        ))),
+            }),
+            options,
+        }),
         [command, subcommand, target] if command == "sessions" && subcommand == "inspect" => Ok(
-            StartupBehavior::Run(Some(SubmitAction::ShowSession(target.clone()))),
+            StartupBehavior::Run {
+                action: Some(SubmitAction::ShowSession(target.clone())),
+                options,
+            },
         ),
         [command, limit] if command == "sessions" => {
             let limit = limit
@@ -58,29 +72,36 @@ pub(crate) fn parse_startup_action(
             if limit == 0 {
                 return Err(anyhow!("sessions limit must be a positive integer"));
             }
-            Ok(StartupBehavior::Run(Some(
-                SubmitAction::OpenSessionPicker {
+            Ok(StartupBehavior::Run {
+                action: Some(SubmitAction::OpenSessionPicker {
                     mode: SessionPickerMode::Browse,
                     limit,
-                },
-            )))
+                }),
+                options,
+            })
         }
-        [command] if command == "resume" => Ok(StartupBehavior::Run(Some(
-            SubmitAction::OpenSessionPicker {
+        [command] if command == "resume" => Ok(StartupBehavior::Run {
+            action: Some(SubmitAction::OpenSessionPicker {
                 mode: SessionPickerMode::Resume,
                 limit: 10,
-            },
-        ))),
+            }),
+            options,
+        }),
         [command, target] if command == "resume" && target == "latest" => {
-            Ok(StartupBehavior::Run(Some(SubmitAction::ResumeLatest)))
+            Ok(StartupBehavior::Run {
+                action: Some(SubmitAction::ResumeLatest),
+                options,
+            })
         }
-        [command, session_id] if command == "resume" => Ok(StartupBehavior::Run(Some(
-            SubmitAction::ResumeSession(session_id.clone()),
-        ))),
+        [command, session_id] if command == "resume" => Ok(StartupBehavior::Run {
+            action: Some(SubmitAction::ResumeSession(session_id.clone())),
+            options,
+        }),
         [command, subcommand, fields @ ..] if command == "provider" && subcommand == "verify" => {
-            Ok(StartupBehavior::Run(Some(SubmitAction::VerifyProvider(
-                fields.to_vec(),
-            ))))
+            Ok(StartupBehavior::Run {
+                action: Some(SubmitAction::VerifyProvider(fields.to_vec())),
+                options,
+            })
         }
         _ => Err(anyhow!(
             "unsupported arguments: {}\n\n{}",
@@ -88,6 +109,35 @@ pub(crate) fn parse_startup_action(
             usage_text()
         )),
     }
+}
+
+fn parse_global_options(args: &[String]) -> Result<(StartupOptions, Vec<String>)> {
+    let mut options = StartupOptions::default();
+    let mut idx = 0;
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--agent-id" => {
+                let value = args
+                    .get(idx + 1)
+                    .ok_or_else(|| anyhow!("--agent-id requires a value"))?;
+                options.agent_id = Some(value.clone());
+                idx += 2;
+            }
+            "--agent-mode" => {
+                let value = args
+                    .get(idx + 1)
+                    .ok_or_else(|| anyhow!("--agent-mode requires a value"))?;
+                options.agent_mode = Some(
+                    normalize_agent_mode(value).ok_or_else(|| {
+                        anyhow!("--agent-mode must be one of: simple, multi, fibre")
+                    })?,
+                );
+                idx += 2;
+            }
+            _ => break,
+        }
+    }
+    Ok((options, args[idx..].to_vec()))
 }
 
 fn parse_config_init_args(args: &[String]) -> Result<(Option<String>, bool)> {

--- a/app/terminal/src/startup/tests.rs
+++ b/app/terminal/src/startup/tests.rs
@@ -13,10 +13,10 @@ fn parse_startup_action_supports_resume_picker() {
     let action = parse_startup_action(vec!["resume".to_string()]).expect("parse");
     assert!(matches!(
         action,
-        StartupBehavior::Run(Some(SubmitAction::OpenSessionPicker {
+        StartupBehavior::Run { action: Some(SubmitAction::OpenSessionPicker {
             mode: SessionPickerMode::Resume,
             limit: 10
-        }))
+        }), .. }
     ));
 }
 
@@ -30,7 +30,7 @@ fn parse_startup_action_supports_run_and_chat_prompts() {
     .expect("parse");
     assert!(matches!(
         run_action,
-        StartupBehavior::Run(Some(SubmitAction::RunTask(prompt)))
+        StartupBehavior::Run { action: Some(SubmitAction::RunTask(prompt)), .. }
             if prompt == "inspect repo"
     ));
 
@@ -38,7 +38,7 @@ fn parse_startup_action_supports_run_and_chat_prompts() {
         parse_startup_action(vec!["chat".to_string(), "hello".to_string()]).expect("parse");
     assert!(matches!(
         chat_action,
-        StartupBehavior::Run(Some(SubmitAction::RunTask(prompt)))
+        StartupBehavior::Run { action: Some(SubmitAction::RunTask(prompt)), .. }
             if prompt == "hello"
     ));
 }
@@ -48,27 +48,27 @@ fn parse_startup_action_supports_doctor() {
     let action = parse_startup_action(vec!["doctor".to_string()]).expect("parse");
     assert!(matches!(
         action,
-        StartupBehavior::Run(Some(SubmitAction::ShowDoctor {
+        StartupBehavior::Run { action: Some(SubmitAction::ShowDoctor {
             probe_provider: false
-        }))
+        }), .. }
     ));
 
     let action = parse_startup_action(vec!["doctor".to_string(), "probe-provider".to_string()])
         .expect("parse");
     assert!(matches!(
         action,
-        StartupBehavior::Run(Some(SubmitAction::ShowDoctor {
+        StartupBehavior::Run { action: Some(SubmitAction::ShowDoctor {
             probe_provider: true
-        }))
+        }), .. }
     ));
 
     let action = parse_startup_action(vec!["doctor".to_string(), "--probe-provider".to_string()])
         .expect("parse");
     assert!(matches!(
         action,
-        StartupBehavior::Run(Some(SubmitAction::ShowDoctor {
+        StartupBehavior::Run { action: Some(SubmitAction::ShowDoctor {
             probe_provider: true
-        }))
+        }), .. }
     ));
 }
 
@@ -78,10 +78,10 @@ fn parse_startup_action_supports_config_init() {
         parse_startup_action(vec!["config".to_string(), "init".to_string()]).expect("parse");
     assert!(matches!(
         action,
-        StartupBehavior::Run(Some(SubmitAction::InitConfig {
+        StartupBehavior::Run { action: Some(SubmitAction::InitConfig {
             path: None,
             force: false
-        }))
+        }), .. }
     ));
 
     let action = parse_startup_action(vec![
@@ -93,10 +93,10 @@ fn parse_startup_action_supports_config_init() {
     .expect("parse");
     assert!(matches!(
         action,
-        StartupBehavior::Run(Some(SubmitAction::InitConfig {
+        StartupBehavior::Run { action: Some(SubmitAction::InitConfig {
             path: Some(path),
             force: true
-        })) if path == "/tmp/demo.env"
+        }), .. } if path == "/tmp/demo.env"
     ));
 }
 
@@ -111,7 +111,7 @@ fn parse_startup_action_supports_provider_verify() {
     .expect("parse");
     assert!(matches!(
         action,
-        StartupBehavior::Run(Some(SubmitAction::VerifyProvider(fields)))
+        StartupBehavior::Run { action: Some(SubmitAction::VerifyProvider(fields)), .. }
             if fields == vec!["name=demo".to_string(), "model=demo-chat".to_string()]
     ));
 }
@@ -121,20 +121,20 @@ fn parse_startup_action_supports_sessions_picker() {
     let action = parse_startup_action(vec!["sessions".to_string()]).expect("parse");
     assert!(matches!(
         action,
-        StartupBehavior::Run(Some(SubmitAction::OpenSessionPicker {
+        StartupBehavior::Run { action: Some(SubmitAction::OpenSessionPicker {
             mode: SessionPickerMode::Browse,
             limit: 10
-        }))
+        }), .. }
     ));
 
     let action =
         parse_startup_action(vec!["sessions".to_string(), "25".to_string()]).expect("parse");
     assert!(matches!(
         action,
-        StartupBehavior::Run(Some(SubmitAction::OpenSessionPicker {
+        StartupBehavior::Run { action: Some(SubmitAction::OpenSessionPicker {
             mode: SessionPickerMode::Browse,
             limit: 25
-        }))
+        }), .. }
     ));
 }
 
@@ -148,7 +148,7 @@ fn parse_startup_action_supports_sessions_inspect() {
     .expect("parse");
     assert!(matches!(
         latest,
-        StartupBehavior::Run(Some(SubmitAction::ShowSession(session_id)))
+        StartupBehavior::Run { action: Some(SubmitAction::ShowSession(session_id)), .. }
             if session_id == "latest"
     ));
 
@@ -160,7 +160,7 @@ fn parse_startup_action_supports_sessions_inspect() {
     .expect("parse");
     assert!(matches!(
         specific,
-        StartupBehavior::Run(Some(SubmitAction::ShowSession(session_id)))
+        StartupBehavior::Run { action: Some(SubmitAction::ShowSession(session_id)), .. }
             if session_id == "local-000123"
     ));
 }
@@ -171,16 +171,46 @@ fn parse_startup_action_supports_resume_targets() {
         parse_startup_action(vec!["resume".to_string(), "latest".to_string()]).expect("parse");
     assert!(matches!(
         latest,
-        StartupBehavior::Run(Some(SubmitAction::ResumeLatest))
+        StartupBehavior::Run { action: Some(SubmitAction::ResumeLatest), .. }
     ));
 
     let specific = parse_startup_action(vec!["resume".to_string(), "local-000123".to_string()])
         .expect("parse");
     assert!(matches!(
         specific,
-        StartupBehavior::Run(Some(SubmitAction::ResumeSession(session_id)))
+        StartupBehavior::Run { action: Some(SubmitAction::ResumeSession(session_id)), .. }
             if session_id == "local-000123"
     ));
+}
+
+#[test]
+fn parse_startup_action_supports_agent_options() {
+    let action = parse_startup_action(vec![
+        "--agent-id".to_string(),
+        "agent_demo".to_string(),
+        "--agent-mode".to_string(),
+        "fibre".to_string(),
+        "run".to_string(),
+        "inspect".to_string(),
+    ])
+    .expect("parse");
+    assert!(matches!(
+        action,
+        StartupBehavior::Run { action: Some(SubmitAction::RunTask(prompt)), options }
+            if prompt == "inspect"
+            && options.agent_id.as_deref() == Some("agent_demo")
+            && options.agent_mode.as_deref() == Some("fibre")
+    ));
+}
+
+#[test]
+fn parse_startup_action_rejects_invalid_agent_mode() {
+    let err = parse_startup_action(vec![
+        "--agent-mode".to_string(),
+        "weird".to_string(),
+    ])
+    .expect_err("should fail");
+    assert!(err.to_string().contains("simple, multi, fibre"));
 }
 
 #[test]
@@ -210,6 +240,6 @@ fn parse_startup_action_supports_help_flag() {
 
 impl StartupBehavior {
     fn matches_run_none(&self) -> bool {
-        matches!(self, StartupBehavior::Run(None))
+        matches!(self, StartupBehavior::Run { action: None, .. })
     }
 }

--- a/app/terminal/src/terminal/actions.rs
+++ b/app/terminal/src/terminal/actions.rs
@@ -1,3 +1,5 @@
+#[path = "actions/agents.rs"]
+mod agents;
 #[path = "actions/chat.rs"]
 mod chat;
 #[path = "actions/model.rs"]
@@ -26,6 +28,7 @@ pub(super) fn handle_submit_action(
         SubmitAction::OpenSessionPicker { mode, limit } => {
             sessions::open_session_picker(app, mode, limit)
         }
+        SubmitAction::ListAgents => agents::list_agents(app),
         SubmitAction::ListSkills => skills::list_skills(app),
         SubmitAction::EnableSkill(skill) => skills::enable_skill(app, skill),
         SubmitAction::DisableSkill(skill) => skills::disable_skill(app, &skill),

--- a/app/terminal/src/terminal/actions/agents.rs
+++ b/app/terminal/src/terminal/actions/agents.rs
@@ -1,0 +1,36 @@
+use anyhow::Result;
+
+use crate::app::{App, MessageKind};
+use crate::backend::list_agents as fetch_agents;
+use crate::terminal_support::format_agents_list;
+
+pub(super) fn list_agents(app: &mut App) -> Result<bool> {
+    match fetch_agents(&app.user_id) {
+        Ok(agents) => {
+            app.set_agent_catalog(
+                agents
+                    .iter()
+                    .map(|agent| {
+                        (
+                            agent.agent_id.clone(),
+                            agent.name.clone(),
+                            agent.agent_mode.clone(),
+                            agent.is_default,
+                            agent.updated_at.clone(),
+                        )
+                    })
+                    .collect(),
+            );
+            app.push_message(
+                MessageKind::Tool,
+                format_agents_list(&agents, app.selected_agent_id.as_deref()),
+            );
+            app.set_status(format!("agents  {}", app.session_id));
+        }
+        Err(err) => {
+            app.push_message(MessageKind::System, format!("failed to list agents: {err}"));
+            app.set_status(format!("error  {}", app.session_id));
+        }
+    }
+    Ok(true)
+}

--- a/app/terminal/src/terminal/actions/chat.rs
+++ b/app/terminal/src/terminal/actions/chat.rs
@@ -13,6 +13,7 @@ pub(super) fn run_task(
     let request = BackendRequest {
         session_id: app.session_id.clone(),
         user_id: app.user_id.clone(),
+        agent_id: app.selected_agent_id.clone(),
         agent_mode: app.agent_mode.clone(),
         max_loop_count: app.max_loop_count,
         workspace: Some(workspace_root()),

--- a/app/terminal/src/terminal/actions/sessions.rs
+++ b/app/terminal/src/terminal/actions/sessions.rs
@@ -9,7 +9,7 @@ pub(super) fn open_session_picker(
     mode: SessionPickerMode,
     limit: usize,
 ) -> Result<bool> {
-    match list_sessions(&app.user_id, limit) {
+    match list_sessions(&app.user_id, app.selected_agent_id.as_deref(), limit) {
         Ok(sessions) if sessions.is_empty() => {
             app.push_message(
                 MessageKind::System,
@@ -44,7 +44,7 @@ pub(super) fn open_session_picker(
 }
 
 pub(super) fn resume_latest(app: &mut App) -> Result<bool> {
-    match inspect_latest_session(&app.user_id) {
+    match inspect_latest_session(&app.user_id, app.selected_agent_id.as_deref()) {
         Ok(Some(detail)) => apply_resumed_session(app, detail),
         Ok(None) => {
             app.push_message(
@@ -62,7 +62,7 @@ pub(super) fn resume_latest(app: &mut App) -> Result<bool> {
 }
 
 pub(super) fn resume_session(app: &mut App, session_id: &str) -> Result<bool> {
-    match inspect_session(session_id, &app.user_id) {
+    match inspect_session(session_id, &app.user_id, app.selected_agent_id.as_deref()) {
         Ok(Some(detail)) => apply_resumed_session(app, detail),
         Ok(None) => {
             app.push_message(
@@ -81,9 +81,9 @@ pub(super) fn resume_session(app: &mut App, session_id: &str) -> Result<bool> {
 
 pub(super) fn show_session(app: &mut App, session_id: &str) -> Result<bool> {
     let detail = if session_id == "latest" {
-        inspect_latest_session(&app.user_id)
+        inspect_latest_session(&app.user_id, app.selected_agent_id.as_deref())
     } else {
-        inspect_session(session_id, &app.user_id)
+        inspect_session(session_id, &app.user_id, app.selected_agent_id.as_deref())
     };
 
     match detail {

--- a/app/terminal/src/terminal/actions/skills.rs
+++ b/app/terminal/src/terminal/actions/skills.rs
@@ -5,7 +5,11 @@ use crate::backend::list_skills as fetch_skills;
 use crate::terminal_support::{format_skills_list, workspace_root};
 
 pub(super) fn list_skills(app: &mut App) -> Result<bool> {
-    match fetch_skills(&app.user_id, Some(workspace_root().as_path())) {
+    match fetch_skills(
+        &app.user_id,
+        app.selected_agent_id.as_deref(),
+        Some(workspace_root().as_path()),
+    ) {
         Ok(skills) => {
             app.set_skill_catalog(
                 skills
@@ -34,7 +38,11 @@ pub(super) fn list_skills(app: &mut App) -> Result<bool> {
 }
 
 pub(super) fn enable_skill(app: &mut App, skill: String) -> Result<bool> {
-    match fetch_skills(&app.user_id, Some(workspace_root().as_path())) {
+    match fetch_skills(
+        &app.user_id,
+        app.selected_agent_id.as_deref(),
+        Some(workspace_root().as_path()),
+    ) {
         Ok(skills) => {
             app.set_skill_catalog(
                 skills

--- a/app/terminal/src/terminal/context.rs
+++ b/app/terminal/src/terminal/context.rs
@@ -1,13 +1,31 @@
 use std::path::PathBuf;
 
 use crate::app::{App, MessageKind};
-use crate::backend::{list_providers, list_skills, SessionDetail};
+use crate::backend::{list_agents, list_providers, list_skills, SessionDetail};
 
 pub(crate) fn workspace_root() -> PathBuf {
     std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
 }
 
 pub(crate) fn sync_contextual_popup_data(app: &mut App) {
+    if app.needs_agent_catalog() {
+        if let Ok(agents) = list_agents(&app.user_id) {
+            app.set_agent_catalog(
+                agents
+                    .into_iter()
+                    .map(|agent| {
+                        (
+                            agent.agent_id,
+                            agent.name,
+                            agent.agent_mode,
+                            agent.is_default,
+                            agent.updated_at,
+                        )
+                    })
+                    .collect(),
+            );
+        }
+    }
     if app.needs_provider_catalog() {
         if let Ok(providers) = list_providers(&app.user_id) {
             app.set_provider_catalog(
@@ -27,7 +45,11 @@ pub(crate) fn sync_contextual_popup_data(app: &mut App) {
         }
     }
     if app.needs_skill_catalog() {
-        if let Ok(skills) = list_skills(&app.user_id, Some(workspace_root().as_path())) {
+        if let Ok(skills) = list_skills(
+            &app.user_id,
+            app.selected_agent_id.as_deref(),
+            Some(workspace_root().as_path()),
+        ) {
             app.set_skill_catalog(
                 skills
                     .into_iter()

--- a/app/terminal/src/terminal/formatting.rs
+++ b/app/terminal/src/terminal/formatting.rs
@@ -1,7 +1,8 @@
 use serde_json::Value;
 
 use crate::backend::{
-    ConfigInfo, ConfigInitInfo, ProviderInfo, ProviderVerifyInfo, SessionDetail, SkillInfo,
+    AgentInfo, ConfigInfo, ConfigInitInfo, ProviderInfo, ProviderVerifyInfo, SessionDetail,
+    SkillInfo,
 };
 
 pub(crate) fn format_session_detail(detail: &SessionDetail) -> String {
@@ -44,6 +45,36 @@ pub(crate) fn format_skills_list(skills: &[SkillInfo], active_skills: &[String])
         lines.push(format!("{}  [{}]", skill.name, skill.source));
         if !skill.description.trim().is_empty() {
             lines.push(format!("  {}", skill.description.trim()));
+        }
+    }
+
+    lines.join("\n")
+}
+
+pub(crate) fn format_agents_list(agents: &[AgentInfo], selected_agent_id: Option<&str>) -> String {
+    let active_agent = selected_agent_id.unwrap_or("(default)");
+    if agents.is_empty() {
+        return format!(
+            "selected agent: {active_agent}\nvisible agents: none\n\nTip: this CLI state currently exposes no saved agents."
+        );
+    }
+
+    let mut lines = vec![
+        format!("selected agent: {active_agent}"),
+        String::new(),
+        "visible agents".to_string(),
+    ];
+
+    for agent in agents {
+        lines.push(format!(
+            "{}{}  [{}]",
+            agent.name,
+            if agent.is_default { "  [default]" } else { "" },
+            agent.agent_mode,
+        ));
+        lines.push(format!("  id: {}", agent.agent_id));
+        if !agent.updated_at.trim().is_empty() {
+            lines.push(format!("  updated: {}", agent.updated_at));
         }
     }
 

--- a/app/terminal/src/terminal/mod.rs
+++ b/app/terminal/src/terminal/mod.rs
@@ -32,11 +32,13 @@ use keys::handle_key;
 pub type AppTerminal = Terminal<BackendImpl>;
 const INLINE_VIEWPORT_IDLE_HEIGHT: u16 = 5;
 const INLINE_VIEWPORT_MAX_HEIGHT: u16 = 14;
+// Keep keyboard enhancement mode minimal.
+//
+// `DISAMBIGUATE_ESCAPE_CODES` is enough to let capable terminals distinguish
+// modified Enter keys such as Shift+Enter. The broader reporting modes caused
+// real-world IME regressions, especially for Chinese input methods.
 const KEYBOARD_ENHANCEMENT_FLAGS: KeyboardEnhancementFlags =
-    KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-        .union(KeyboardEnhancementFlags::REPORT_EVENT_TYPES)
-        .union(KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS)
-        .union(KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES);
+    KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES;
 
 pub fn setup_terminal(_app: &App) -> Result<AppTerminal> {
     let startup_cursor = cursor::position()
@@ -173,8 +175,10 @@ fn drain_backend(app: &mut App, backend: &mut Option<BackendHandle>) -> bool {
                 },
                 BackendEvent::Message(kind, message) => app.push_message(kind, message),
                 BackendEvent::Status(status) => app.set_status(status),
+                BackendEvent::PhaseChanged(phase) => app.set_active_phase(phase),
                 BackendEvent::ToolStarted(name) => app.start_tool(name),
                 BackendEvent::ToolFinished(name) => app.finish_tool(name),
+                BackendEvent::Stats(stats) => app.apply_backend_stats(stats),
                 BackendEvent::Error(message) => app.fail_request(message),
                 BackendEvent::Finished => {
                     app.complete_request();

--- a/app/terminal/src/terminal_support.rs
+++ b/app/terminal/src/terminal_support.rs
@@ -7,7 +7,8 @@ mod provider_args;
 
 pub(crate) use context::{apply_resumed_session, sync_contextual_popup_data, workspace_root};
 pub(crate) use formatting::{
-    format_config, format_config_init, format_doctor_info, format_provider_detail,
-    format_provider_verify, format_providers, format_session_detail, format_skills_list,
+    format_agents_list, format_config, format_config_init, format_doctor_info,
+    format_provider_detail, format_provider_verify, format_providers, format_session_detail,
+    format_skills_list,
 };
 pub(crate) use provider_args::{parse_provider_mutation, parse_provider_mutation_allow_empty};

--- a/app/terminal/src/ui.rs
+++ b/app/terminal/src/ui.rs
@@ -134,18 +134,27 @@ fn footer_hint(app: &App) -> String {
         }
         None if app.busy => match app.active_tool_status() {
             Some(tool) => format!("running {tool}"),
-            None => "working... output is streaming".to_string(),
+            None => match app.active_phase_label() {
+                Some(phase) => format!("{phase}... output is streaming"),
+                None => "working... output is streaming".to_string(),
+            },
         },
         None => "shift+enter newline  •  /help commands  •  enter send".to_string(),
     }
 }
 
 fn footer_status_summary(app: &App) -> String {
-    let mut parts = vec![
-        app.agent_mode.clone(),
-        compact_workspace_label(&app.workspace_label),
-        normalize_footer_status(&app.footer_status()),
-    ];
+    let mut parts = vec![app.agent_mode.clone()];
+    if let Some(agent_id) = app.selected_agent_id.as_deref() {
+        parts.push(format!("agent {}", truncate_middle(agent_id, 18)));
+    }
+    parts.push(compact_workspace_label(&app.workspace_label));
+    if app.busy {
+        if let Some(phase) = app.active_phase_label() {
+            parts.push(format!("phase {phase}"));
+        }
+    }
+    parts.push(normalize_footer_status(&app.footer_status()));
     if app.busy && app.active_tool_status().is_none() {
         parts.push(app.session_id.clone());
     }
@@ -161,5 +170,54 @@ fn compact_workspace_label(workspace_label: &str) -> String {
         workspace_label.to_string()
     } else {
         truncate_middle(workspace_label, 26)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{footer_hint, footer_status_summary};
+    use crate::app::App;
+
+    #[test]
+    fn busy_footer_hint_prefers_active_phase() {
+        let mut app = App::new();
+        app.input = "explain repo".to_string();
+        let _ = app.submit_input();
+        app.set_active_phase("planning");
+
+        assert_eq!(footer_hint(&app), "planning... output is streaming");
+    }
+
+    #[test]
+    fn busy_footer_summary_includes_active_phase() {
+        let mut app = App::new();
+        app.input = "explain repo".to_string();
+        let _ = app.submit_input();
+        app.set_active_phase("assistant_text");
+
+        let summary = footer_status_summary(&app);
+        assert!(summary.contains("phase assistant text"));
+    }
+
+    #[test]
+    fn busy_footer_hint_prefers_active_tool_over_phase() {
+        let mut app = App::new();
+        app.input = "explain repo".to_string();
+        let _ = app.submit_input();
+        app.set_active_phase("planning");
+        app.start_tool("read_file".to_string());
+
+        let hint = footer_hint(&app);
+        assert!(hint.contains("running #1 read_file"));
+        assert!(!hint.contains("planning..."));
+    }
+
+    #[test]
+    fn busy_footer_hint_falls_back_without_phase_or_tool() {
+        let mut app = App::new();
+        app.input = "explain repo".to_string();
+        let _ = app.submit_input();
+
+        assert_eq!(footer_hint(&app), "working... output is streaming");
     }
 }

--- a/docs/en/applications/CLI.md
+++ b/docs/en/applications/CLI.md
@@ -389,6 +389,20 @@ The current summary includes:
 
 Prints structured stream events instead of plain text.
 
+The JSON stream now has three layers:
+
+- raw runtime events such as `assistant`, `analysis`, `tool_call`, and `tool_result`
+- CLI control events such as `cli_phase` and `cli_tool`
+- a final `cli_stats` event when `--stats` is enabled
+
+The intended contract is:
+
+- `cli_phase`: emitted when the CLI detects a phase transition such as `planning`, `tool`, or `assistant_text`
+- `cli_tool`: emitted when a tool step starts or finishes; includes `action`, `step`, `tool_name`, `tool_call_id`, and `status`
+- `cli_stats`: emitted once at the end; includes final `tool_steps`, `phase_timings`, timing summary, and token summary
+
+Consumers should treat `cli_phase` and `cli_tool` as the preferred real-time UI contract, and treat raw `tool_call` / `tool_result` lines as compatibility input rather than the primary surface.
+
 When used together with `--stats`, the CLI appends a final `cli_stats` JSON event for post-run analysis:
 
 ```bash
@@ -401,6 +415,8 @@ This is useful for:
 - comparing runs
 - extracting token usage
 - checking whether tools or skills were actually used
+
+For a concrete end-to-end sample, see `tests/app/cli/fixtures/stream_contract_round_trip.jsonl`.
 
 ## Workspace Usage
 
@@ -435,6 +451,7 @@ Then verify:
 - config values look correct
 - skills output matches what is visible locally
 - stats include the expected user/workspace/skill context
+- JSON mode emits `cli_phase` / `cli_tool` during the run
 - JSON mode ends with a `cli_stats` event
 
 ## Maintainer Validation

--- a/docs/en/applications/TUI.md
+++ b/docs/en/applications/TUI.md
@@ -82,6 +82,8 @@ Currently supported startup forms:
 
 ```bash
 sage-terminal
+sage-terminal --agent-id agent_demo
+sage-terminal --agent-id agent_demo --agent-mode fibre
 sage-terminal run "inspect this repo"
 sage-terminal chat "hello"
 sage-terminal config init
@@ -111,6 +113,8 @@ cargo run --quiet --offline -- resume
 The current TUI preview includes these core commands:
 
 - `/help`
+- `/agent`
+- `/mode`
 - `/new`
 - `/sessions`
 - `/resume`
@@ -125,6 +129,24 @@ The current TUI preview includes these core commands:
 - `/transcript`
 - `/welcome`
 - `/exit`
+
+## Agent Selection
+
+The TUI can override the runtime agent without taking over agent configuration management.
+
+Supported entrypoints:
+
+- startup flags:
+  - `--agent-id <id>`
+  - `--agent-mode <simple|multi|fibre>`
+- in-app commands:
+  - `/agent`
+  - `/agent set <agent_id>`
+  - `/agent clear`
+  - `/mode`
+  - `/mode set <simple|multi|fibre>`
+
+The actual agent definition, tools, skills, and behavior still come from the Sage runtime's stored agent configuration.
 
 ## Current Scope
 

--- a/docs/zh/applications/CLI.md
+++ b/docs/zh/applications/CLI.md
@@ -386,6 +386,20 @@ sage chat --skill my_skill
 
 以结构化流事件的方式输出，而不是仅输出纯文本。
 
+现在的 JSON 流可以分成三层：
+
+- 原始运行时事件，例如 `assistant`、`analysis`、`tool_call`、`tool_result`
+- CLI 控制事件，例如 `cli_phase` 和 `cli_tool`
+- 如果启用了 `--stats`，结尾追加一个 `cli_stats` 事件
+
+建议按下面这套 contract 来消费：
+
+- `cli_phase`：CLI 检测到阶段切换时发出，例如 `planning`、`tool`、`assistant_text`
+- `cli_tool`：工具 step 开始或结束时发出，包含 `action`、`step`、`tool_name`、`tool_call_id`、`status`
+- `cli_stats`：只在结束时发出一次，包含最终 `tool_steps`、`phase_timings`、时延摘要和 token 摘要
+
+对前端消费者来说，`cli_phase` 和 `cli_tool` 应该作为首选的实时 UI contract；原始 `tool_call` / `tool_result` 更适合作为兼容输入，而不是主要展示协议。
+
 当和 `--stats` 一起使用时，CLI 会在结尾追加一个 `cli_stats` JSON 事件：
 
 ```bash
@@ -398,6 +412,8 @@ sage run --json --stats "用一句话介绍你自己。"
 - 对比不同运行结果
 - 抽取 token usage
 - 判断 tool/skill 是否真的生效
+
+如果想看一份完整的端到端示例，可以参考 `tests/app/cli/fixtures/stream_contract_round_trip.jsonl`。
 
 ## Workspace 用法
 
@@ -432,6 +448,7 @@ sage run --json --stats "用一句话介绍你自己。"
 - config 是否和你的预期一致
 - skills 是否反映当前本地可见 skill
 - stats 是否带上了正确的 user/workspace/skill 上下文
+- JSON 模式运行中是否发出了 `cli_phase` / `cli_tool`
 - JSON 模式最后是否有 `cli_stats` 事件
 
 ## 维护者验证

--- a/docs/zh/applications/TUI.md
+++ b/docs/zh/applications/TUI.md
@@ -82,6 +82,8 @@ cargo build --release
 
 ```bash
 sage-terminal
+sage-terminal --agent-id agent_demo
+sage-terminal --agent-id agent_demo --agent-mode fibre
 sage-terminal run "inspect this repo"
 sage-terminal chat "hello"
 sage-terminal config init
@@ -111,6 +113,8 @@ cargo run --quiet --offline -- resume
 当前这版预览主要包含这些命令：
 
 - `/help`
+- `/agent`
+- `/mode`
 - `/new`
 - `/sessions`
 - `/resume`
@@ -125,6 +129,24 @@ cargo run --quiet --offline -- resume
 - `/transcript`
 - `/welcome`
 - `/exit`
+
+## Agent 选择
+
+TUI 现在可以覆盖运行时使用的 agent，但不会自己接管 agent 配置管理。
+
+目前支持：
+
+- 启动参数：
+  - `--agent-id <id>`
+  - `--agent-mode <simple|multi|fibre>`
+- TUI 内命令：
+  - `/agent`
+  - `/agent set <agent_id>`
+  - `/agent clear`
+  - `/mode`
+  - `/mode set <simple|multi|fibre>`
+
+真正的 agent 定义、工具、skills 和行为仍然来自 Sage runtime 已保存的 agent 配置。
 
 ## 当前定位
 

--- a/sagents/context/session_context.py
+++ b/sagents/context/session_context.py
@@ -296,6 +296,220 @@ class SessionContext:
             "flow_node_timings": flow_node_timings,
         }
 
+    def _build_tool_step_summary(self) -> List[Dict[str, Any]]:
+        timing_by_message_id = {
+            str(item.get("message_id")): item
+            for item in self._message_timing.values()
+            if item.get("message_id")
+        }
+
+        steps: List[Dict[str, Any]] = []
+        active_steps: Dict[str, Dict[str, Any]] = {}
+        step_seq = 0
+
+        for message in self.message_manager.messages:
+            role = getattr(message, "role", None)
+            message_id = getattr(message, "message_id", None)
+            timing = timing_by_message_id.get(str(message_id)) if message_id else None
+
+            if role == "assistant" and getattr(message, "tool_calls", None):
+                for tool_call in message.tool_calls or []:
+                    if not isinstance(tool_call, dict):
+                        continue
+                    function = tool_call.get("function") or {}
+                    tool_name = str(function.get("name") or "").strip() or "unknown"
+                    tool_call_id = str(tool_call.get("id") or "").strip() or None
+                    key = tool_call_id or f"synthetic-step-{step_seq + 1}"
+                    if key in active_steps:
+                        continue
+
+                    step_seq += 1
+                    step = {
+                        "step": step_seq,
+                        "tool_name": tool_name,
+                        "tool_call_id": tool_call_id,
+                        "status": "running",
+                        "started_at": timing.get("start_ts") if timing else None,
+                        "finished_at": None,
+                        "duration_ms": None,
+                        "start_message_id": message_id,
+                        "finish_message_id": None,
+                    }
+                    steps.append(step)
+                    active_steps[key] = step
+
+            if role == "tool":
+                tool_call_id = str(getattr(message, "tool_call_id", "") or "").strip() or None
+                if not tool_call_id:
+                    continue
+
+                step = active_steps.get(tool_call_id)
+                if step is None:
+                    step_seq += 1
+                    step = {
+                        "step": step_seq,
+                        "tool_name": "unknown",
+                        "tool_call_id": tool_call_id,
+                        "status": "running",
+                        "started_at": timing.get("start_ts") if timing else None,
+                        "finished_at": None,
+                        "duration_ms": None,
+                        "start_message_id": None,
+                        "finish_message_id": None,
+                    }
+                    steps.append(step)
+                    active_steps[tool_call_id] = step
+
+                finished_at = timing.get("end_ts") if timing else None
+                if finished_at is None and timing:
+                    finished_at = timing.get("start_ts")
+                started_at = step.get("started_at")
+                step["status"] = "completed"
+                step["finished_at"] = finished_at
+                step["finish_message_id"] = message_id
+                if started_at is not None and finished_at is not None:
+                    step["duration_ms"] = round(
+                        max(0.0, (float(finished_at) - float(started_at)) * 1000.0),
+                        3,
+                    )
+
+        return steps
+
+    def _build_phase_timing_summary(self) -> List[Dict[str, Any]]:
+        events = sorted(
+            self.execution_timeline_events,
+            key=lambda item: (
+                float(item.get("perf_ms") or 0.0),
+                float(item.get("timestamp") or 0.0),
+            ),
+        )
+
+        phase_totals: Dict[str, Dict[str, Any]] = {}
+        phase_order: List[str] = []
+        active_segments: Dict[str, Dict[str, Any]] = {}
+        last_timestamp = None
+        last_perf_ms = None
+
+        for event in events:
+            event_type = str(event.get("event_type") or "").strip()
+            phase_name = str(event.get("phase_name") or event.get("phase") or "").strip()
+            timestamp = event.get("timestamp")
+            perf_ms = event.get("perf_ms")
+
+            if isinstance(timestamp, (int, float)):
+                last_timestamp = float(timestamp)
+            if isinstance(perf_ms, (int, float)):
+                last_perf_ms = float(perf_ms)
+
+            if not phase_name:
+                continue
+
+            if event_type == "agent_phase_start":
+                active_segments[phase_name] = {
+                    "started_at": float(timestamp) if isinstance(timestamp, (int, float)) else None,
+                    "started_perf_ms": float(perf_ms) if isinstance(perf_ms, (int, float)) else None,
+                }
+                if phase_name not in phase_totals:
+                    phase_totals[phase_name] = {
+                        "phase": phase_name,
+                        "started_at": None,
+                        "finished_at": None,
+                        "duration_ms": 0.0,
+                        "segment_count": 0,
+                    }
+                    phase_order.append(phase_name)
+                continue
+
+            if event_type != "agent_phase_end":
+                continue
+
+            totals = phase_totals.setdefault(
+                phase_name,
+                {
+                    "phase": phase_name,
+                    "started_at": None,
+                    "finished_at": None,
+                    "duration_ms": 0.0,
+                    "segment_count": 0,
+                },
+            )
+            if phase_name not in phase_order:
+                phase_order.append(phase_name)
+
+            segment = active_segments.pop(phase_name, None) or {}
+            started_at = segment.get("started_at")
+            started_perf_ms = segment.get("started_perf_ms")
+            finished_at = float(timestamp) if isinstance(timestamp, (int, float)) else started_at
+            finished_perf_ms = (
+                float(perf_ms) if isinstance(perf_ms, (int, float)) else started_perf_ms
+            )
+
+            duration_ms = 0.0
+            if isinstance(started_perf_ms, (int, float)) and isinstance(finished_perf_ms, (int, float)):
+                duration_ms = max(0.0, float(finished_perf_ms) - float(started_perf_ms))
+            elif isinstance(started_at, (int, float)) and isinstance(finished_at, (int, float)):
+                duration_ms = max(0.0, (float(finished_at) - float(started_at)) * 1000.0)
+
+            if isinstance(started_at, (int, float)):
+                totals["started_at"] = (
+                    float(started_at)
+                    if totals["started_at"] is None
+                    else min(float(totals["started_at"]), float(started_at))
+                )
+            if isinstance(finished_at, (int, float)):
+                totals["finished_at"] = (
+                    float(finished_at)
+                    if totals["finished_at"] is None
+                    else max(float(totals["finished_at"]), float(finished_at))
+                )
+
+            totals["duration_ms"] = round(float(totals.get("duration_ms") or 0.0) + duration_ms, 3)
+            totals["segment_count"] = int(totals.get("segment_count") or 0) + 1
+
+        for phase_name, segment in active_segments.items():
+            totals = phase_totals.setdefault(
+                phase_name,
+                {
+                    "phase": phase_name,
+                    "started_at": None,
+                    "finished_at": None,
+                    "duration_ms": 0.0,
+                    "segment_count": 0,
+                },
+            )
+            if phase_name not in phase_order:
+                phase_order.append(phase_name)
+
+            started_at = segment.get("started_at")
+            started_perf_ms = segment.get("started_perf_ms")
+            finished_at = last_timestamp if isinstance(last_timestamp, (int, float)) else started_at
+            finished_perf_ms = (
+                last_perf_ms if isinstance(last_perf_ms, (int, float)) else started_perf_ms
+            )
+            duration_ms = 0.0
+            if isinstance(started_perf_ms, (int, float)) and isinstance(finished_perf_ms, (int, float)):
+                duration_ms = max(0.0, float(finished_perf_ms) - float(started_perf_ms))
+            elif isinstance(started_at, (int, float)) and isinstance(finished_at, (int, float)):
+                duration_ms = max(0.0, (float(finished_at) - float(started_at)) * 1000.0)
+
+            if isinstance(started_at, (int, float)):
+                totals["started_at"] = (
+                    float(started_at)
+                    if totals["started_at"] is None
+                    else min(float(totals["started_at"]), float(started_at))
+                )
+            if isinstance(finished_at, (int, float)):
+                totals["finished_at"] = (
+                    float(finished_at)
+                    if totals["finished_at"] is None
+                    else max(float(totals["finished_at"]), float(finished_at))
+                )
+
+            totals["duration_ms"] = round(float(totals.get("duration_ms") or 0.0) + duration_ms, 3)
+            totals["segment_count"] = int(totals.get("segment_count") or 0) + 1
+
+        return [phase_totals[phase_name] for phase_name in phase_order]
+
     def add_messages(self, messages: Union[MessageChunk, List[MessageChunk], List[Dict[str, Any]]]) -> None:
         """
         Add messages to the message manager with session_id validation.

--- a/sagents/session_runtime.py
+++ b/sagents/session_runtime.py
@@ -845,12 +845,32 @@ class Session:
             logger.info(f"SAgent: {phase_name} 阶段被中断，会话ID: {session_id}")
             return
 
-        async for chunk in agent.run_stream(session_context):
-            # 在每个块之间检查中断
-            if session.should_interrupt():
-                logger.info(f"SAgent: {phase_name} 阶段在块处理中被中断，会话ID: {session_id}")
-                return
-            yield chunk
+        phase_status = "completed"
+        session_context.record_timing_event(
+            "agent_phase_start",
+            session_id=session_id,
+            phase_name=phase_name,
+            agent_name=agent.agent_name,
+        )
+        try:
+            async for chunk in agent.run_stream(session_context):
+                # 在每个块之间检查中断
+                if session.should_interrupt():
+                    phase_status = "interrupted"
+                    logger.info(f"SAgent: {phase_name} 阶段在块处理中被中断，会话ID: {session_id}")
+                    return
+                yield chunk
+        except Exception:
+            phase_status = "error"
+            raise
+        finally:
+            session_context.record_timing_event(
+                "agent_phase_end",
+                session_id=session_id,
+                phase_name=phase_name,
+                agent_name=agent.agent_name,
+                status=phase_status,
+            )
 
         logger.info(f"SAgent: {phase_name} 阶段完成")
 
@@ -903,6 +923,16 @@ class Session:
             f"model={primary_model} steps={len(token_usage['per_step_info'])} "
             f"total={token_usage['total_info']}"
         )
+        tool_steps: List[Dict[str, Any]] = []
+        try:
+            tool_steps = session_context._build_tool_step_summary()
+        except Exception as e:
+            logger.warning(f"SAgent: 生成 tool_steps 失败，会话 {session_id}: {e}")
+        phase_timings: List[Dict[str, Any]] = []
+        try:
+            phase_timings = session_context._build_phase_timing_summary()
+        except Exception as e:
+            logger.warning(f"SAgent: 生成 phase_timings 失败，会话 {session_id}: {e}")
 
         return [
             MessageChunk(
@@ -913,6 +943,8 @@ class Session:
                     "token_usage": token_usage,
                     "model": primary_model,
                     "models": list(token_usage.get("models") or []),
+                    "tool_steps": tool_steps,
+                    "phase_timings": phase_timings,
                     "session_id": session_id,
                 },
             )

--- a/tests/app/cli/fixtures/stream_contract_round_trip.jsonl
+++ b/tests/app/cli/fixtures/stream_contract_round_trip.jsonl
@@ -1,0 +1,11 @@
+{"type":"cli_phase","phase":"planning"}
+{"type":"analysis","role":"assistant","content":"Plan the work first."}
+{"type":"cli_phase","phase":"tool"}
+{"type":"cli_tool","action":"started","step":1,"tool_name":"read_file","tool_call_id":"call_1","status":"running"}
+{"type":"tool_call","tool_calls":[{"id":"call_1","function":{"name":"read_file","arguments":"{\"path\":\"README.md\"}"}}],"content":"running read_file"}
+{"type":"tool_result","role":"tool","tool_call_id":"call_1","metadata":{"tool_name":"read_file"},"content":"completed read_file"}
+{"type":"cli_tool","action":"finished","step":1,"tool_name":"read_file","tool_call_id":"call_1","status":"completed"}
+{"type":"cli_phase","phase":"assistant_text"}
+{"type":"assistant","role":"assistant","content":"Here is the answer."}
+{"type":"stream_end"}
+{"type":"cli_stats","elapsed_seconds":1.25,"first_output_seconds":0.18,"prompt_tokens":10,"completion_tokens":20,"total_tokens":30,"tool_steps":[{"step":1,"tool_name":"read_file","tool_call_id":"call_1","status":"completed","started_at":10.0,"finished_at":10.12,"duration_ms":120.0}],"phase_timings":[{"phase":"planning","started_at":9.8,"finished_at":10.0,"duration_ms":200.0,"segment_count":1},{"phase":"tool","started_at":10.0,"finished_at":10.12,"duration_ms":120.0,"segment_count":1},{"phase":"assistant_text","started_at":10.12,"finished_at":10.3,"duration_ms":180.0,"segment_count":1}]}

--- a/tests/app/cli/test_json_contracts.py
+++ b/tests/app/cli/test_json_contracts.py
@@ -2,6 +2,7 @@
 import asyncio
 import io
 import json
+from pathlib import Path
 import unittest
 from contextlib import redirect_stdout
 from unittest.mock import patch
@@ -11,6 +12,28 @@ import app.cli.service as cli_service
 
 
 class TestCliJsonContracts(unittest.TestCase):
+    def test_stream_contract_fixture_uses_supported_event_types(self):
+        fixture_path = (
+            Path(__file__).resolve().parent / "fixtures" / "stream_contract_round_trip.jsonl"
+        )
+        events = [
+            json.loads(line)
+            for line in fixture_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
+        self.assertEqual(events[0], {"type": "cli_phase", "phase": "planning"})
+        self.assertEqual(events[1]["type"], "analysis")
+        self.assertEqual(events[2], {"type": "cli_phase", "phase": "tool"})
+        self.assertEqual(events[3]["type"], "cli_tool")
+        self.assertEqual(events[3]["action"], "started")
+        self.assertEqual(events[6]["type"], "cli_tool")
+        self.assertEqual(events[6]["action"], "finished")
+        self.assertEqual(events[7], {"type": "cli_phase", "phase": "assistant_text"})
+        self.assertEqual(events[-1]["type"], "cli_stats")
+        self.assertEqual(events[-1]["tool_steps"][0]["tool_name"], "read_file")
+        self.assertEqual(events[-1]["phase_timings"][0]["phase"], "planning")
+
     def test_doctor_command_json_outputs_structured_payload(self):
         args = cli_main.build_argument_parser().parse_args(["doctor", "--json"])
         fake_info = {

--- a/tests/app/cli/test_stats_tool_detection.py
+++ b/tests/app/cli/test_stats_tool_detection.py
@@ -13,6 +13,7 @@ from app.cli.main import (
     _emit_stream_idle_notice_for_state,
     _empty_render_state,
     _empty_stats,
+    _finalize_stats,
     _stream_request,
     _print_plain_event,
     _record_stats_event,
@@ -77,6 +78,218 @@ class TestStatsToolDetection(unittest.TestCase):
         _record_stats_event(stats, second_event, 0.0)
 
         self.assertEqual(stats["tools"], ["search_memory"])
+
+    def test_records_structured_tool_steps_from_tool_events(self):
+        stats = _empty_stats(
+            request=type(
+                "Request",
+                (),
+                {
+                    "session_id": None,
+                    "user_id": None,
+                    "agent_id": None,
+                    "agent_mode": "simple",
+                    "available_skills": [],
+                    "max_loop_count": 50,
+                },
+            )(),
+            workspace=None,
+        )
+
+        _record_stats_event(
+            stats,
+            {
+                "type": "tool_call",
+                "timestamp": 10.0,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": "{\"path\":\"/tmp/demo.txt\"}",
+                        },
+                    }
+                ],
+            },
+            0.0,
+        )
+        _record_stats_event(
+            stats,
+            {
+                "type": "tool_result",
+                "role": "tool",
+                "timestamp": 10.12,
+                "tool_call_id": "call_1",
+                "metadata": {"tool_name": "read_file"},
+            },
+            0.0,
+        )
+
+        self.assertEqual(len(stats["tool_steps"]), 1)
+        self.assertEqual(stats["tool_steps"][0]["step"], 1)
+        self.assertEqual(stats["tool_steps"][0]["tool_name"], "read_file")
+        self.assertEqual(stats["tool_steps"][0]["status"], "completed")
+        self.assertEqual(stats["tool_steps"][0]["started_at"], 10.0)
+        self.assertEqual(stats["tool_steps"][0]["finished_at"], 10.12)
+        self.assertAlmostEqual(stats["tool_steps"][0]["duration_ms"], 120.0)
+
+    def test_token_usage_tool_steps_override_local_inference(self):
+        stats = _empty_stats(
+            request=type(
+                "Request",
+                (),
+                {
+                    "session_id": None,
+                    "user_id": None,
+                    "agent_id": None,
+                    "agent_mode": "simple",
+                    "available_skills": [],
+                    "max_loop_count": 50,
+                },
+            )(),
+            workspace=None,
+        )
+
+        _record_stats_event(
+            stats,
+            {
+                "type": "tool_call",
+                "timestamp": 10.0,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    }
+                ],
+            },
+            0.0,
+        )
+        _record_stats_event(
+            stats,
+            {
+                "type": "token_usage",
+                "metadata": {
+                    "token_usage": {
+                        "total_info": {
+                            "prompt_tokens": 10,
+                            "completion_tokens": 20,
+                            "total_tokens": 30,
+                        }
+                    },
+                    "tool_steps": [
+                        {
+                            "step": 7,
+                            "tool_name": "grep",
+                            "tool_call_id": "call_7",
+                            "status": "completed",
+                            "started_at": 11.0,
+                            "finished_at": 11.08,
+                            "duration_ms": 80.0,
+                        }
+                    ],
+                },
+            },
+            0.0,
+        )
+
+        self.assertEqual(stats["prompt_tokens"], 10)
+        self.assertEqual(stats["completion_tokens"], 20)
+        self.assertEqual(stats["total_tokens"], 30)
+        self.assertEqual(stats["tool_steps"][0]["step"], 7)
+        self.assertEqual(stats["tool_steps"][0]["tool_name"], "grep")
+
+    def test_records_phase_timings_across_planning_tool_and_assistant_output(self):
+        stats = _empty_stats(
+            request=type(
+                "Request",
+                (),
+                {
+                    "session_id": None,
+                    "user_id": None,
+                    "agent_id": None,
+                    "agent_mode": "simple",
+                    "available_skills": [],
+                    "max_loop_count": 50,
+                },
+            )(),
+            workspace=None,
+        )
+
+        _record_stats_event(
+            stats,
+            {"type": "analysis", "role": "assistant", "content": "先分析一下。", "timestamp": 10.0},
+            0.0,
+        )
+        _record_stats_event(
+            stats,
+            {
+                "type": "tool_call",
+                "timestamp": 10.3,
+                "tool_calls": [{"id": "call_1", "function": {"name": "read_file", "arguments": "{}"}}],
+            },
+            0.0,
+        )
+        _record_stats_event(
+            stats,
+            {"type": "text", "role": "assistant", "content": "处理完成。", "timestamp": 11.1},
+            0.0,
+        )
+        _finalize_stats(stats, finished_at=11.5)
+
+        self.assertEqual([item["phase"] for item in stats["phase_timings"]], [
+            "planning",
+            "tool",
+            "assistant_text",
+        ])
+        self.assertAlmostEqual(stats["phase_timings"][0]["duration_ms"], 300.0)
+        self.assertAlmostEqual(stats["phase_timings"][1]["duration_ms"], 800.0)
+        self.assertAlmostEqual(stats["phase_timings"][2]["duration_ms"], 400.0)
+
+    def test_token_usage_phase_timings_override_local_inference(self):
+        stats = _empty_stats(
+            request=type(
+                "Request",
+                (),
+                {
+                    "session_id": None,
+                    "user_id": None,
+                    "agent_id": None,
+                    "agent_mode": "simple",
+                    "available_skills": [],
+                    "max_loop_count": 50,
+                },
+            )(),
+            workspace=None,
+        )
+
+        _record_stats_event(
+            stats,
+            {"type": "analysis", "role": "assistant", "content": "先分析一下。", "timestamp": 10.0},
+            0.0,
+        )
+        _record_stats_event(
+            stats,
+            {
+                "type": "token_usage",
+                "metadata": {
+                    "phase_timings": [
+                        {
+                            "phase": "planning",
+                            "started_at": 9.9,
+                            "finished_at": 10.6,
+                            "duration_ms": 700.0,
+                            "segment_count": 1,
+                        }
+                    ]
+                },
+            },
+            0.0,
+        )
+        _finalize_stats(stats, finished_at=11.0)
+
+        self.assertEqual(len(stats["phase_timings"]), 1)
+        self.assertEqual(stats["phase_timings"][0]["phase"], "planning")
+        self.assertEqual(stats["phase_timings"][0]["duration_ms"], 700.0)
 
     def test_render_assistant_content_hides_split_skill_markup(self):
         render_state = _empty_render_state()
@@ -278,6 +491,127 @@ class TestStreamRequestIdlePolling(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result, 0)
         self.assertIn("hello", stdout.getvalue())
+
+    async def test_stream_request_emits_cli_phase_events_in_json_mode(self):
+        async def fake_run_request_stream(_request, workspace=None):
+            del workspace
+            yield {
+                "type": "analysis",
+                "role": "assistant",
+                "content": "先分析一下",
+            }
+            yield {
+                "type": "assistant",
+                "role": "assistant",
+                "content": "开始回答",
+            }
+            yield {
+                "type": "stream_end",
+            }
+
+        request = type(
+            "Request",
+            (),
+            {
+                "session_id": "session-test",
+                "user_id": "user-test",
+                "agent_id": None,
+                "agent_mode": "simple",
+                "available_skills": [],
+                "max_loop_count": 50,
+            },
+        )()
+
+        from io import StringIO
+        import json
+
+        stdout = StringIO()
+        stderr = StringIO()
+        with (
+            patch("app.cli.service.run_request_stream", fake_run_request_stream),
+            patch("sys.stdout", stdout),
+            patch("sys.stderr", stderr),
+        ):
+            result = await _stream_request(request, json_output=True, stats_output=False, workspace=None)
+
+        self.assertEqual(result, 0)
+        events = [json.loads(line) for line in stdout.getvalue().splitlines() if line.strip()]
+        self.assertEqual(events[0], {"type": "cli_phase", "phase": "planning"})
+        self.assertEqual(events[1]["type"], "analysis")
+        self.assertEqual(events[2], {"type": "cli_phase", "phase": "assistant_text"})
+        self.assertEqual(events[3]["type"], "assistant")
+
+    async def test_stream_request_emits_cli_tool_events_in_json_mode(self):
+        async def fake_run_request_stream(_request, workspace=None):
+            del workspace
+            yield {
+                "type": "tool_call",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    }
+                ],
+            }
+            yield {
+                "type": "tool_result",
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "metadata": {"tool_name": "read_file"},
+            }
+            yield {
+                "type": "stream_end",
+            }
+
+        request = type(
+            "Request",
+            (),
+            {
+                "session_id": "session-test",
+                "user_id": "user-test",
+                "agent_id": None,
+                "agent_mode": "simple",
+                "available_skills": [],
+                "max_loop_count": 50,
+            },
+        )()
+
+        from io import StringIO
+        import json
+
+        stdout = StringIO()
+        stderr = StringIO()
+        with (
+            patch("app.cli.service.run_request_stream", fake_run_request_stream),
+            patch("sys.stdout", stdout),
+            patch("sys.stderr", stderr),
+        ):
+            result = await _stream_request(request, json_output=True, stats_output=False, workspace=None)
+
+        self.assertEqual(result, 0)
+        events = [json.loads(line) for line in stdout.getvalue().splitlines() if line.strip()]
+        cli_tool_events = [event for event in events if event.get("type") == "cli_tool"]
+        self.assertEqual(
+            cli_tool_events,
+            [
+                {
+                    "type": "cli_tool",
+                    "action": "started",
+                    "step": 1,
+                    "tool_name": "read_file",
+                    "tool_call_id": "call_1",
+                    "status": "running",
+                },
+                {
+                    "type": "cli_tool",
+                    "action": "finished",
+                    "step": 1,
+                    "tool_name": "read_file",
+                    "tool_call_id": "call_1",
+                    "status": "completed",
+                },
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/sagents/context/test_tool_step_summary.py
+++ b/tests/sagents/context/test_tool_step_summary.py
@@ -1,0 +1,126 @@
+from sagents.context.messages.message import MessageChunk
+from sagents.context.session_context import SessionContext
+
+
+def _make_session(tmp_path):
+    return SessionContext(
+        session_id="sess_tool_steps",
+        user_id="u1",
+        agent_id="a1",
+        session_root_space=str(tmp_path),
+    )
+
+
+def test_build_tool_step_summary_pairs_tool_call_and_result(tmp_path):
+    ctx = _make_session(tmp_path)
+    assistant = MessageChunk(
+        role="assistant",
+        content="",
+        tool_calls=[
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "{\"path\":\"a.txt\"}"},
+            }
+        ],
+        message_id="assistant-tool-call",
+        message_type="tool_call",
+    )
+    tool = MessageChunk(
+        role="tool",
+        content="ok",
+        tool_call_id="call_1",
+        message_id="tool-result",
+        message_type="tool_call_result",
+    )
+    ctx.message_manager.messages = [assistant, tool]
+    ctx._message_timing = {
+        "assistant-tool-call": {
+            "message_id": "assistant-tool-call",
+            "start_ts": 10.0,
+            "end_ts": 10.1,
+        },
+        "tool-result": {
+            "message_id": "tool-result",
+            "start_ts": 10.2,
+            "end_ts": 10.6,
+        },
+    }
+
+    steps = ctx._build_tool_step_summary()
+
+    assert len(steps) == 1
+    assert steps[0]["step"] == 1
+    assert steps[0]["tool_name"] == "read_file"
+    assert steps[0]["tool_call_id"] == "call_1"
+    assert steps[0]["status"] == "completed"
+    assert steps[0]["started_at"] == 10.0
+    assert steps[0]["finished_at"] == 10.6
+    assert steps[0]["duration_ms"] == 600.0
+
+
+def test_build_phase_timing_summary_aggregates_segments(tmp_path):
+    ctx = _make_session(tmp_path)
+    ctx.execution_timeline_events = [
+        {
+            "event_type": "agent_phase_start",
+            "phase_name": "planning",
+            "timestamp": 10.0,
+            "perf_ms": 100.0,
+        },
+        {
+            "event_type": "agent_phase_end",
+            "phase_name": "planning",
+            "timestamp": 10.3,
+            "perf_ms": 400.0,
+        },
+        {
+            "event_type": "agent_phase_start",
+            "phase_name": "tool",
+            "timestamp": 10.5,
+            "perf_ms": 500.0,
+        },
+        {
+            "event_type": "agent_phase_end",
+            "phase_name": "tool",
+            "timestamp": 11.0,
+            "perf_ms": 1000.0,
+        },
+        {
+            "event_type": "agent_phase_start",
+            "phase_name": "assistant_text",
+            "timestamp": 11.1,
+            "perf_ms": 1100.0,
+        },
+        {
+            "event_type": "agent_phase_end",
+            "phase_name": "assistant_text",
+            "timestamp": 11.3,
+            "perf_ms": 1300.0,
+        },
+        {
+            "event_type": "agent_phase_start",
+            "phase_name": "assistant_text",
+            "timestamp": 11.4,
+            "perf_ms": 1400.0,
+        },
+        {
+            "event_type": "agent_phase_end",
+            "phase_name": "assistant_text",
+            "timestamp": 11.6,
+            "perf_ms": 1600.0,
+        },
+    ]
+
+    phases = ctx._build_phase_timing_summary()
+
+    assert [item["phase"] for item in phases] == ["planning", "tool", "assistant_text"]
+    assert phases[0]["started_at"] == 10.0
+    assert phases[0]["finished_at"] == 10.3
+    assert phases[0]["duration_ms"] == 300.0
+    assert phases[0]["segment_count"] == 1
+    assert phases[1]["duration_ms"] == 500.0
+    assert phases[2]["started_at"] == 11.1
+    assert phases[2]["finished_at"] == 11.6
+    assert phases[2]["duration_ms"] == 400.0
+    assert phases[2]["segment_count"] == 2


### PR DESCRIPTION
## Summary
  - position sage-terminal as a thinner TUI over the Sage CLI/runtime boundary
  - add agent selection flows in terminal and connect them to CLI/backend contracts
  - formalize streamed CLI events for phase/tool updates and final stats summaries

  ## What Changed
  - add terminal agent selection support including startup flags, slash commands, listing, and picker flows
  - extend CLI JSON streaming with cli_phase, cli_tool, and richer cli_stats payloads
  - propagate runtime-owned tool_steps and phase_timings through sagents -> CLI -> terminal
  - update terminal transcript/footer rendering to consume structured execution contracts
  - add fixture, protocol, transcript, UI, and CLI/runtime regression coverage
  - refresh CLI/TUI docs to describe the stream contract

  ## Validation
  - pytest -q tests/app/cli/test_json_contracts.py tests/app/cli/test_stats_tool_detection.py tests/sagents/context/test_tool_step_summary.py
  - cargo test backend::tests::contract --quiet
  - cargo test app::tests::transcript --quiet
  - cargo test ui::tests --quiet
  - cargo test backend::tests::handle --quiet
  - python3 -m py_compile app/cli/main.py sagents/context/session_context.py sagents/session_runtime.py