### PR TITLE
fix(llm): sanitize OpenAI reasoning and tool_choice=required kwargs

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -1,3 +1,5 @@
+2026-05-01 撤回未合并的「会话生成中引导候选区」（interruptStaging）本地改动：`MessageInput.vue` 与四语 locale 恢复为 HEAD；行为回到生成中首次提交即 `needInterrupt` 发送。
+
 2026-05-01 能力预设引导门槛：`presetText` 写入后经 `<skill>` 剥离的正文与技能 chips 才写入快照；门控不再因「已有技能 chip」误判而立刻解除，首击 Enter 仍先 toast、二次 Enter 发送（desktop/server `MessageInput.vue`）。
 
 2026-05-01 编辑已发用户消息并重跑：`handleMessage` 合并同 message_id 时用户气泡改为用流式载荷整段替换 `content`，不再与本地历史拼接，消除正文重复一遍（desktop/server `useChatPage.js`）。

--- a/sagents/utils/llm_request_utils.py
+++ b/sagents/utils/llm_request_utils.py
@@ -8,6 +8,27 @@ from openai import APIError
 from .logger import logger
 
 
+_REASONING_MODEL_PREFIXES: tuple[str, ...] = (
+    "o1-",
+    "o3-",
+    "o4-",
+    "gpt-5",
+)
+_REASONING_MODEL_EXACT: frozenset[str] = frozenset({"o1", "o3", "o4"})
+
+
+def _is_openai_reasoning_model_name(model: Optional[str]) -> bool:
+    """与 ``sagents.llm.model_capabilities.is_openai_reasoning_model`` 判定一致（避免循环/包初始化副作用）。"""
+    if not model:
+        return False
+    name = model.strip().lower()
+    if not name:
+        return False
+    if name in _REASONING_MODEL_EXACT:
+        return True
+    return any(name.startswith(p) for p in _REASONING_MODEL_PREFIXES)
+
+
 def uses_max_completion_tokens(model: Optional[str]) -> bool:
     """
     部分 OpenAI 模型（o1/o3、GPT-5 等）的 Chat Completions API 仅接受
@@ -76,6 +97,62 @@ def get_structured_output_support(
     return None
 
 
+def _tool_choice_is_required(tool_choice: Any) -> bool:
+    if isinstance(tool_choice, str):
+        return tool_choice.strip().lower() == "required"
+    return False
+
+
+def _drop_reasoning_effort_when_tool_choice_required(sanitized: Dict[str, Any]) -> None:
+    """
+    OpenAI：gpt-5.4 等在 chat/completions 上 function tools + tool_choice=required
+    与 extra_body.reasoning_effort 互斥，会返回 invalid_request_error。
+    """
+    if not _tool_choice_is_required(sanitized.get("tool_choice")):
+        return
+    eb = sanitized.get("extra_body")
+    if not isinstance(eb, dict) or "reasoning_effort" not in eb:
+        return
+    sanitized["extra_body"] = {k: v for k, v in eb.items() if k != "reasoning_effort"}
+    logger.debug(
+        "sanitize_model_request_kwargs: dropped reasoning_effort from extra_body "
+        "(tool_choice=required, chat/completions compatibility)"
+    )
+
+
+def _drop_sampling_params_when_reasoning_effort_active(
+    sanitized: Dict[str, Any],
+    model: Optional[str],
+) -> None:
+    """
+    OpenAI / Azure reasoning：extra_body 中显式带上非 none 的 reasoning_effort 时，
+    自定义 temperature 等采样参数常返回 unsupported_value（仅允许默认）。
+
+    须在 ``_drop_reasoning_effort_when_tool_choice_required`` 之后调用，以便
+    tool_choice=required 路径已去掉 reasoning_effort 时仍保留用户配置的 temperature。
+    """
+    if not model or not _is_openai_reasoning_model_name(model):
+        return
+    eb = sanitized.get("extra_body")
+    if not isinstance(eb, dict) or "reasoning_effort" not in eb:
+        return
+    effort = eb.get("reasoning_effort")
+    if effort is None:
+        return
+    if str(effort).strip().lower() in ("none", ""):
+        return
+    dropped = []
+    for key in ("temperature", "top_p", "presence_penalty", "frequency_penalty"):
+        if key in sanitized:
+            sanitized.pop(key, None)
+            dropped.append(key)
+    if dropped:
+        logger.debug(
+            f"sanitize_model_request_kwargs: dropped {dropped} "
+            f"(OpenAI reasoning model with reasoning_effort={effort!r})"
+        )
+
+
 def sanitize_model_request_kwargs(
     request_kwargs: Dict[str, Any],
     *,
@@ -91,6 +168,12 @@ def sanitize_model_request_kwargs(
     - 如果能力未知，则保留，交给运行时 fallback 兜底。
 
     另：对仅支持 max_completion_tokens 的模型，将 max_tokens 映射为该参数。
+
+    当 tool_choice 为 ``required`` 时，从 ``extra_body`` 移除 ``reasoning_effort``，
+    避免部分 OpenAI 推理模型在 chat/completions 上报错。
+
+    当仍携带非 ``none`` 的 ``extra_body.reasoning_effort`` 时，移除 ``temperature`` 等采样参数，
+    与 OpenAI/Azure reasoning 模型约束一致。
     """
     sanitized = dict(request_kwargs)
     for key in list(sanitized.keys()):
@@ -119,6 +202,8 @@ def sanitize_model_request_kwargs(
     structured_support = get_structured_output_support(client=client, model_config=model_config)
     if structured_support is False:
         sanitized.pop("response_format", None)
+    _drop_reasoning_effort_when_tool_choice_required(sanitized)
+    _drop_sampling_params_when_reasoning_effort_active(sanitized, resolved_model)
     return sanitized
 
 

--- a/tests/sagents/utils/test_llm_request_utils.py
+++ b/tests/sagents/utils/test_llm_request_utils.py
@@ -92,3 +92,96 @@ def test_sanitize_keeps_zero_sampling_values() -> None:
         model="gpt-4o",
     )
     assert out == {"temperature": 0, "top_p": 0.0, "presence_penalty": 0}
+
+
+def test_sanitize_strips_reasoning_effort_when_tool_choice_required() -> None:
+    out = sanitize_model_request_kwargs(
+        {
+            "tool_choice": "required",
+            "extra_body": {
+                "reasoning_effort": "low",
+                "_step_name": "main",
+            },
+        },
+        model="gpt-5.4",
+    )
+    assert out["tool_choice"] == "required"
+    assert "reasoning_effort" not in out["extra_body"]
+    assert out["extra_body"]["_step_name"] == "main"
+
+
+def test_sanitize_strips_reasoning_effort_tool_choice_required_case_insensitive() -> None:
+    out = sanitize_model_request_kwargs(
+        {
+            "tool_choice": "  Required ",
+            "extra_body": {"reasoning_effort": "minimal"},
+        },
+    )
+    assert "reasoning_effort" not in out["extra_body"]
+
+
+def test_sanitize_keeps_reasoning_effort_when_tool_choice_auto() -> None:
+    out = sanitize_model_request_kwargs(
+        {
+            "tool_choice": "auto",
+            "extra_body": {"reasoning_effort": "low"},
+        },
+    )
+    assert out["extra_body"]["reasoning_effort"] == "low"
+
+
+def test_sanitize_keeps_reasoning_effort_when_no_tool_choice() -> None:
+    out = sanitize_model_request_kwargs(
+        {"extra_body": {"reasoning_effort": "high"}},
+    )
+    assert out["extra_body"]["reasoning_effort"] == "high"
+
+
+def test_sanitize_drops_temperature_when_reasoning_effort_active_gpt54() -> None:
+    out = sanitize_model_request_kwargs(
+        {
+            "temperature": 0.7,
+            "top_p": 0.9,
+            "extra_body": {"reasoning_effort": "low", "_step_name": "tool_suggestion"},
+        },
+        model="gpt-5.4",
+    )
+    assert "temperature" not in out
+    assert "top_p" not in out
+    assert out["extra_body"]["reasoning_effort"] == "low"
+
+
+def test_sanitize_keeps_temperature_when_reasoning_effort_none() -> None:
+    out = sanitize_model_request_kwargs(
+        {
+            "temperature": 0.7,
+            "extra_body": {"reasoning_effort": "none"},
+        },
+        model="gpt-5.4",
+    )
+    assert out["temperature"] == 0.7
+
+
+def test_sanitize_keeps_temperature_after_tool_choice_strips_reasoning() -> None:
+    out = sanitize_model_request_kwargs(
+        {
+            "temperature": 0.7,
+            "tool_choice": "required",
+            "extra_body": {"reasoning_effort": "low"},
+        },
+        model="gpt-5.4",
+    )
+    assert out["temperature"] == 0.7
+    assert "reasoning_effort" not in out["extra_body"]
+
+
+def test_sanitize_keeps_temperature_for_gpt4_with_reasoning_effort_in_body() -> None:
+    """非 OpenAI reasoning slug 不因 extra_body 误带 reasoning_effort 而去温度。"""
+    out = sanitize_model_request_kwargs(
+        {
+            "temperature": 0.7,
+            "extra_body": {"reasoning_effort": "low"},
+        },
+        model="gpt-4o",
+    )
+    assert out["temperature"] == 0.7


### PR DESCRIPTION
## Summary
- Extend `sanitize_model_request_kwargs`: strip `extra_body.reasoning_effort` when `tool_choice=required` to avoid chat/completions 400s on some OpenAI reasoning models.
- When non-`none` `reasoning_effort` remains on a reasoning model, drop `temperature` / `top_p` / penalty fields to match API constraints; order preserves temperature if reasoning_effort was removed by the required-tools path.
- Add unit tests in `tests/sagents/utils/test_llm_request_utils.py`.
- `change_log.md`: revert note for unmerged interrupt-staging work plus this change.

## Files
- `sagents/utils/llm_request_utils.py`
- `tests/sagents/utils/test_llm_request_utils.py`
- `change_log.md`

Made with [Cursor](https://cursor.com)