### PR TITLE
Add server web tool progress streaming

### DIFF
--- a/app/server/web/src/components/chat/workbench/renderers/ToolCallRenderer.vue
+++ b/app/server/web/src/components/chat/workbench/renderers/ToolCallRenderer.vue
@@ -74,6 +74,9 @@
         <ShellCommandToolRenderer
           :tool-args="toolArgs"
           :tool-result="toolResult"
+          :live-output="item?.liveOutput || ''"
+          :live-segments="item?.liveSegments || []"
+          :live="item?.live === true"
         />
       </template>
 

--- a/app/server/web/src/components/chat/workbench/renderers/toolcall/ShellCommandToolRenderer.vue
+++ b/app/server/web/src/components/chat/workbench/renderers/toolcall/ShellCommandToolRenderer.vue
@@ -1,46 +1,127 @@
 <template>
-  <div class="shell-container bg-black text-green-400 font-mono text-sm p-4 h-full overflow-auto">
-    <div class="shell-header text-gray-500 mb-2">$ {{ shellCommand }}</div>
-    <div v-if="shellOutput" class="shell-output whitespace-pre-wrap break-all">{{ shellOutput }}</div>
-    <div v-if="shellError" class="shell-error text-red-400 mt-2 whitespace-pre-wrap break-all">{{ shellError }}</div>
+  <div class="shell-container bg-black text-green-400 font-mono text-sm p-4 h-full overflow-auto" ref="scrollEl">
+    <div class="shell-header text-gray-500 mb-2 flex items-center gap-2">
+      <span class="select-all">$ {{ shellCommand }}</span>
+      <span
+        v-if="showLiveBadge"
+        class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] uppercase tracking-wide bg-emerald-900/40 text-emerald-300 border border-emerald-700/50"
+      >
+        <span class="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
+        live
+      </span>
+    </div>
+
+    <!-- 实时输出区域：命令尚未结束时优先展示 progress 通道增量 -->
+    <template v-if="hasLiveSegments && !hasFinalResult">
+      <div
+        v-for="(seg, idx) in liveSegments"
+        :key="idx"
+        :class="[
+          'whitespace-pre-wrap break-all',
+          seg.stream === 'stderr' ? 'text-red-400' : 'text-green-400',
+        ]"
+      >{{ seg.text }}</div>
+    </template>
+
+    <!-- 命令完成后展示最终 stdout / stderr（来自 tool message 的完整结果） -->
+    <template v-else>
+      <div v-if="shellOutput" class="shell-output whitespace-pre-wrap break-all">{{ shellOutput }}</div>
+      <div v-if="shellError" class="shell-error text-red-400 mt-2 whitespace-pre-wrap break-all">{{ shellError }}</div>
+    </template>
+
+    <!-- 完成后的状态行：exit_code 等 -->
+    <div
+      v-if="hasFinalResult && exitCode !== null"
+      class="mt-2 pt-2 border-t border-gray-700 text-xs"
+    >
+      <span class="text-gray-500">exit_code: </span>
+      <span :class="exitCode === 0 ? 'text-emerald-400' : 'text-red-400'">{{ exitCode }}</span>
+    </div>
   </div>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref, nextTick, watch } from 'vue'
 
 const props = defineProps({
   toolArgs: { type: Object, default: () => ({}) },
-  toolResult: { type: Object, default: null }
+  toolResult: { type: Object, default: null },
+  liveOutput: { type: String, default: '' },
+  liveSegments: { type: Array, default: () => [] },
+  live: { type: Boolean, default: false }
 })
+
+const scrollEl = ref(null)
 
 const shellCommand = computed(() => props.toolArgs.command || props.toolArgs.cmd || '')
 
-const shellOutput = computed(() => {
-  if (!props.toolResult) return ''
-  const content = props.toolResult.content
+const hasFinalResult = computed(() => !!props.toolResult)
+const hasLiveSegments = computed(() => Array.isArray(props.liveSegments) && props.liveSegments.length > 0)
+
+// 命令仍在运行（未拿到最终 toolResult），且 live=true（progress 流未关闭）
+const showLiveBadge = computed(() => !hasFinalResult.value && props.live)
+
+const parsedResult = computed(() => {
+  if (!props.toolResult) return null
+  let content = props.toolResult.content
   if (typeof content === 'string') {
     try {
-      const parsed = JSON.parse(content)
-      return parsed.stdout || parsed.output || content
+      return JSON.parse(content)
     } catch {
-      return content
+      return { stdout: content }
     }
   }
-  return content?.stdout || content?.output || JSON.stringify(content)
+  return content || null
+})
+
+const shellOutput = computed(() => {
+  const r = parsedResult.value
+  if (!r) return ''
+  return r.stdout || r.output || (typeof r === 'string' ? r : '')
 })
 
 const shellError = computed(() => {
-  if (!props.toolResult) return ''
-  const content = props.toolResult.content
-  if (typeof content === 'string') {
-    try {
-      const parsed = JSON.parse(content)
-      return parsed.stderr || parsed.error || ''
-    } catch {
-      return ''
-    }
-  }
-  return content?.stderr || content?.error || ''
+  const r = parsedResult.value
+  if (!r) return ''
+  return r.stderr || r.error || ''
 })
+
+const exitCode = computed(() => {
+  const r = parsedResult.value
+  if (!r || typeof r !== 'object') return null
+  if (typeof r.exit_code === 'number') return r.exit_code
+  if (typeof r.return_code === 'number') return r.return_code
+  return null
+})
+
+// 自动滚到底部：仅在用户当前已贴底时执行，避免抢占用户向上滚动查看历史的操作
+const _isStickyBottom = () => {
+  const el = scrollEl.value
+  if (!el) return true
+  return el.scrollHeight - el.scrollTop - el.clientHeight < 32
+}
+
+const scrollToBottomSoon = () => {
+  nextTick(() => {
+    const el = scrollEl.value
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+  })
+}
+
+// 实时段累积时自动滚动
+watch(
+  () => (props.liveSegments || []).length,
+  () => {
+    if (_isStickyBottom()) scrollToBottomSoon()
+  }
+)
+
+// 最终结果到达时再滚一次
+watch(
+  () => props.toolResult,
+  () => {
+    if (_isStickyBottom()) scrollToBottomSoon()
+  }
+)
 </script>

--- a/app/server/web/src/composables/chat/useChatPage.js
+++ b/app/server/web/src/composables/chat/useChatPage.js
@@ -398,6 +398,21 @@ export const useChatPage = (props) => {
 
   const handleMessage = (messageData) => {
     if (messageData.type === 'stream_end') return
+    if (messageData.type === 'tool_progress') {
+      // 工具执行过程实时片段：不进 messages 列表、不进历史，仅追加到对应 tool 卡片的 live area
+      try {
+        workbenchStore.appendToolProgress({
+          toolCallId: messageData.tool_call_id,
+          text: messageData.text,
+          stream: messageData.stream,
+          closed: !!messageData.closed,
+          ts: messageData.ts
+        })
+      } catch (e) {
+        console.warn('[Chat] handle tool_progress failed:', e)
+      }
+      return
+    }
     const messageId = messageData.message_id
     const extractWorkbenchFromMessage = (message) => {
       if (!message) return

--- a/app/server/web/src/stores/workbench.js
+++ b/app/server/web/src/stores/workbench.js
@@ -227,6 +227,20 @@ export const useWorkbenchStore = defineStore('workbench', () => {
       console.log('[Workbench] Auto-jump to index:', currentIndex.value)
     }
 
+    // tool_call item 落地后，把可能先到的 progress 缓存灌进去
+    if (newItem.type === 'tool_call') {
+      const tcId = newItem.data?.id || newItem.data?.tool_call_id
+      if (tcId && pendingToolProgress.value.has(tcId)) {
+        const buf = pendingToolProgress.value.get(tcId)
+        pendingToolProgress.value.delete(tcId)
+        if (buf.liveOutput) {
+          newItem.liveOutput = buf.liveOutput
+          newItem.liveSegments = buf.liveSegments
+        }
+        newItem.live = buf.live
+      }
+    }
+
     return newItem
   }
 
@@ -456,6 +470,60 @@ export const useWorkbenchStore = defineStore('workbench', () => {
     }
   }
 
+  // tool_call_id 还没匹配到 workbench item 时缓存的 progress 文本
+  // 一旦对应的 tool_call item 被 addItem 创建，flushPendingToolProgress 会把缓存灌进去
+  const pendingToolProgress = ref(new Map())
+
+  // 从工具实时执行通道追加增量文本（stdout/stderr）。
+  // - 同一 tool_call_id 的所有 progress 累加到 item.liveOutput；
+  // - 按 stream 字段保留分段信息以便前端按通道渲染（item.liveSegments）；
+  // - closed=true 表示该 tool 的 progress 流结束，前端可收起 spinner。
+  // 不影响 item.toolResult（最终工具结果由现有 updateToolResult 写入）。
+  const appendToolProgress = ({ toolCallId, text = '', stream = 'stdout', closed = false, ts = null }) => {
+    if (!toolCallId) return false
+    const item = items.value.find(i =>
+      i.type === 'tool_call' && (i.data.id === toolCallId || i.data.tool_call_id === toolCallId)
+    )
+    if (!item) {
+      // 工具卡片还没创建（极少数情况：progress 事件先于 tool_call 消息到达）
+      const buf = pendingToolProgress.value.get(toolCallId) || { liveOutput: '', liveSegments: [], live: true }
+      if (text) {
+        buf.liveOutput += text
+        buf.liveSegments.push({ stream, text, ts })
+      }
+      if (closed) buf.live = false
+      pendingToolProgress.value.set(toolCallId, buf)
+      return false
+    }
+    if (text) {
+      item.liveOutput = (item.liveOutput || '') + text
+      if (!Array.isArray(item.liveSegments)) item.liveSegments = []
+      item.liveSegments.push({ stream, text, ts })
+    }
+    if (closed) {
+      item.live = false
+    } else {
+      item.live = true
+    }
+    return true
+  }
+
+  const flushPendingToolProgress = (toolCallId) => {
+    const buf = pendingToolProgress.value.get(toolCallId)
+    if (!buf) return
+    pendingToolProgress.value.delete(toolCallId)
+    const item = items.value.find(i =>
+      i.type === 'tool_call' && (i.data.id === toolCallId || i.data.tool_call_id === toolCallId)
+    )
+    if (!item) return
+    if (buf.liveOutput) {
+      item.liveOutput = (item.liveOutput || '') + buf.liveOutput
+      if (!Array.isArray(item.liveSegments)) item.liveSegments = []
+      item.liveSegments.push(...buf.liveSegments)
+    }
+    item.live = buf.live
+  }
+
   return {
     // State
     items,
@@ -486,7 +554,10 @@ export const useWorkbenchStore = defineStore('workbench', () => {
     toggleListView,
     setListView,
     extractFromMessage,
-    updateToolResult
+    updateToolResult,
+    appendToolProgress,
+    flushPendingToolProgress,
+    pendingToolProgress
   }
 })
 

--- a/change_log.md
+++ b/change_log.md
@@ -1,3 +1,7 @@
+2026-04-29 21:00 tool_progress 节流：emit_tool_progress 默认按 (tool_call_id, stream) 做 50ms 时间窗 / 16KB 字节阈值合并；closed 与 unregister 强制 flush / cancel pending；新增 5 条合并单测，全套 23/23 绿；docs ENV_VARS + 架构 §12 同步。
+
+2026-04-28 19:30 工具流式过程通道（v4 · Codex 风格）：新增 sagents/tool/tool_progress.py 与 emit_tool_progress；AgentBase._execute_tool 用 contextvars 绑定 session_id/tool_call_id；ChatService 在 NDJSON 通道并入新事件 type=tool_progress；execute_shell_command 阻塞等待时按 tail 增量推送 stdout/stderr；前端 useChatPage 识别后追加到 ToolCallRenderer 的 live area；不进 MessageManager / 不喂 LLM；总开关 SAGE_TOOL_PROGRESS_ENABLED；新增 18 条单测全绿。
+
 2026-04-29 SimpleAgent tool_choice=required 改为环境变量 SAGE_FORCE_TOOL_CHOICE_REQUIRED 控制（默认关闭，避免不支持的模型报错），调用方传入参数仍优先生效。
 
 2026-04-29 server web ModelProviderList 与 desktop 对齐：采样参数（temperature/top_p/presence_penalty/max_tokens/max_model_len）默认 null，提交走 optionalNumber 显式 null 下发；后端 sanitize_model_request_kwargs 会丢弃 None 字段，OpenAI SDK 不会收到空值。
@@ -38,7 +42,7 @@
 
 2026-04-27 23:05 shell tool GC + reminder 优化：system_reminder tail 截至 512B 尾部优先 + 提示调 await_shell 拿完整结果；pop_completion_events 不删 _BG_TASKS；加 12h 超期 GC（每次 spawn 触发）；补测试 11 项全绿。
 
-2026-04-27 22:15 shell 工具反轮询优化：execute_command_tool 加后台 completion watcher 与 session 级事件字典；_call_llm_streaming 每次请求前 flush 为 <system_reminder> 注入；await_shell 默认 600s + 自适应改写 + 元数据；统一 system prompt 加 reminder 语义说明；新增单元测试。
+2026-04-27 22:15 shell 工具反轮询优化：execute_command_tool 加后台 completion watcher 与 session 级事件字典；_call_llm_streaming 每次请求前 flush 为  注入；await_shell 默认 600s + 自适应改写 + 元数据；统一 system prompt 加 reminder 语义说明；新增单元测试。
 
 2026-04-27 20:05 turn_status 上下文裁剪策略升级 + reasoning_effort 修正：strip_turn_status_from_llm_context 新增"保留最后一条 turn_status pair"，避免模型看不到自己上一轮状态决策反复重刷；新增白名单式 is_openai_reasoning_model 替换 agent_base 宽匹配（不再误伤 gpt-4o 等）；抽出 resolve_reasoning_effort，思考关闭时默认仍 low，新增 SAGE_REASONING_EFFORT_OFF 环境变量按需切 minimal/medium/high；补 strip 与 reasoning 判定/effort 单测。
 
@@ -54,7 +58,7 @@
 
 2026-04-27 18:30 turn_status reject 让模型可见：SimpleAgent 拒绝时给 tool 结果打 metadata.turn_status_rejected=True；strip_turn_status_from_llm_context 按标记保留这对 pair（含同条 assistant 里的 turn_status tool_call），SSE 仍按 tool_call_id 隐藏。修复 reject 后模型上下文丢失反馈、反复重蹈覆辙的问题。补 4 条单测。
 
-2026-04-27 18:05 隐藏工具过滤抽常量 + 续片鲁棒性：HIDDEN_FROM_STREAM_TOOL_NAMES 移到 sagents/tool/impl/__init__.py；helper 重命名 _redact_hidden_tools_from_chunk 并改用 _HiddenToolStreamState（新增 last_was_hidden 贪心续接，覆盖 id/index 都缺失的兼容场景）；补两条续片单测。
+2026-04-27 18:05 隐藏工具过滤抽常量 + 续片鲁棒性：HIDDEN_FROM_STREAM_TOOL_NAMES 移到 sagents/tool/impl/**init**.py；helper 重命名 _redact_hidden_tools_from_chunk 并改用 _HiddenToolStreamState（新增 last_was_hidden 贪心续接，覆盖 id/index 都缺失的兼容场景）；补两条续片单测。
 
 2026-04-27 17:55 SAgent.run_stream 出口最小过滤 turn_status：新增模块级 helper，按流局部 call_ids/index→id 状态识别 tool_call 续片与对应 tool 结果，整体丢弃；落盘与 LLM 上下文剔除均不变。
 
@@ -68,7 +72,7 @@
 
 2026-04-28 22:30 修复 CommonAgent.process_tool_response 重写未跟随 agent_base 新签名（tool_name 第 3 参），导致 _execute_tool 调用时 TypeError，工具结果走错误分支被吞，前端文字之后第一个非 turn_status 工具结果消失；同时把 metadata.tool_name 写入 CommonAgent 的工具结果，前端兜底过滤一致。
 
-2026-04-28 22:15 MessageChunk.__post_init__：将 role 规范为字符串；修复传入 MessageRole 枚举时 redact/校验与 ".value" 比较不命中导致 turn_status 泄漏。成功体启发式对 content 先 strip 再 json.loads。
+2026-04-28 22:15 MessageChunk.**post_init**：将 role 规范为字符串；修复传入 MessageRole 枚举时 redact/校验与 ".value" 比较不命中导致 turn_status 泄漏。成功体启发式对 content 先 strip 再 json.loads。
 
 2026-04-28 22:00 SSE redact：tool 块 metadata.tool_name=turn_status 一律不下发；单测覆盖。workbench 防误写保留兜底。
 
@@ -124,11 +128,11 @@
 
 2026-04-27 12:25 修复 AnyTool MCP 502：DB 等存储的 streamable_http_url 残留旧端口与 SAGE_PORT 不一致时，mcp_service 对 kind=anytool 按 _get_backend_port 重写 URL。
 
-2026-04-27 12:05 修复桌面端打包后 fetch 报 CORS：为 Tauri 源增加显式 allow_origins（tauri://localhost、http/https://tauri.localhost）与锚定 fullmatch 正则；main 设置 SAGE_INTERNAL_DESKTOP_PROCESS=1 防止误走 server 空 CORS； abilities 等接口若仍 500 可在修复 CORS 后从响应体看到真实错误。
+2026-04-27 12:05 修复桌面端打包后 fetch 报 CORS：为 Tauri 源增加显式 allow_origins（tauri://localhost、http/[https://tauri.localhost）与锚定](https://tauri.localhost）与锚定) fullmatch 正则；main 设置 SAGE_INTERNAL_DESKTOP_PROCESS=1 防止误走 server 空 CORS； abilities 等接口若仍 500 可在修复 CORS 后从响应体看到真实错误。
 
 2026-04-26 23:50 桌面端构建优化两项：(1) PyInstaller 配置统一到 sage-desktop.spec，build.sh 不再传一长串 flags，仅通过 SAGE_PYI_MODE 控制 strip；(2) CSP 收紧，default-src 'self'、script-src 仅 'self'（彻底禁止 inline script），style-src 保留 'unsafe-inline' 兼容 radix-vue 运行时样式，显式声明 img/media/font/connect/worker/object/base-uri/frame-ancestors。
 
-2026-04-26 23:30 修复桌面端打包后白色滚动条问题：根因是 Tauri CSP 未含 'unsafe-inline'，拦截了 radix-vue 运行时注入的隐藏原生滚动条 <style>，导致 macOS native overlay scrollbar 漏出。index.css 显式声明 [data-radix-scroll-area-viewport] 隐藏原生滚动条规则；tauri.conf.json CSP 增加 style-src 'unsafe-inline' 与 img-src/media-src 放行 asset/blob/data。
+2026-04-26 23:30 修复桌面端打包后白色滚动条问题：根因是 Tauri CSP 未含 'unsafe-inline'，拦截了 radix-vue 运行时注入的隐藏原生滚动条 ，导致 macOS native overlay scrollbar 漏出。index.css 显式声明 [data-radix-scroll-area-viewport] 隐藏原生滚动条规则；tauri.conf.json CSP 增加 style-src 'unsafe-inline' 与 img-src/media-src 放行 asset/blob/data。
 
 2026-04-26 22:55 桌面端切断对 server/web 的跨项目引用：McpServerAdd/AnyToolToolEditor 直接复制源码至 desktop，并新建 AnyToolSchemaFieldEditor，导入路径全部改为 @/ 别名；移除 vite.config 的 lucide-vue-next/pinia alias 与 tailwind.config 中 server/web 内容路径；build.sh 增加 --collect-submodules=sagents 修复 PyInstaller 漏打包基础工具。
 
@@ -266,7 +270,7 @@
 
 2026-04-21 22:30 修复 sage 上传图片两个问题：1) 输入框 markdown alt 与最终 URL 文件名不一致（原 png/被压成 jpg + 时间戳后缀）——oss.uploadFile 改返回 {url, filename}，MessageInput/ChipInput 在上传完成后用服务端文件名刷新 chip 与 file.name，buildOrderedMultimodalContent 直接取 URL 末段作为 alt，desktop+server-web 同步；2) image_url 没转 base64 导致 dashscope 报 InvalidParameter——multimodal_image.process_multimodal_content 增加本机地址 HTTP 抓取兜底（httpx 已在 requirements），Path.home 反解失败时再走 GET URL→压缩→data:image/jpeg;base64 分支，加 warning/error 日志便于排查。
 
-2026-04-21 21:30 server 端登录页：当 allow_registration=false 时新增显眼提示——告知当前网页不允许创建新用户，推荐下载桌面版 https://zavixai.com/html/sage.html，或自行从 GitHub 部署 Web 版，并附微信联系方式 cfyz0814 / zhangzheng-thu。新增 zh/en 文案和 2 条 Login 单测，全部通过。
+2026-04-21 21:30 server 端登录页：当 allow_registration=false 时新增显眼提示——告知当前网页不允许创建新用户，推荐下载桌面版 [https://zavixai.com/html/sage.html，或自行从](https://zavixai.com/html/sage.html，或自行从) GitHub 部署 Web 版，并附微信联系方式 cfyz0814 / zhangzheng-thu。新增 zh/en 文案和 2 条 Login 单测，全部通过。
 
 2026-04-21 17:10 限制 Fibre 专属工具仅在 fibre 模式下可选：AgentEdit.vue 增加 isFibreOnlyToolUnavailable，非 fibre 模式下 sys_spawn_agent / sys_delegate_task / sys_finish_task 复选框禁用并打「仅 Fibre 模式」徽章 + 提示；模式切出 fibre 时自动从 availableTools 移除；后端 chat router 新增 _sync_fibre_only_tools 兜底，非 fibre 请求强制剔除这三个工具。
 
@@ -278,7 +282,7 @@
 
 2026-04-21 11:35 修复未装/离线浏览器扩展时仍把 12 个 browser_* 工具注入到 chat 请求的问题：browser_capability.get_browser_tool_sync_state 在扩展从未连接时把 supported_tools 默认成全集且不按 online 过滤，被 chat router 当成 online_browser_tools 全部 append。改为仅在 online 时返回 supported_tools，否则返回 [] ；_sync_browser_tools_for_request 离线时无条件清空所有浏览器工具，并补充日志便于排查。
 
-2026-04-21 11:20 修复 desktop 启动后 impl/ 下多数工具丢失问题：commit 4f9ff693 将 sagents/tool/impl/__init__.py 改为懒加载 __getattr__，导致 ToolManager.discover_tools_from_path 仅 `import sagents.tool.impl` 时不再触发子模块加载，@tool 装饰器未执行。改为默认调用 _discover_import_path 扫描 impl 目录，工具注册数从个位数恢复到 19。
+2026-04-21 11:20 修复 desktop 启动后 impl/ 下多数工具丢失问题：commit 4f9ff693 将 sagents/tool/impl/**init**.py 改为懒加载 **getattr**，导致 ToolManager.discover_tools_from_path 仅 `import sagents.tool.impl` 时不再触发子模块加载，@tool 装饰器未执行。改为默认调用 _discover_import_path 扫描 impl 目录，工具注册数从个位数恢复到 19。
 
 2026-04-21 文档站侧边栏真正根因：`docs/_includes/components/sidebar.html` 自定义实现里对 `nav_pages` 单层 for 循环输出链接，未调用主题自带的 `components/nav/pages.html`（parent 分组 + 递归子菜单），故无论 front matter 是否正确，左侧始终为扁平列表；已改为 `where` 过滤语言后 `include components/nav/pages.html`，恢复「架构」下二级菜单。
 
@@ -298,7 +302,7 @@
 
 2026-04-18 sandbox/_stdout_echo 增加 48 条单测（test_stdout_echo.py），覆盖 echo 开关全部取值、空/None/异常 stdout 兜底、header 截断、footer 各种 rc、流式 helper 的 stdout/stderr 隔离/cwd/env/大输出/非 UTF-8/实时性断言/超时；测试中发现 timeout 路径会被持有 pipe 的子孙进程（如 sleep）阻塞 drain 线程~4s 的回归，顺手修：Popen 加 start_new_session，超时改成 killpg(SIGKILL) 干掉整个进程组，并去掉 raise 前重复的 join。
 
-2026-04-18 ExecuteCommandTool/沙箱命令实时回显：新增 sandbox/_stdout_echo（含 echo_chunk/header/footer 与 run_with_streaming_stdout helper），LocalSandboxProvider 直接路径在 read_output 里增量写 sys.stdout；Seatbelt/Bwrap parent 改用流式 helper 转发 stdout、stderr 单独捕获用于报错；launcher.py shell mode 也从 subprocess.run 换成 Popen+双线程 drain，命令 stdout 实时透传到外层；三处 isolation 始终覆盖 launcher.py 让升级生效；ExecuteCommandTool 加 $ <cmd> / ↪ rc=N 头尾分隔。受 SAGE_ECHO_SHELL_OUTPUT 控制，默认开启，0/false/no/off/空 关闭。
+2026-04-18 ExecuteCommandTool/沙箱命令实时回显：新增 sandbox/_stdout_echo（含 echo_chunk/header/footer 与 run_with_streaming_stdout helper），LocalSandboxProvider 直接路径在 read_output 里增量写 sys.stdout；Seatbelt/Bwrap parent 改用流式 helper 转发 stdout、stderr 单独捕获用于报错；launcher.py shell mode 也从 subprocess.run 换成 Popen+双线程 drain，命令 stdout 实时透传到外层；三处 isolation 始终覆盖 launcher.py 让升级生效；ExecuteCommandTool 加 $  / ↪ rc=N 头尾分隔。受 SAGE_ECHO_SHELL_OUTPUT 控制，默认开启，0/false/no/off/空 关闭。
 
 2026-04-18 放开 todo 子任务"≤10"硬上限：task_decompose_prompts 三语全删掉 10 条上限，改成按复杂度自适应（trivial 1-3 / 常规 5-15 / 复杂多阶段 15-40+），并要求带"和/然后"或跨多文件的步骤必须继续拆；同步在 todo_write 工具描述里补上同样的颗粒度指导，让不走 task_decompose 的 SimpleAgent 也能拿到信号。
 
@@ -375,7 +379,7 @@
 2026-03-06 20:30:00 完善 Orchestrator 子会话创建流程：适配 `AgentFlow` 执行简单子 Agent，修正 `_get_or_create_sub_session` 和 `delegate_task` 的调用逻辑，确保路径、上下文及 Orchestrator 引用正确传递。
 2026-03-06 20:40:00 规范化 Session 空间变量名：将 `session_space` 全局重构为 `session_root_space`，明确其作为根目录的语义，避免与具体 Session 工作区混淆。修正 Orchestrator 中的异步调用遗漏。
 2026-03-06 20:50:00 优化 Session 持久化与发现机制：SessionContext.save() 现统一保存为 `session_context.json`（包含上下文、状态、配置概要），移除旧的 agent_config/session_status 文件；SessionManager 新增 `_scan_sessions` 自动建立路径索引，实现对任意嵌套深度会话的 O(1) 访问。
-2026-03-06 21:00:00 清理旧版配置文件加载逻辑：SessionRuntime._load_saved_system_context 已完全移除对 session_status_*.json 的读取，仅支持标准的 session_context.json；SessionContext._load_persisted_messages 仅保留从 messages.json 加载消息，确保不再读取已废弃的旧格式文件。
+2026-03-06 21:00:00 清理旧版配置文件加载逻辑：SessionRuntime.*load_saved_system_context 已完全移除对 session_status**.json 的读取，仅支持标准的 session_context.json；SessionContext._load_persisted_messages 仅保留从 messages.json 加载消息，确保不再读取已废弃的旧格式文件。
 2026-03-06 21:10:00 Agent 接口全面重构：简化 `AgentBase.run_stream` 签名，移除冗余的 `tool_manager` 和 `session_id` 参数，统一通过 `SessionContext` 传递上下文。同步更新所有 Agent 实现、SessionRuntime、FlowExecutor 及 Orchestrator 中的调用逻辑。
 2026-03-06 21:30:00 适配应用层调用：更新 `sage_cli.py` 和 `app/server` 中的 `SAgent` 调用，适配新的 `session_root_space` 参数和 `run_stream` 接口；修复构建脚本 `build_simple.py` 以包含新引入的 `sagents/flow` 模块。
 2026-03-06 21:40:00 适配演示与服务层：更新 `sage_demo.py` 和 `sage_server.py` 以适配 `SAgent` 新接口，并显式配置 `app/server` 启用沙箱。重构了 `run_stream` 的调用逻辑，确保与底层的 Session 机制变更保持一致。

--- a/common/services/chat_service.py
+++ b/common/services/chat_service.py
@@ -952,6 +952,12 @@ async def execute_chat_session(
     mode: Optional[str] = None,
     **kwargs: Any,
 ):
+    from sagents.tool.tool_progress import (
+        register_progress_queue,
+        unregister_progress_queue,
+    )
+    from common.utils.stream_merge import interleave_message_and_progress
+
     session_id = stream_service.request.session_id
     request = stream_service.request
     original_skills = (
@@ -964,8 +970,14 @@ async def execute_chat_session(
     last_activity_time = time.time()
     token_usage_persisted = False
     token_usage_payload: Optional[Dict[str, Any]] = None
+
+    progress_queue: asyncio.Queue = asyncio.Queue()
+    register_progress_queue(session_id, progress_queue)
+
     try:
-        async for result in stream_service.process_stream():
+        async for kind, payload in interleave_message_and_progress(
+            stream_service.process_stream(), progress_queue
+        ):
             stream_counter += 1
             current_time = time.time()
             if stream_counter % 100 == 0:
@@ -976,6 +988,12 @@ async def execute_chat_session(
                     f"📊 流处理状态 - 计数: {stream_counter}, 间隔: {time_since_last:.3f}s"
                 )
 
+            if kind == "tool_progress":
+                # progress 事件不进 token usage、不进 MessageManager；直接下发
+                yield json.dumps(payload, ensure_ascii=False) + "\n"
+                continue
+
+            result = payload
             token_usage_payload = _extract_token_usage_payload(result) or token_usage_payload
 
             yield_result = result.copy()
@@ -1000,12 +1018,15 @@ async def execute_chat_session(
             ensure_ascii=False,
         ) + "\n"
     finally:
+        unregister_progress_queue(session_id)
         if not token_usage_persisted:
             await _persist_token_usage_if_available(
                 stream_service,
                 token_usage_payload=token_usage_payload,
             )
         await _finalize_session_end(request, original_skills)
+
+
 
 
 async def _finalize_session_end(

--- a/common/utils/stream_merge.py
+++ b/common/utils/stream_merge.py
@@ -1,0 +1,89 @@
+"""流式合并工具。
+
+把"主消息异步迭代器"与"次级事件队列"交错输出为一个统一的异步迭代器，
+用于 ``ChatService`` 把 LLM/Agent 输出的 message 流与工具的 ``tool_progress``
+事件合并到同一个 NDJSON 通道。
+
+设计要点：
+- 主消息流（``message_iter``）的结束即整个合并 generator 的结束；次级队列
+  （``progress_queue``）只是过程展示，不主导生命周期。
+- 内部用一个汇聚队列把两路转写后的事件按到达顺序串行输出；不依赖 ``cancel``
+  pending 任务，避免丢消息。
+- 主消息流抛出的异常会向上传播。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, AsyncIterator, Tuple
+
+_MERGE_SENTINEL = object()
+
+
+async def interleave_message_and_progress(
+    message_iter: AsyncIterator[Any],
+    progress_queue: asyncio.Queue,
+) -> AsyncIterator[Tuple[str, Any]]:
+    """把 message 异步迭代器与 progress 队列交错输出。
+
+    Yields:
+        ``(kind, payload)`` 二元组：
+
+        - ``kind == "message"``：来自 ``message_iter`` 的对象。
+        - ``kind == "tool_progress"``：来自 ``progress_queue`` 的事件 dict。
+
+    Raises:
+        ``message_iter`` 内部抛出的任何异常会向上传播。
+    """
+    out_queue: asyncio.Queue = asyncio.Queue()
+
+    async def _drain_messages():
+        try:
+            async for msg in message_iter:
+                await out_queue.put(("msg", msg))
+        except Exception as exc:
+            await out_queue.put(("error", exc))
+        finally:
+            await out_queue.put(("msg_end", None))
+
+    async def _drain_progress():
+        while True:
+            ev = await progress_queue.get()
+            if ev is _MERGE_SENTINEL:
+                break
+            await out_queue.put(("prog", ev))
+
+    msg_task = asyncio.create_task(_drain_messages())
+    prog_task = asyncio.create_task(_drain_progress())
+
+    try:
+        while True:
+            kind, payload = await out_queue.get()
+            if kind == "msg":
+                yield ("message", payload)
+            elif kind == "prog":
+                yield ("tool_progress", payload)
+            elif kind == "error":
+                raise payload
+            elif kind == "msg_end":
+                # 通知 progress drainer 退出
+                await progress_queue.put(_MERGE_SENTINEL)
+                # 等 drainer 把 sentinel 之前残留的 prog 事件全部 forward 到 out_queue
+                try:
+                    await prog_task
+                except Exception:
+                    pass
+                # 把 out_queue 中残留的 progress 事件 flush 出去
+                while not out_queue.empty():
+                    k2, p2 = out_queue.get_nowait()
+                    if k2 == "prog":
+                        yield ("tool_progress", p2)
+                break
+    finally:
+        if not msg_task.done():
+            msg_task.cancel()
+        if not prog_task.done():
+            prog_task.cancel()
+
+
+__all__ = ["interleave_message_and_progress"]

--- a/docs/en/ENV_VARS.md
+++ b/docs/en/ENV_VARS.md
@@ -87,6 +87,9 @@ ref: env_vars
 | `SAGE_EMIT_TOOL_CALL_ON_COMPLETE` | `true` | Re-emit tool_call chunks once the LLM stream completes |
 | `SAGE_ECHO_SHELL_OUTPUT` | `false` | Echo background-shell stdout/stderr into the main stream |
 | `SAGE_FORCE_TOOL_CHOICE_REQUIRED` | `false` | Force `tool_choice=required` on every LLM call that carries `tools`. Off by default to avoid `unsupported_parameter` errors on models such as OpenAI o1/o3; enable explicitly with `1/true/yes/on` |
+| `SAGE_TOOL_PROGRESS_ENABLED` | `true` | Enable the tool live-progress channel (NDJSON `type=tool_progress` events for the UI only; never sent to MessageManager or the LLM) |
+| `SAGE_TOOL_PROGRESS_FLUSH_INTERVAL_MS` | `50` | Coalesce window (ms). Multiple `emit_tool_progress` calls within the window for the same `(tool_call, stream)` are merged into one event. Set to `0` to disable coalescing and emit immediately |
+| `SAGE_TOOL_PROGRESS_FLUSH_BYTES` | `16384` | Per-stream byte threshold; once accumulated text reaches it, flush immediately (prevents fast-producing commands from saturating the channel) |
 
 ## 6. Memory
 

--- a/docs/en/api/HTTP_API_CHAT.md
+++ b/docs/en/api/HTTP_API_CHAT.md
@@ -41,6 +41,26 @@ Shared validation: `messages` must be non-empty. `user_id` can be injected from 
 - `POST /api/conversations/{session_id}/rerun-stream`: does not require `messages` in the request body. The server loads the last user turn and re-runs the stream. Optional `RerunStreamRequest` fields override `agent_id`, sub-agents, mode, etc. Same `text/plain` stream shape as `web-stream`.
 - `POST /api/conversations/{session_id}/edit-last-user-message` updates the stored last **user** message; call `rerun-stream` after if you need a new model response.
 
+## `tool_progress` events in the stream
+
+In addition to regular `message` events, the NDJSON stream from any of the three
+endpoints above may also contain `tool_progress` events that carry incremental
+output from a tool while it is still running:
+
+```json
+{"type":"tool_progress","tool_call_id":"call_abc","text":"...","stream":"stdout","closed":false,"ts":1761700000.123}
+```
+
+- UI-only. These events **never** enter session history / MessageManager / the
+  LLM context.
+- Clients aggregate by `tool_call_id` into the corresponding tool card;
+  `closed: true` marks the end of the live stream.
+- Downstream consumers that don't care can simply ignore lines with
+  `type=tool_progress`; the existing protocol is fully preserved.
+- To disable: set `SAGE_TOOL_PROGRESS_ENABLED=false` on the server.
+
+See [Architecture · §12 Tool live-progress channel](../architecture/ARCHITECTURE_SAGENTS_TOOL_SKILL.md#12-tool-live-progress-channel-tool_progress).
+
 ## Interrupt
 
 `POST /api/sessions/{session_id}/interrupt` stops a running session at the engine level. That is different from the automatic stop inside `web-stream` / `rerun-stream` when the same session is replaced.

--- a/docs/en/architecture/ARCHITECTURE_SAGENTS_TOOL_SKILL.md
+++ b/docs/en/architecture/ARCHITECTURE_SAGENTS_TOOL_SKILL.md
@@ -316,3 +316,100 @@ skill_manager.add_skill_dir("/path/to/skills_root")
 ```
 
 For a given session, scope the visible skills with `SkillProxy(skill_manager, available_skills=["my_skill"])` and pass it into `SAgent.run_stream`.
+
+---
+
+## 12. Tool live-progress channel (tool_progress)
+
+Long-running tools (notably blocking `execute_shell_command`) often need to
+push intermediate output to the UI before the tool finishes, without polluting
+the final tool message that goes to the LLM. Sage adopts the same "two event
+types" approach as Codex App Server / Claude Code:
+
+- **`message` events**: unchanged. The complete tool result (with structured
+  fields like `exit_code`, `stdout`, `stderr`) is appended to MessageManager,
+  persisted, and fed back to the LLM.
+- **`tool_progress` events**: a new pure-progress channel **for the UI only**.
+  These events never enter MessageManager, are not persisted, and are not sent
+  to the LLM.
+
+### How a tool emits progress
+
+```python
+from sagents.tool import emit_tool_progress
+
+@tool(name="my_long_tool", description="...")
+async def my_long_tool(...):
+    async for chunk in some_stream():
+        await emit_tool_progress(chunk, stream="stdout")  # safe no-op when not in a chat session
+    return {"content": "...final structured result..."}
+```
+
+- `emit_tool_progress(text, stream="stdout"|"stderr"|"info")` is a fire-and-
+  forget API. Outside a chat context (CLI / unit tests / legacy callers) it
+  silently no-ops, so the tool's behaviour is unchanged.
+- Tool signature and return value require **no changes**; MCP tools are
+  unaffected.
+
+### Wire format
+
+A new event type is added to the NDJSON stream:
+
+```json
+{
+  "type": "tool_progress",
+  "tool_call_id": "call_abc",
+  "text": "...incremental output...",
+  "stream": "stdout",
+  "closed": false,
+  "ts": 1761700000.123
+}
+```
+
+- `tool_call_id` ties each chunk back to the originating assistant tool_call;
+  the frontend aggregates by this key.
+- `closed: true` marks the end of the progress stream so the UI can drop the
+  spinner.
+- The existing `message` event shape is fully preserved; downstream consumers
+  that don't care about `tool_progress` can simply ignore it.
+
+### Coalescing / throttling
+
+`emit_tool_progress` coalesces by `(tool_call_id, stream)` using a time window
+to prevent high-frequency small writes from saturating the channel:
+
+| Trigger | Behaviour |
+| --- | --- |
+| Another emit on the same stream < 50ms after the previous one | Append to in-memory buffer, do not enqueue yet |
+| Time window elapses (default 50ms) | Buffer is merged into a single `tool_progress` event and enqueued |
+| Per-stream accumulated bytes ≥ 16KB | Flush immediately, even if the window hasn't elapsed |
+| `emit_tool_progress_closed()` | Force-flush all pending streams under the current `tool_call_id`, then emit `closed=True` |
+| `unregister_progress_queue()` (chat ends) | Cancel pending flush tasks; remaining buffer is discarded |
+
+Tunables:
+
+- `SAGE_TOOL_PROGRESS_FLUSH_INTERVAL_MS` (default `50`). Set to `0` to disable
+  coalescing and emit immediately.
+- `SAGE_TOOL_PROGRESS_FLUSH_BYTES` (default `16384`).
+
+Coalescing is lock-free and safe within a single event loop: the `flush_task`
+is scheduled with `asyncio.create_task`, subsequent emits reuse the same task,
+and a synchronous flush (byte threshold or close) cancels the task—so an event
+is never enqueued twice.
+
+### Disabling
+
+Set `SAGE_TOOL_PROGRESS_ENABLED=false` to make `emit_tool_progress` a global
+no-op. The UI then only sees the final result once the tool returns; all other
+behaviour is unchanged.
+
+### Key modules
+
+| Module | Purpose |
+| --- | --- |
+| `sagents/tool/tool_progress.py` | protocol constants, `contextvars` binding, `emit_tool_progress` |
+| `sagents/agent/agent_base.py` | binds `tool_progress` context inside `_execute_tool` |
+| `common/utils/stream_merge.py` | `interleave_message_and_progress` merges both event streams into NDJSON |
+| `common/services/chat_service.py` | registers / unregisters progress queues, forwards `tool_progress` |
+| `app/server/web/src/composables/chat/useChatPage.js` | frontend dispatcher for `type=tool_progress` into the workbench |
+| `app/server/web/src/components/chat/workbench/renderers/toolcall/ShellCommandToolRenderer.vue` | live-output area rendered per stream |

--- a/docs/zh/ENV_VARS.md
+++ b/docs/zh/ENV_VARS.md
@@ -86,6 +86,9 @@ ref: env_vars
 | `SAGE_EMIT_TOOL_CALL_ON_COMPLETE` | `true` | LLM 完整产出后是否补发 tool_call chunk |
 | `SAGE_ECHO_SHELL_OUTPUT` | `false` | 后台 shell 输出是否回显到主流 |
 | `SAGE_FORCE_TOOL_CHOICE_REQUIRED` | `false` | 是否对所有带 tools 的 LLM 调用强制 `tool_choice=required`。默认关闭，避免 OpenAI o1/o3 等不支持该参数的模型报错；显式设为 `1/true/yes/on` 后启用 |
+| `SAGE_TOOL_PROGRESS_ENABLED` | `true` | 是否启用工具实时过程通道（NDJSON `type=tool_progress` 事件，仅给前端 UI，不进 MessageManager / 不喂 LLM） |
+| `SAGE_TOOL_PROGRESS_FLUSH_INTERVAL_MS` | `50` | 工具过程合并时间窗（毫秒）。同 `(tool_call, stream)` 维度下窗口内的多次 emit 合并成一条事件下发；设 `0` 关闭合并立即推送 |
+| `SAGE_TOOL_PROGRESS_FLUSH_BYTES` | `16384` | 单 stream 累计字节阈值，达到即立即 flush（防极快产生输出的命令挤爆通道） |
 
 ## 6. Memory
 

--- a/docs/zh/api/HTTP_API_CHAT.md
+++ b/docs/zh/api/HTTP_API_CHAT.md
@@ -43,6 +43,22 @@ ref: http-api-chat
 - `POST /api/conversations/{session_id}/rerun-stream`：不依赖本次请求里的 `messages`。服务端用 `get_rerun_conversation_payload` 取出「最后用户消息」与历史 agent 绑定，并构造 `StreamRequest`（`system_context` 中标记重跑来源）。`RerunStreamRequest` 中字段均可选，用于覆盖 `agent_id`、子 Agent 列表、模式等。响应与 `web-stream` 一样走 `StreamManager` 的 `text/plain` 流。
 - `POST /api/conversations/{session_id}/edit-last-user-message`：只更新存储中的最后一条 **用户** 消息；若之后要重跑模型输出，可再调 `rerun-stream`。
 
+## 流中的 `tool_progress` 事件
+
+三种流式入口下发的 NDJSON 中除了常规 `message` 事件，还可能包含 `tool_progress`
+事件，用于工具执行过程的实时增量推送：
+
+```json
+{"type":"tool_progress","tool_call_id":"call_abc","text":"...","stream":"stdout","closed":false,"ts":1761700000.123}
+```
+
+- 仅用于 UI 实时展示，**不会**进入会话历史 / MessageManager / LLM 上下文。
+- 客户端按 `tool_call_id` 聚合到对应工具卡片；`closed: true` 表示流结束。
+- 不关心实时过程的下游应用直接忽略 `type=tool_progress` 即可，老协议完全兼容。
+- 关闭：服务端设 `SAGE_TOOL_PROGRESS_ENABLED=false`，不再产生此类事件。
+
+详见 [架构文档 · §12 工具实时过程通道](../architecture/ARCHITECTURE_SAGENTS_TOOL_SKILL.md#12-工具实时过程通道tool_progress)。
+
 ## 与 `/api/sessions/.../interrupt` 的关系
 
 `interrupt` 会尝试停止正在运行的 sagents 会话；与 `web-stream` / `rerun-stream` 里「同会话重入先停旧流」是两条路径：前者是显式用户中断，后者是自动替换流。

--- a/docs/zh/architecture/ARCHITECTURE_SAGENTS_TOOL_SKILL.md
+++ b/docs/zh/architecture/ARCHITECTURE_SAGENTS_TOOL_SKILL.md
@@ -294,3 +294,90 @@ skill_manager.add_skill_dir("/path/to/skills_root")
 ```
 
 之后通过 `SkillProxy(skill_manager, available_skills=["my_skill"])` 限定本次会话能看到的技能子集，再传给 `SAgent.run_stream`。
+
+---
+
+## 12. 工具实时过程通道（tool_progress）
+
+长耗时工具（典型如 `execute_shell_command` 阻塞执行）希望在工具完全结束之前
+就把过程输出推到前端 UI，但又不能污染最终给 LLM 的 tool message。Sage 采用
+Codex App Server / Claude Code 的"双 event type"做法：
+
+- **`message` 事件**：保持原状。工具一次性返回的完整结果（含 `exit_code`、
+  `stdout`、`stderr` 等结构化字段）写入 MessageManager / 落盘 / 喂 LLM。
+- **`tool_progress` 事件**：新增的纯过程通道，仅用于前端 UI 实时展示，
+  **不进 MessageManager、不落盘、不喂 LLM**。
+
+### 后端工具如何推送
+
+```python
+from sagents.tool import emit_tool_progress
+
+@tool(name="my_long_tool", description="...")
+async def my_long_tool(...):
+    async for chunk in some_stream():
+        await emit_tool_progress(chunk, stream="stdout")  # 静默 no-op 安全
+    return {"content": "...final structured result..."}
+```
+
+- `emit_tool_progress(text, stream="stdout"|"stderr"|"info")` 是单方向、
+  零受影响 API：未在 chat 上下文中（如 CLI / 单测 / 旧调用方）会静默 no-op。
+- 工具签名/返回值 **不需要任何变化**；MCP 工具不受影响。
+
+### 协议形态
+
+进程内 NDJSON 流里新增一种事件：
+
+```json
+{
+  "type": "tool_progress",
+  "tool_call_id": "call_abc",
+  "text": "...incremental output...",
+  "stream": "stdout",
+  "closed": false,
+  "ts": 1761700000.123
+}
+```
+
+- `tool_call_id` 关联到对应的 assistant tool_call，前端按它聚合。
+- `closed: true` 表示当前工具的过程通道结束，UI 可收起 spinner。
+- 老的 `message` 事件结构完全兼容，不依赖此协议的下游应用无感知。
+
+### 节流 / 合并
+
+`emit_tool_progress` 默认按 `(tool_call_id, stream)` 维度做时间窗合并，避免
+高频小增量挤爆通道：
+
+| 触发条件 | 行为 |
+| --- | --- |
+| 同 stream 距上次 emit < 50ms | 新增文本累积进 buffer，不立刻入队 |
+| 50ms 时间窗到期 | buffer 内容合并成一条 `tool_progress` 事件入队 |
+| 单 stream 累计字节 ≥ 16KB | 立即 flush（即便时间窗未到） |
+| `emit_tool_progress_closed()` | 强制 flush 当前 tool_call 下所有 stream 的残余，再下发 `closed=True` |
+| `unregister_progress_queue()`（chat 结束） | 取消挂起的 flush task，丢弃残余 |
+
+可调环境变量：
+
+- `SAGE_TOOL_PROGRESS_FLUSH_INTERVAL_MS`：默认 `50`。设 `0` 关闭合并、立即推送。
+- `SAGE_TOOL_PROGRESS_FLUSH_BYTES`：默认 `16384`。
+
+合并是无锁、单事件循环内安全的：`flush_task` 用 `asyncio.create_task` 调度，
+新一波 emit 复用同一个 task；超阈值或 closed 时同步 flush 并 cancel task，
+不会出现重复入队。
+
+### 关闭
+
+设环境变量 `SAGE_TOOL_PROGRESS_ENABLED=false`，`emit_tool_progress` 全部
+no-op，不再产生 `tool_progress` 事件。此时前端只能在工具返回后看到完整结果，
+其余功能不变。
+
+### 关键文件
+
+| 模块 | 说明 |
+| --- | --- |
+| `sagents/tool/tool_progress.py` | 协议常量、`contextvars` 绑定、`emit_tool_progress` |
+| `sagents/agent/agent_base.py` | `_execute_tool` 进入工具前 `bind_tool_progress_context` |
+| `common/utils/stream_merge.py` | `interleave_message_and_progress` 把两路事件合到 NDJSON |
+| `common/services/chat_service.py` | 注册 / 注销 progress 队列，下发 `tool_progress` |
+| `app/server/web/src/composables/chat/useChatPage.js` | 前端识别 `type=tool_progress` 累加到 workbench |
+| `app/server/web/src/components/chat/workbench/renderers/toolcall/ShellCommandToolRenderer.vue` | live output 区域按 stream 分栏渲染 |

--- a/sagents/agent/agent_base.py
+++ b/sagents/agent/agent_base.py
@@ -5,6 +5,10 @@ import uuid
 import asyncio
 from sagents.utils.logger import logger
 from sagents.tool.tool_manager import ToolManager
+from sagents.tool.tool_progress import (
+    bind_tool_progress_context as _bind_tool_progress_context,
+    emit_tool_progress_closed as _emit_tool_progress_closed,
+)
 from sagents.context.session_context import SessionContext
 from sagents.context.messages.message import MessageChunk, MessageRole, MessageType
 from sagents.utils.prompt_manager import prompt_manager
@@ -1196,11 +1200,18 @@ class AgentBase(ABC):
             # 如果 arguments 中有 session_id，移除它（因为会作为显式参数传递）
             call_kwargs.pop('session_id', None)
 
-            tool_response = await tool_manager.run_tool_async(
-                tool_name,
-                session_id=session_id,
-                **call_kwargs
-            )
+            with _bind_tool_progress_context(session_id, tool_call['id']):
+                try:
+                    tool_response = await tool_manager.run_tool_async(
+                        tool_name,
+                        session_id=session_id,
+                        **call_kwargs
+                    )
+                finally:
+                    try:
+                        await _emit_tool_progress_closed()
+                    except Exception:
+                        pass
 
             # 检查是否为流式响应
             if hasattr(tool_response, '__iter__') and not isinstance(tool_response, (str, bytes)):

--- a/sagents/tool/__init__.py
+++ b/sagents/tool/__init__.py
@@ -14,10 +14,18 @@ def __getattr__(name):
     elif name == "get_tool_manager":
         from .tool_manager import get_tool_manager
         return get_tool_manager
+    elif name == "emit_tool_progress":
+        from .tool_progress import emit_tool_progress
+        return emit_tool_progress
+    elif name == "emit_tool_progress_closed":
+        from .tool_progress import emit_tool_progress_closed
+        return emit_tool_progress_closed
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 __all__ = [
     'ToolManager',
     'ToolProxy',
     'get_tool_manager',
+    'emit_tool_progress',
+    'emit_tool_progress_closed',
 ]

--- a/sagents/tool/_progress_diff.py
+++ b/sagents/tool/_progress_diff.py
@@ -1,0 +1,37 @@
+"""progress 通道的 tail 增量计算工具。
+
+抽到独立模块以便单测无需触发 ``execute_command_tool`` 的沉重 import 链。
+"""
+
+from __future__ import annotations
+
+
+def diff_tail_for_progress(prev: str, cur: str) -> str:
+    """计算从 ``prev`` 到 ``cur`` 的新增部分用于 progress 推送。
+
+    沙箱 ``read_background_output`` 通常返回 tail（受 max_bytes 限制），
+    随着新输出到来 tail 整体右移；这里用 ``cur`` 的尾部相对 ``prev`` 的
+    新增片段作为 delta。
+
+    策略：
+    - 若 ``prev`` 是 ``cur`` 的前缀，返回 ``cur[len(prev):]``（最常见）。
+    - 否则（沙箱 tail 已截断旧字节），尝试在 ``cur`` 中找 ``prev`` 末尾
+      ~512 字节的位置，从其之后输出；找不到则把 ``cur`` 整体作为 delta
+      返回（极少数边界场景，可能会重复输出一段，可接受）。
+    """
+    if not cur:
+        return ""
+    if not prev:
+        return cur
+    if cur.startswith(prev):
+        return cur[len(prev):]
+    # 沙箱 tail 已截断旧字节：找 cur 的开头与 prev 的末尾的最长重叠 k，
+    # 使 prev.endswith(cur[:k])。窗口最大限制 512 字符。
+    max_overlap = min(len(prev), len(cur), 512)
+    for k in range(max_overlap, 0, -1):
+        if prev.endswith(cur[:k]):
+            return cur[k:]
+    return cur
+
+
+__all__ = ["diff_tail_for_progress"]

--- a/sagents/tool/impl/execute_command_tool.py
+++ b/sagents/tool/impl/execute_command_tool.py
@@ -23,6 +23,8 @@ import uuid
 from typing import Any, Dict, List, Optional, Tuple
 
 from ..tool_base import tool
+from ..tool_progress import emit_tool_progress
+from .._progress_diff import diff_tail_for_progress as _diff_tail_for_progress
 from ..error_codes import ToolErrorCode, make_tool_error
 from sagents.utils.logger import logger
 from sagents.utils.sandbox._stdout_echo import echo_header, echo_footer
@@ -566,8 +568,16 @@ class ExecuteCommandTool:
         task_info: Dict[str, Any],
         block_until_ms: int,
         pattern: Optional[str] = None,
+        emit_progress: bool = False,
     ) -> Tuple[bool, Optional[int]]:
-        """轮询直到命令结束 / 超时 / 命中 pattern。返回 (finished, exit_code)。"""
+        """轮询直到命令结束 / 超时 / 命中 pattern。返回 (finished, exit_code)。
+
+        Args:
+            emit_progress: 若为 True，每次轮询新增的 tail 输出会通过
+                ``emit_tool_progress`` 推送到前端 UI 实时显示。整体
+                ``stdout`` 由调用方在结束时再读取一次返回，progress 推送
+                只是"过程展示"，不影响最终给 LLM 的工具结果。
+        """
         deadline = time.time() + max(0, block_until_ms) / 1000.0
         compiled = None
         if pattern:
@@ -577,9 +587,26 @@ class ExecuteCommandTool:
                 logger.warning(f"await_shell pattern 编译失败，忽略: {exc}")
                 compiled = None
 
+        # progress 推送状态：以 "已发出的字节长度" 作为偏移
+        # 沙箱 read_background_output 仅返回 tail（不一定从头读），所以这里
+        # 用"上次完整 tail 长度"做差分。注意：read_background_output 有
+        # max_bytes 上限，对超过上限的输出我们只能近似处理（取 tail 增量）。
+        emitted_tail: str = ""
+
         sleep_s = 0.2
         while True:
             exit_code = await self._read_exit(sandbox, task_info)
+
+            if emit_progress:
+                try:
+                    cur_tail = await self._read_tail(sandbox, task_info, max_bytes=65536)
+                    delta = _diff_tail_for_progress(emitted_tail, cur_tail or "")
+                    if delta:
+                        await emit_tool_progress(delta, stream="stdout")
+                        emitted_tail = cur_tail or ""
+                except Exception as exc:
+                    logger.debug(f"emit progress 失败（忽略）: {exc}")
+
             if exit_code is not None:
                 return True, exit_code
 
@@ -723,7 +750,9 @@ class ExecuteCommandTool:
                     "message": f"已在后台启动，task_id={task_id}",
                 }
 
-            finished, exit_code = await self._wait_for_finish(sandbox, task_info, block_until_ms)
+            finished, exit_code = await self._wait_for_finish(
+                sandbox, task_info, block_until_ms, emit_progress=True
+            )
             if finished:
                 stdout_text, total_bytes, truncated = await self._read_completed_output(
                     sandbox, task_info
@@ -853,7 +882,9 @@ class ExecuteCommandTool:
             block_until_ms = 300_000
 
         sandbox = self._get_sandbox(session_id)
-        finished, exit_code = await self._wait_for_finish(sandbox, task_info, block_until_ms, pattern=pattern)
+        finished, exit_code = await self._wait_for_finish(
+            sandbox, task_info, block_until_ms, pattern=pattern, emit_progress=True
+        )
         if finished:
             stdout_text, total_bytes, truncated = await self._read_completed_output(
                 sandbox, task_info

--- a/sagents/tool/tool_progress.py
+++ b/sagents/tool/tool_progress.py
@@ -1,0 +1,294 @@
+"""Tool progress channel.
+
+允许工具在执行过程中通过 ``emit_tool_progress`` 推送实时增量到前端 UI，
+不影响最终给 LLM 的 tool message（仍然是工具一次性返回的完整结果）。
+
+设计参考 Codex App Server / Claude Code 的 ``item/*/delta`` 机制：
+"过程展示" 与 "工具结果" 用两种 event type 分离，共用同一个传输通道。
+
+依赖关系：
+- 上游（``AgentBase._execute_tool``）在调用工具前用 ``bind_tool_progress_context``
+  绑定当前 ``session_id`` / ``tool_call_id``，工具内部即可直接调
+  ``await emit_tool_progress(...)`` 推送增量。
+- 接收侧（``ChatService.execute_chat_session``）用 ``register_progress_queue``
+  把 session 对应的 ``asyncio.Queue`` 注册进来；emit 时事件入队。
+- 任何环节缺失时（无注册队列、上下文未绑定、总开关关闭）emit 静默 no-op，
+  保证工具行为零受影响、零异常。
+
+合并 / 节流：
+默认开启 50ms 时间窗 + 16KB 字节阈值合并，避免高频小增量挤爆通道；阈值任一
+触发即 flush；显式调用 ``emit_tool_progress_closed``、注销 queue 也会强制
+flush 残余。可用 ``SAGE_TOOL_PROGRESS_FLUSH_INTERVAL_MS=0`` 关闭合并以保持
+原样实时推送。
+
+所有公开 API 都是同步无副作用的注册操作，或纯粹的 ``await`` 调用，便于在任意
+地方使用。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import os
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+# session_id -> asyncio.Queue，由 ChatService 在每条 chat 请求开始时注册
+_progress_queues: Dict[str, asyncio.Queue] = {}
+
+
+class _Coalescer:
+    """单个 (session_id, tool_call_id, stream) 维度的待合并缓冲区。"""
+
+    __slots__ = ("parts", "total_len", "flush_task")
+
+    def __init__(self) -> None:
+        self.parts: List[str] = []
+        self.total_len: int = 0
+        self.flush_task: Optional[asyncio.Task] = None
+
+
+# (session_id, tool_call_id, stream) -> _Coalescer
+_pending_buffers: Dict[Tuple[str, str, str], _Coalescer] = {}
+
+# 当前正在执行的 tool_call_id（由 AgentBase._execute_tool 绑定）
+_current_tool_call_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "sage_current_tool_call_id", default=None
+)
+_current_session_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "sage_current_session_id", default=None
+)
+
+
+def _is_progress_enabled() -> bool:
+    val = os.environ.get("SAGE_TOOL_PROGRESS_ENABLED", "true")
+    return val.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _get_flush_interval_ms() -> int:
+    """合并时间窗（毫秒）。<=0 关闭合并立即推送。默认 50ms。"""
+    raw = os.environ.get("SAGE_TOOL_PROGRESS_FLUSH_INTERVAL_MS", "50")
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 50
+
+
+def _get_flush_bytes() -> int:
+    """单 stream 累计字节阈值，超过即立即 flush。默认 16KB。"""
+    raw = os.environ.get("SAGE_TOOL_PROGRESS_FLUSH_BYTES", "16384")
+    try:
+        n = int(raw)
+        return n if n > 0 else 16384
+    except (TypeError, ValueError):
+        return 16384
+
+
+def register_progress_queue(session_id: str, queue: asyncio.Queue) -> None:
+    """为指定 session 注册 progress 接收队列。重复注册会覆盖。"""
+    if session_id:
+        _progress_queues[session_id] = queue
+
+
+def unregister_progress_queue(session_id: str) -> None:
+    """注销 progress 队列；找不到则忽略。应在 chat 会话结束 finally 中调用。
+
+    同时清理该 session 下所有 pending 的合并 buffer 与 flush task，避免
+    悬挂 task 在事件循环里写入已被释放的队列。
+    """
+    _progress_queues.pop(session_id, None)
+    if not _pending_buffers:
+        return
+    keys = [k for k in list(_pending_buffers.keys()) if k[0] == session_id]
+    for k in keys:
+        coalescer = _pending_buffers.pop(k, None)
+        if coalescer and coalescer.flush_task is not None and not coalescer.flush_task.done():
+            coalescer.flush_task.cancel()
+
+
+def get_progress_queue(session_id: str) -> Optional[asyncio.Queue]:
+    return _progress_queues.get(session_id)
+
+
+class _ToolProgressContextToken:
+    """Context manager，用 with/async with 包裹工具调用以临时绑定上下文。"""
+
+    def __init__(self, session_id: Optional[str], tool_call_id: Optional[str]):
+        self._sid = session_id
+        self._tcid = tool_call_id
+        self._sid_token = None
+        self._tcid_token = None
+
+    def __enter__(self):
+        if self._sid is not None:
+            self._sid_token = _current_session_id.set(self._sid)
+        if self._tcid is not None:
+            self._tcid_token = _current_tool_call_id.set(self._tcid)
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if self._tcid_token is not None:
+            _current_tool_call_id.reset(self._tcid_token)
+        if self._sid_token is not None:
+            _current_session_id.reset(self._sid_token)
+        return False
+
+
+def bind_tool_progress_context(session_id: Optional[str], tool_call_id: Optional[str]) -> _ToolProgressContextToken:
+    """绑定当前协程上下文中的 session_id / tool_call_id。
+
+    用法::
+
+        with bind_tool_progress_context(session_id, tool_call_id):
+            tool_response = await tool_manager.run_tool_async(...)
+    """
+    return _ToolProgressContextToken(session_id, tool_call_id)
+
+
+def _flush_buffer(key: Tuple[str, str, str]) -> None:
+    """把指定 key 的 buffer 合并成一条事件入队，并清掉 buffer / flush_task。"""
+    coalescer = _pending_buffers.pop(key, None)
+    if coalescer is None:
+        return
+    if coalescer.flush_task is not None and not coalescer.flush_task.done():
+        coalescer.flush_task.cancel()
+    if not coalescer.parts:
+        return
+    session_id, tool_call_id, stream = key
+    queue = _progress_queues.get(session_id)
+    if queue is None:
+        return
+    text = "".join(coalescer.parts)
+    try:
+        queue.put_nowait(_build_event(tool_call_id, text, stream, closed=False))
+    except asyncio.QueueFull:
+        pass
+    except Exception:
+        pass
+
+
+def _flush_buffers_for_tool(session_id: str, tool_call_id: str) -> None:
+    """flush 指定 (session_id, tool_call_id) 下所有 stream 的 pending buffer。"""
+    if not _pending_buffers:
+        return
+    keys = [
+        k for k in list(_pending_buffers.keys())
+        if k[0] == session_id and k[1] == tool_call_id
+    ]
+    for k in keys:
+        _flush_buffer(k)
+
+
+async def _delayed_flush(key: Tuple[str, str, str], delay_s: float) -> None:
+    try:
+        await asyncio.sleep(delay_s)
+    except asyncio.CancelledError:
+        return
+    try:
+        _flush_buffer(key)
+    except Exception:
+        pass
+
+
+async def emit_tool_progress(text: str, *, stream: str = "stdout") -> None:
+    """工具调用过程中推送一段实时输出到前端 UI。
+
+    Args:
+        text: 本次新增的文本片段。
+        stream: 通道标识，``stdout`` / ``stderr`` / ``info``。前端可按通道分栏渲染。
+
+    安全降级：若总开关 ``SAGE_TOOL_PROGRESS_ENABLED`` 关闭、当前协程上下文未绑定
+    session_id/tool_call_id、或 session 未注册接收队列，本函数静默 no-op，
+    不抛异常、不阻塞。这样保证工具在 CLI / 单测 / 旧上下文中的行为完全不受影响。
+
+    合并行为：默认 50ms 内的多次 emit（同一 stream）会被合并成一条事件下发；
+    单 stream 累计 ≥16KB 也会立即 flush；二选一；可用环境变量
+    ``SAGE_TOOL_PROGRESS_FLUSH_INTERVAL_MS`` / ``SAGE_TOOL_PROGRESS_FLUSH_BYTES``
+    调整或关闭（设为 ``0`` 走立即推送）。
+    """
+    if not text:
+        return
+    if not _is_progress_enabled():
+        return
+    tool_call_id = _current_tool_call_id.get()
+    session_id = _current_session_id.get()
+    if not tool_call_id or not session_id:
+        return
+    queue = _progress_queues.get(session_id)
+    if queue is None:
+        return
+
+    interval_ms = _get_flush_interval_ms()
+    if interval_ms <= 0:
+        try:
+            queue.put_nowait(_build_event(tool_call_id, text, stream, closed=False))
+        except asyncio.QueueFull:
+            pass
+        except Exception:
+            pass
+        return
+
+    key = (session_id, tool_call_id, stream)
+    coalescer = _pending_buffers.get(key)
+    if coalescer is None:
+        coalescer = _Coalescer()
+        _pending_buffers[key] = coalescer
+    coalescer.parts.append(text)
+    coalescer.total_len += len(text)
+
+    if coalescer.total_len >= _get_flush_bytes():
+        _flush_buffer(key)
+        return
+
+    if coalescer.flush_task is None or coalescer.flush_task.done():
+        try:
+            coalescer.flush_task = asyncio.create_task(
+                _delayed_flush(key, interval_ms / 1000.0)
+            )
+        except RuntimeError:
+            # 没有运行中的事件循环（极少数边界），退化为立即 flush
+            _flush_buffer(key)
+
+
+async def emit_tool_progress_closed(*, stream: str = "info") -> None:
+    """显式标记当前 tool 的 progress 流结束，让前端立即收起 spinner。
+
+    AgentBase 在 ``_execute_tool`` finally 中会调用一次；工具自己一般不需要调。
+    会先 flush 该 tool_call 下所有 pending 的合并 buffer，再下发 ``closed=True``
+    事件，保证前端先看到完整内容、再看到结束标记。
+    """
+    if not _is_progress_enabled():
+        return
+    tool_call_id = _current_tool_call_id.get()
+    session_id = _current_session_id.get()
+    if not tool_call_id or not session_id:
+        return
+    _flush_buffers_for_tool(session_id, tool_call_id)
+    queue = _progress_queues.get(session_id)
+    if queue is None:
+        return
+    try:
+        queue.put_nowait(_build_event(tool_call_id, "", stream, closed=True))
+    except Exception:
+        pass
+
+
+def _build_event(tool_call_id: str, text: str, stream: str, closed: bool) -> Dict[str, Any]:
+    return {
+        "type": "tool_progress",
+        "tool_call_id": tool_call_id,
+        "text": text,
+        "stream": stream,
+        "closed": closed,
+        "ts": time.time(),
+    }
+
+
+__all__ = [
+    "register_progress_queue",
+    "unregister_progress_queue",
+    "get_progress_queue",
+    "bind_tool_progress_context",
+    "emit_tool_progress",
+    "emit_tool_progress_closed",
+]


### PR DESCRIPTION
## Summary
- Add a UI-only `tool_progress` stream path for server web shell tool live output.
- Render live stdout/stderr segments in the server web workbench shell tool card.
- Document the new progress events and related environment variables in English and Chinese docs.

## Test plan
- Not run in this commit step; committed only the already-staged selected diff.


Made with [Cursor](https://cursor.com)