### PR TITLE
fix: 修复 fibre 模式无白名单时 ToolProxy 私有属性访问导致的崩溃

### DIFF
--- a/sagents/agent/tool_suggestion_agent.py
+++ b/sagents/agent/tool_suggestion_agent.py
@@ -104,9 +104,11 @@ class ToolSuggestionAgent(AgentBase):
             # 如果是 ToolProxy 且处于 fibre 模式，动态添加 fibre 特有工具
             if isinstance(session_context.tool_manager, ToolProxy):
                 if session_context.agent_config.get("agent_mode", "fibre") == "fibre":
-                    session_context.tool_manager._available_tools.add("sys_spawn_agent")
-                    session_context.tool_manager._available_tools.add("sys_delegate_task")
-                    session_context.tool_manager._available_tools.add("sys_finish_task")
+                    session_context.tool_manager.allow_tools([
+                        "sys_spawn_agent",
+                        "sys_delegate_task",
+                        "sys_finish_task",
+                    ])
 
             available_tools = session_context.tool_manager.list_tools_simplified(lang=session_context.get_language())
             # 准备工具列表字符串，包含ID和名称，以及描述的前100个字符

--- a/sagents/tool/tool_proxy.py
+++ b/sagents/tool/tool_proxy.py
@@ -63,6 +63,16 @@ class ToolProxy:
             
         if tool_name not in self._available_tools:
             raise ValueError(f"工具 '{tool_name}' 不在可用工具列表中")
+
+    def allow_tools(self, tool_names: List[str]) -> None:
+        """
+        将工具加入白名单。
+
+        若当前未启用白名单（所有工具默认可用），此方法为 no-op，避免对 None 调用 .add()。
+        """
+        if self._available_tools is None:
+            return
+        self._available_tools.update(tool_names)
     
     # ToolManager 兼容接口
     


### PR DESCRIPTION
- ToolProxy 新增公共方法 allow_tools()，安全处理 _available_tools 为 None 的场景
- tool_suggestion_agent.py 改用 allow_tools() 替代直接访问私有 _available_tools
- 修复原 bug: 当 fibre 模式未配置工具白名单时，对 None 调用 .add() 抛 AttributeError