### PR TITLE
fix: Allow required tool use to escape loops

### DIFF
--- a/sagents/agent/simple_agent.py
+++ b/sagents/agent/simple_agent.py
@@ -378,6 +378,41 @@ class SimpleAgent(AgentBase):
             if ((tool.get("function") or {}).get("name") or "")
         }
 
+    def _resolve_tool_choice(
+        self,
+        tools_json: List[Dict[str, Any]],
+        force_tool_choice_required: bool = False,
+        force_tool_choice_auto: bool = False,
+    ) -> Optional[str]:
+        if not tools_json:
+            return None
+        if force_tool_choice_required:
+            return "required"
+        if force_tool_choice_auto:
+            return "auto"
+
+        env_force_required = os.getenv("SAGE_FORCE_TOOL_CHOICE_REQUIRED", "").strip().lower()
+        if env_force_required in ("1", "true", "yes", "on"):
+            return "required"
+        return None
+
+    def _should_escape_required_next_turn(
+        self,
+        chunks: List[MessageChunk],
+        pattern: Optional[Dict[str, int]],
+    ) -> bool:
+        if pattern:
+            return True
+
+        for chunk in chunks or []:
+            if (
+                chunk.role == MessageRole.TOOL.value
+                and isinstance(chunk.metadata, dict)
+                and chunk.metadata.get("turn_status_rejected") is True
+            ):
+                return True
+        return False
+
     def _is_turn_status_only_request(self, tools_json: List[Dict[str, Any]], force_tool_choice_required: bool) -> bool:
         return force_tool_choice_required and self._allowed_tool_names(tools_json) == {"turn_status"}
 
@@ -637,6 +672,7 @@ class SimpleAgent(AgentBase):
         recent_signatures: List[str] = message_manager.get_recent_loop_signatures()
         logger.debug(f"SimpleAgent: 加载历史签名 {len(recent_signatures)} 个")
         turn_status_only_next = False
+        force_auto_next_turn = False
         while True:
             if self._should_abort_due_to_session(session_context):
                 break
@@ -673,6 +709,10 @@ class SimpleAgent(AgentBase):
             turn_status_only_next = False
             if current_turn_status_only:
                 logger.info("SimpleAgent: 上一轮纯文本无工具调用，本轮仅开放 turn_status 并启用 tool_choice=required")
+            current_force_auto = force_auto_next_turn and not current_turn_status_only
+            force_auto_next_turn = False
+            if current_force_auto:
+                logger.info("SimpleAgent: 上一轮检测到工具循环风险，本轮临时释放 tool_choice=auto")
 
             # 调用LLM
             should_break = False
@@ -683,6 +723,7 @@ class SimpleAgent(AgentBase):
                 tool_manager=tool_manager,
                 session_id=session_id,
                 force_tool_choice_required=current_turn_status_only,
+                force_tool_choice_auto=current_force_auto,
             ):
                 non_empty_chunks = [c for c in chunks if (c.message_type != MessageType.EMPTY.value)]
                 if len(non_empty_chunks) > 0:
@@ -765,6 +806,9 @@ class SimpleAgent(AgentBase):
                 recent_signatures = recent_signatures[-24:]
 
             pattern = self._detect_repeat_pattern(recent_signatures)
+            if self._should_escape_required_next_turn(all_new_response_chunks, pattern):
+                force_auto_next_turn = True
+
             if pattern:
                 repeat_pattern_hits += 1
                 correction_message = self._build_self_correction_message(
@@ -828,6 +872,7 @@ class SimpleAgent(AgentBase):
                                              tool_manager: Optional[ToolManager],
                                              session_id: str,
                                              force_tool_choice_required: bool = False,
+                                             force_tool_choice_auto: bool = False,
                                              ) -> AsyncGenerator[tuple[List[MessageChunk], bool], None]:
 
         # 准备消息：提取可用消息 -> 检查压缩 -> 执行压缩
@@ -854,12 +899,13 @@ class SimpleAgent(AgentBase):
 
         if len(tools_json) > 0:
             model_config_override['tools'] = tools_json
-            # 通过环境变量 SAGE_FORCE_TOOL_CHOICE_REQUIRED 控制是否强制 tool_choice=required。
-            # 默认关闭：部分模型（如 OpenAI o1/o3、部分国产模型）不支持 tool_choice=required，
-            # 显式启用后才下发给 LLM。调用方传入的 force_tool_choice_required 仍优先生效。
-            env_force_required = os.getenv("SAGE_FORCE_TOOL_CHOICE_REQUIRED", "").strip().lower() in ("1", "true", "yes", "on")
-            if force_tool_choice_required or env_force_required:
-                model_config_override['tool_choice'] = 'required'
+            tool_choice = self._resolve_tool_choice(
+                tools_json=tools_json,
+                force_tool_choice_required=force_tool_choice_required,
+                force_tool_choice_auto=force_tool_choice_auto,
+            )
+            if tool_choice:
+                model_config_override['tool_choice'] = tool_choice
         response = self._call_llm_streaming(
             messages=cast(List[Union[MessageChunk, Dict[str, Any]]], clean_message_input),
             session_id=session_id,

--- a/sagents/utils/repeat_pattern.py
+++ b/sagents/utils/repeat_pattern.py
@@ -76,7 +76,7 @@ def detect_repeat_pattern(
     - AABBAABB (period=4)
     """
     n = len(signatures)
-    if n < 3:
+    if n < 2:
         return None
 
     upper_period = min(max_period, n // 2 if n >= 4 else 1)
@@ -96,6 +96,8 @@ def detect_repeat_pattern(
             idx -= period
 
         if cycles >= min_cycles:
+            if period == 1 and cycles == 2 and idx > 0:
+                continue
             return {
                 "period": period,
                 "cycles": cycles,
@@ -110,4 +112,3 @@ def build_self_correction_message(pattern: Dict[str, int]) -> str:
         "从下一步开始禁止复用同一路径；必须改变执行策略："
         "优先尝试不同工具或参数；若仍无法推进，先明确阻塞点并提出最小必要澄清问题。"
     )
-

--- a/tests/sagents/agent/test_simple_agent_finish_summary.py
+++ b/tests/sagents/agent/test_simple_agent_finish_summary.py
@@ -196,3 +196,121 @@ def test_turn_status_from_tool_call_reads_continue_work():
     }
 
     assert _agent()._turn_status_from_tool_call(tool_call) == "continue_work"
+
+
+def test_env_force_required_keeps_required_without_escape(monkeypatch):
+    monkeypatch.setenv("SAGE_FORCE_TOOL_CHOICE_REQUIRED", "true")
+
+    assert _agent()._resolve_tool_choice(
+        tools_json=[{"function": {"name": "todo_read"}}],
+        force_tool_choice_required=False,
+        force_tool_choice_auto=False,
+    ) == "required"
+
+
+def test_normal_path_omits_tool_choice_without_env_or_escape(monkeypatch):
+    monkeypatch.delenv("SAGE_FORCE_TOOL_CHOICE_REQUIRED", raising=False)
+
+    assert _agent()._resolve_tool_choice(
+        tools_json=[{"function": {"name": "todo_read"}}],
+        force_tool_choice_required=False,
+        force_tool_choice_auto=False,
+    ) is None
+
+
+def test_escape_auto_overrides_env_required_once(monkeypatch):
+    monkeypatch.setenv("SAGE_FORCE_TOOL_CHOICE_REQUIRED", "true")
+
+    assert _agent()._resolve_tool_choice(
+        tools_json=[{"function": {"name": "todo_read"}}],
+        force_tool_choice_required=False,
+        force_tool_choice_auto=True,
+    ) == "auto"
+
+
+def test_required_protocol_turn_overrides_escape_auto(monkeypatch):
+    monkeypatch.setenv("SAGE_FORCE_TOOL_CHOICE_REQUIRED", "true")
+
+    assert _agent()._resolve_tool_choice(
+        tools_json=[{"function": {"name": "turn_status"}}],
+        force_tool_choice_required=True,
+        force_tool_choice_auto=True,
+    ) == "required"
+
+
+def test_turn_status_rejection_requests_required_escape():
+    chunks = [
+        MessageChunk(
+            role=MessageRole.TOOL.value,
+            content="turn_status call rejected",
+            tool_call_id="call_1",
+            message_type=MessageType.TOOL_CALL_RESULT.value,
+            metadata={"turn_status_rejected": True},
+        )
+    ]
+
+    assert _agent()._should_escape_required_next_turn(chunks, pattern=None) is True
+
+
+def test_repeat_pattern_requests_required_escape():
+    chunks = [
+        MessageChunk(
+            role=MessageRole.TOOL.value,
+            content="same result",
+            tool_call_id="call_1",
+            message_type=MessageType.TOOL_CALL_RESULT.value,
+        )
+    ]
+
+    assert _agent()._should_escape_required_next_turn(
+        chunks,
+        pattern={"period": 1, "cycles": 2, "span": 2},
+    ) is True
+
+
+def test_historical_repeat_signature_requests_required_escape():
+    agent = _agent()
+    chunks = [
+        MessageChunk(
+            role=MessageRole.ASSISTANT.value,
+            content=None,
+            tool_calls=[
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "todo_read",
+                        "arguments": '{"session_id":"s1"}',
+                    },
+                }
+            ],
+            message_type=MessageType.TOOL_CALL.value,
+        ),
+        MessageChunk(
+            role=MessageRole.TOOL.value,
+            content="当前未完成任务清单:\n- [进行中] t12",
+            tool_call_id="call_1",
+            message_type=MessageType.TOOL_CALL_RESULT.value,
+            metadata={"tool_name": "todo_read"},
+        ),
+    ]
+    historical_signature = agent._build_loop_signature(chunks)
+    current_signature = agent._build_loop_signature(chunks)
+
+    pattern = agent._detect_repeat_pattern([historical_signature, current_signature])
+
+    assert pattern == {"period": 1, "cycles": 2, "span": 2}
+    assert agent._should_escape_required_next_turn(chunks, pattern=pattern) is True
+
+
+def test_normal_tool_result_does_not_request_required_escape():
+    chunks = [
+        MessageChunk(
+            role=MessageRole.TOOL.value,
+            content='{"success":true}',
+            tool_call_id="call_1",
+            message_type=MessageType.TOOL_CALL_RESULT.value,
+        )
+    ]
+
+    assert _agent()._should_escape_required_next_turn(chunks, pattern=None) is False


### PR DESCRIPTION
## 防止 required 工具调用陷入循环

SimpleAgent 仍然保留 SAGE_FORCE_TOOL_CHOICE_REQUIRED 下的工具强制调用行为，但当运行时检测到重复执行签名或 turn_status 被拒绝时，会仅在下一次普通模型调用中临时释放为 tool_choice=auto，让模型有机会停止重复调用同一个工具并输出面向用户的总结。