### PR TITLE
Stabilize terminal transcript display flows

### DIFF
--- a/app/terminal/src/app/commands/agent.rs
+++ b/app/terminal/src/app/commands/agent.rs
@@ -1,17 +1,22 @@
 use crate::app::{App, MessageKind};
+use crate::display_policy::DisplayMode;
 
 const VALID_AGENT_MODES: &[&str] = &["simple", "multi", "fibre"];
 
 impl App {
-    pub fn apply_startup_agent_options(
+    pub fn apply_startup_options(
         &mut self,
         agent_id: Option<String>,
         agent_mode: Option<String>,
+        display_mode: Option<DisplayMode>,
         workspace: Option<std::path::PathBuf>,
     ) {
         self.selected_agent_id = agent_id.filter(|value| !value.trim().is_empty());
         if let Some(mode) = agent_mode {
             self.agent_mode = mode;
+        }
+        if let Some(display_mode) = display_mode {
+            self.display_mode = display_mode;
         }
         self.set_workspace_override(workspace);
     }

--- a/app/terminal/src/app/commands/dispatch.rs
+++ b/app/terminal/src/app/commands/dispatch.rs
@@ -1,5 +1,6 @@
 use crate::app::{App, MessageKind, SubmitAction};
 use crate::app_preview::provider_help_text;
+use crate::display_policy::display_mode_name;
 use crate::slash_command;
 
 use super::agent::normalize_agent_mode;
@@ -313,7 +314,7 @@ impl App {
                             .clone()
                             .unwrap_or_else(|| "(default)".to_string()),
                         self.agent_mode,
-                        super::display::display_mode_name(self.display_mode),
+                        display_mode_name(self.display_mode),
                         self.max_loop_count,
                         if self.selected_skills.is_empty() {
                             "(none)".to_string()

--- a/app/terminal/src/app/commands/display.rs
+++ b/app/terminal/src/app/commands/display.rs
@@ -1,5 +1,5 @@
 use crate::app::{App, MessageKind};
-use crate::display_policy::DisplayMode;
+use crate::display_policy::{display_mode_name, DisplayMode};
 
 impl App {
     pub fn set_display_mode(&mut self, mode: DisplayMode) {
@@ -25,12 +25,5 @@ pub(crate) fn parse_display_mode(value: &str) -> Option<DisplayMode> {
         "compact" => Some(DisplayMode::Compact),
         "verbose" => Some(DisplayMode::Verbose),
         _ => None,
-    }
-}
-
-pub(crate) fn display_mode_name(mode: DisplayMode) -> &'static str {
-    match mode {
-        DisplayMode::Compact => "compact",
-        DisplayMode::Verbose => "verbose",
     }
 }

--- a/app/terminal/src/app/runtime.rs
+++ b/app/terminal/src/app/runtime.rs
@@ -148,6 +148,7 @@ impl App {
             &self.session_id,
             self.selected_agent_id.as_deref(),
             &self.agent_mode,
+            self.display_mode,
             self.max_loop_count,
             &self.workspace_label,
         )
@@ -292,6 +293,7 @@ impl App {
             &self.session_id,
             self.selected_agent_id.as_deref(),
             &self.agent_mode,
+            self.display_mode,
             self.max_loop_count,
             &self.workspace_label,
         );

--- a/app/terminal/src/app/tests.rs
+++ b/app/terminal/src/app/tests.rs
@@ -2,6 +2,8 @@
 mod agent;
 #[path = "tests/display.rs"]
 mod display;
+#[path = "tests/golden.rs"]
+mod golden;
 #[path = "tests/popup.rs"]
 mod popup;
 #[path = "tests/sessions.rs"]

--- a/app/terminal/src/app/tests/agent.rs
+++ b/app/terminal/src/app/tests/agent.rs
@@ -1,4 +1,5 @@
 use crate::app::{App, SubmitAction};
+use crate::display_policy::DisplayMode;
 use std::path::PathBuf;
 
 #[test]
@@ -36,32 +37,36 @@ fn mode_command_updates_agent_mode_and_requests_restart() {
 }
 
 #[test]
-fn startup_agent_options_apply_without_emitting_messages() {
+fn startup_options_apply_without_emitting_messages() {
     let mut app = App::new();
 
-    app.apply_startup_agent_options(
+    app.apply_startup_options(
         Some("agent_demo".to_string()),
         Some("multi".to_string()),
+        Some(DisplayMode::Verbose),
         None,
     );
 
     assert_eq!(app.selected_agent_id.as_deref(), Some("agent_demo"));
     assert_eq!(app.agent_mode, "multi");
+    assert_eq!(app.display_mode, DisplayMode::Verbose);
     assert_eq!(app.workspace_label, "~/.sage");
 }
 
 #[test]
-fn startup_agent_options_apply_explicit_workspace_override() {
+fn startup_options_apply_explicit_workspace_override() {
     let mut app = App::new();
 
-    app.apply_startup_agent_options(
+    app.apply_startup_options(
         Some("agent_demo".to_string()),
         Some("multi".to_string()),
+        Some(DisplayMode::Compact),
         Some(PathBuf::from("/tmp/demo-workspace")),
     );
 
     assert_eq!(app.selected_agent_id.as_deref(), Some("agent_demo"));
     assert_eq!(app.agent_mode, "multi");
+    assert_eq!(app.display_mode, DisplayMode::Compact);
     assert_eq!(
         app.workspace_override_path(),
         Some(PathBuf::from("/tmp/demo-workspace").as_path())

--- a/app/terminal/src/app/tests/fixtures/compact_completion.txt
+++ b/app/terminal/src/app/tests/fixtures/compact_completion.txt
@@ -1,0 +1,4 @@
+• Process
+  │ tools • execute_shell_command • 60ms • internal tools ×4
+  │ phases • planning 500ms • memory 500ms • response 700ms
+  │ completed • total 1.2s • ttft 180ms • tokens 30

--- a/app/terminal/src/app/tests/fixtures/verbose_completion.txt
+++ b/app/terminal/src/app/tests/fixtures/verbose_completion.txt
@@ -1,0 +1,9 @@
+• Process
+  │ tools
+  │ step 1  completed search_memory • 20ms
+  │ step 2  completed turn_status • 600ms
+  │ step 3  completed search_memory • 20ms
+  │ step 4  completed turn_status • 600ms
+  │ step 5  completed execute_shell_command • 60ms
+  │ phases • ToolSuggestionAgent 500ms • MemoryRecallAgent 500ms • SimpleAgent 700ms
+  │ completed • total 1.2s • ttft 180ms • tokens 30

--- a/app/terminal/src/app/tests/golden.rs
+++ b/app/terminal/src/app/tests/golden.rs
@@ -1,0 +1,126 @@
+use super::super::App;
+use crate::backend::{BackendPhaseTiming, BackendStats, BackendToolStep};
+use crate::display_policy::DisplayMode;
+
+#[test]
+fn compact_completion_summary_matches_golden_fixture() {
+    let mut app = App::new();
+    app.display_mode = DisplayMode::Compact;
+    app.busy = true;
+    app.apply_backend_stats(sample_backend_stats());
+    app.complete_request();
+
+    assert_eq!(
+        render_pending_history(&app),
+        include_str!("fixtures/compact_completion.txt").trim_end()
+    );
+}
+
+#[test]
+fn verbose_completion_summary_matches_golden_fixture() {
+    let mut app = App::new();
+    app.display_mode = DisplayMode::Verbose;
+    app.busy = true;
+    app.apply_backend_stats(sample_backend_stats());
+    app.complete_request();
+
+    assert_eq!(
+        render_pending_history(&app),
+        include_str!("fixtures/verbose_completion.txt").trim_end()
+    );
+}
+
+fn render_pending_history(app: &App) -> String {
+    app.pending_history_lines
+        .iter()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim_end()
+        .to_string()
+}
+
+fn sample_backend_stats() -> BackendStats {
+    BackendStats {
+        elapsed_seconds: Some(1.25),
+        first_output_seconds: Some(0.18),
+        prompt_tokens: Some(10),
+        completion_tokens: Some(20),
+        total_tokens: Some(30),
+        tool_steps: vec![
+            BackendToolStep {
+                step: 1,
+                tool_name: "search_memory".to_string(),
+                tool_call_id: Some("call_1".to_string()),
+                status: "completed".to_string(),
+                started_at: Some(10.0),
+                finished_at: Some(10.02),
+                duration_ms: Some(20.0),
+            },
+            BackendToolStep {
+                step: 2,
+                tool_name: "turn_status".to_string(),
+                tool_call_id: Some("call_2".to_string()),
+                status: "completed".to_string(),
+                started_at: Some(10.02),
+                finished_at: Some(10.62),
+                duration_ms: Some(600.0),
+            },
+            BackendToolStep {
+                step: 3,
+                tool_name: "search_memory".to_string(),
+                tool_call_id: Some("call_3".to_string()),
+                status: "completed".to_string(),
+                started_at: Some(10.62),
+                finished_at: Some(10.64),
+                duration_ms: Some(20.0),
+            },
+            BackendToolStep {
+                step: 4,
+                tool_name: "turn_status".to_string(),
+                tool_call_id: Some("call_4".to_string()),
+                status: "completed".to_string(),
+                started_at: Some(10.64),
+                finished_at: Some(11.24),
+                duration_ms: Some(600.0),
+            },
+            BackendToolStep {
+                step: 5,
+                tool_name: "execute_shell_command".to_string(),
+                tool_call_id: Some("call_5".to_string()),
+                status: "completed".to_string(),
+                started_at: Some(11.24),
+                finished_at: Some(11.30),
+                duration_ms: Some(60.0),
+            },
+        ],
+        phase_timings: vec![
+            BackendPhaseTiming {
+                phase: "ToolSuggestionAgent".to_string(),
+                started_at: Some(9.8),
+                finished_at: Some(10.3),
+                duration_ms: Some(500.0),
+                segment_count: 1,
+            },
+            BackendPhaseTiming {
+                phase: "MemoryRecallAgent".to_string(),
+                started_at: Some(10.3),
+                finished_at: Some(10.8),
+                duration_ms: Some(500.0),
+                segment_count: 1,
+            },
+            BackendPhaseTiming {
+                phase: "SimpleAgent".to_string(),
+                started_at: Some(10.8),
+                finished_at: Some(11.5),
+                duration_ms: Some(700.0),
+                segment_count: 1,
+            },
+        ],
+    }
+}

--- a/app/terminal/src/app/tests/welcome.rs
+++ b/app/terminal/src/app/tests/welcome.rs
@@ -13,6 +13,8 @@ fn welcome_banner_renders_in_idle_region_before_transcript() {
         .collect::<Vec<_>>()
         .join("\n");
     assert!(rendered.contains("Sage Terminal"));
+    assert!(rendered.contains("display: "));
+    assert!(rendered.contains("compact"));
     assert!(rendered.contains("Tip: "));
 }
 

--- a/app/terminal/src/app_render/welcome.rs
+++ b/app/terminal/src/app_render/welcome.rs
@@ -1,6 +1,8 @@
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
+use crate::display_policy::{display_mode_name, DisplayMode};
+
 use super::common::{
     accent_style, card_inner_width, subtle_body_style, truncate_middle,
     with_border_with_inner_width,
@@ -13,6 +15,7 @@ pub(crate) fn welcome_lines(
     session_id: &str,
     agent_id: Option<&str>,
     agent_mode: &str,
+    display_mode: DisplayMode,
     max_loop_count: u32,
     workspace_label: &str,
 ) -> Vec<Line<'static>> {
@@ -42,6 +45,9 @@ pub(crate) fn welcome_lines(
                 agent_mode.to_string(),
                 Style::default().fg(Color::Rgb(236, 240, 231)),
             ),
+            Span::raw("   "),
+            Span::styled("display: ", dim),
+            Span::styled(display_mode_name(display_mode), accent_style()),
             Span::raw("   "),
             Span::styled("agent: ", dim),
             Span::styled(

--- a/app/terminal/src/display_policy.rs
+++ b/app/terminal/src/display_policy.rs
@@ -4,6 +4,13 @@ pub(crate) enum DisplayMode {
     Verbose,
 }
 
+pub(crate) fn display_mode_name(mode: DisplayMode) -> &'static str {
+    match mode {
+        DisplayMode::Compact => "compact",
+        DisplayMode::Verbose => "verbose",
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ToolDisplayClass {
     UserFacing,

--- a/app/terminal/src/main.rs
+++ b/app/terminal/src/main.rs
@@ -33,9 +33,10 @@ fn main() -> Result<()> {
         }
     };
     let mut app = App::new();
-    app.apply_startup_agent_options(
+    app.apply_startup_options(
         startup_options.agent_id,
         startup_options.agent_mode,
+        startup_options.display_mode,
         startup_options.workspace.map(PathBuf::from),
     );
     let mut terminal = setup_terminal(&app)?;

--- a/app/terminal/src/startup/help.rs
+++ b/app/terminal/src/startup/help.rs
@@ -4,17 +4,17 @@ pub(crate) fn print_usage() {
 
 pub(crate) fn usage_text() -> &'static str {
     "Usage:
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>]
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] run <prompt>
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] chat <prompt>
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] config init [path] [--force]
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] doctor
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] doctor probe-provider
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] provider verify [key=value...]
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] sessions
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] sessions <limit>
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] sessions inspect <latest|session_id>
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] resume
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] resume latest
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] resume <session_id>"
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>]
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] run <prompt>
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] chat <prompt>
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] config init [path] [--force]
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] doctor
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] doctor probe-provider
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] provider verify [key=value...]
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] sessions
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] sessions <limit>
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] sessions inspect <latest|session_id>
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] resume
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] resume latest
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] resume <session_id>"
 }

--- a/app/terminal/src/startup/mod.rs
+++ b/app/terminal/src/startup/mod.rs
@@ -1,3 +1,5 @@
+use crate::display_policy::DisplayMode;
+
 mod help;
 mod parse;
 #[cfg(test)]
@@ -7,6 +9,7 @@ mod tests;
 pub(crate) struct StartupOptions {
     pub(crate) agent_id: Option<String>,
     pub(crate) agent_mode: Option<String>,
+    pub(crate) display_mode: Option<DisplayMode>,
     pub(crate) workspace: Option<String>,
 }
 

--- a/app/terminal/src/startup/parse.rs
+++ b/app/terminal/src/startup/parse.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 
 use crate::app::{normalize_agent_mode, SessionPickerMode, SubmitAction};
+use crate::display_policy::DisplayMode;
 
 use super::help::usage_text;
 use super::StartupBehavior;
@@ -140,10 +141,25 @@ fn parse_global_options(args: &[String]) -> Result<(StartupOptions, Vec<String>)
                 options.workspace = Some(value.clone());
                 idx += 2;
             }
+            "--display" => {
+                let value = args
+                    .get(idx + 1)
+                    .ok_or_else(|| anyhow!("--display requires a value"))?;
+                options.display_mode = Some(parse_display_mode(value)?);
+                idx += 2;
+            }
             _ => break,
         }
     }
     Ok((options, args[idx..].to_vec()))
+}
+
+fn parse_display_mode(value: &str) -> Result<DisplayMode> {
+    match value.trim().to_lowercase().as_str() {
+        "compact" => Ok(DisplayMode::Compact),
+        "verbose" => Ok(DisplayMode::Verbose),
+        _ => Err(anyhow!("--display must be one of: compact, verbose")),
+    }
 }
 
 fn parse_config_init_args(args: &[String]) -> Result<(Option<String>, bool)> {

--- a/app/terminal/src/startup/tests.rs
+++ b/app/terminal/src/startup/tests.rs
@@ -1,5 +1,6 @@
 use super::{parse_startup_action, StartupBehavior};
 use crate::app::{SessionPickerMode, SubmitAction};
+use crate::display_policy::DisplayMode;
 
 #[test]
 fn parse_startup_action_defaults_to_plain_tui() {
@@ -214,6 +215,8 @@ fn parse_startup_action_supports_agent_options() {
         "agent_demo".to_string(),
         "--agent-mode".to_string(),
         "fibre".to_string(),
+        "--display".to_string(),
+        "verbose".to_string(),
         "run".to_string(),
         "inspect".to_string(),
     ])
@@ -224,6 +227,7 @@ fn parse_startup_action_supports_agent_options() {
             if prompt == "inspect"
             && options.agent_id.as_deref() == Some("agent_demo")
             && options.agent_mode.as_deref() == Some("fibre")
+            && options.display_mode == Some(DisplayMode::Verbose)
             && options.workspace.is_none()
     ));
 }
@@ -246,10 +250,34 @@ fn parse_startup_action_supports_workspace_option() {
 }
 
 #[test]
+fn parse_startup_action_supports_display_option() {
+    let action = parse_startup_action(vec![
+        "--display".to_string(),
+        "compact".to_string(),
+        "run".to_string(),
+        "inspect".to_string(),
+    ])
+    .expect("parse");
+    assert!(matches!(
+        action,
+        StartupBehavior::Run { action: Some(SubmitAction::RunTask(prompt)), options }
+            if prompt == "inspect"
+            && options.display_mode == Some(DisplayMode::Compact)
+    ));
+}
+
+#[test]
 fn parse_startup_action_rejects_invalid_agent_mode() {
     let err = parse_startup_action(vec!["--agent-mode".to_string(), "weird".to_string()])
         .expect_err("should fail");
     assert!(err.to_string().contains("simple, multi, fibre"));
+}
+
+#[test]
+fn parse_startup_action_rejects_invalid_display_mode() {
+    let err = parse_startup_action(vec!["--display".to_string(), "loud".to_string()])
+        .expect_err("should fail");
+    assert!(err.to_string().contains("compact, verbose"));
 }
 
 #[test]

--- a/app/terminal/src/terminal/tests/interaction.rs
+++ b/app/terminal/src/terminal/tests/interaction.rs
@@ -217,3 +217,17 @@ fn popup_visible_enter_submits_typed_slash_command_instead_of_selected_popup_ite
     assert!(handled);
     assert!(app.should_quit);
 }
+
+#[test]
+fn display_command_switches_mode_through_normal_input_flow() {
+    let mut app = App::new();
+    app.input = "/display set verbose".to_string();
+    app.input_cursor = app.input.len();
+
+    let action = app.submit_input();
+    assert!(matches!(action, SubmitAction::Handled));
+    assert_eq!(
+        app.display_mode,
+        crate::display_policy::DisplayMode::Verbose
+    );
+}

--- a/docs/en/applications/TUI.md
+++ b/docs/en/applications/TUI.md
@@ -83,6 +83,8 @@ Currently supported startup forms:
 
 ```bash
 sage-terminal
+sage-terminal --display compact
+sage-terminal --display verbose
 sage-terminal --agent-id agent_demo
 sage-terminal --agent-id agent_demo --agent-mode fibre
 sage-terminal --workspace /path/to/project
@@ -118,6 +120,7 @@ The current TUI preview includes these core commands:
 - `/help`
 - `/agent`
 - `/mode`
+- `/display`
 - `/new`
 - `/sessions`
 - `/resume`
@@ -142,14 +145,35 @@ Supported entrypoints:
 - startup flags:
   - `--agent-id <id>`
   - `--agent-mode <simple|multi|fibre>`
+  - `--display <compact|verbose>`
 - in-app commands:
   - `/agent`
   - `/agent set <agent_id>`
   - `/agent clear`
   - `/mode`
   - `/mode set <simple|multi|fibre>`
+  - `/display`
+  - `/display set <compact|verbose>`
 
 The actual agent definition, tools, skills, and behavior still come from the Sage runtime's stored agent configuration.
+
+## Display Modes
+
+Terminal transcript rendering supports two presentation modes:
+
+- `compact`: the default. Internal tool chatter is hidden, summaries are collapsed, and phase names are mapped to shorter user-facing labels.
+- `verbose`: restores internal tool steps, step numbers, and raw phase names for debugging.
+
+You can choose the mode either at startup or inside the TUI:
+
+```bash
+sage-terminal --display verbose
+```
+
+```text
+/display set compact
+/display set verbose
+```
 
 ## Workspace Behavior
 

--- a/docs/zh/applications/TUI.md
+++ b/docs/zh/applications/TUI.md
@@ -83,6 +83,8 @@ cargo build --release
 
 ```bash
 sage-terminal
+sage-terminal --display compact
+sage-terminal --display verbose
 sage-terminal --agent-id agent_demo
 sage-terminal --agent-id agent_demo --agent-mode fibre
 sage-terminal --workspace /path/to/project
@@ -118,6 +120,7 @@ cargo run --quiet --offline -- resume
 - `/help`
 - `/agent`
 - `/mode`
+- `/display`
 - `/new`
 - `/sessions`
 - `/resume`
@@ -142,14 +145,35 @@ TUI 现在可以覆盖运行时使用的 agent，但不会自己接管 agent 配
 - 启动参数：
   - `--agent-id <id>`
   - `--agent-mode <simple|multi|fibre>`
+  - `--display <compact|verbose>`
 - TUI 内命令：
   - `/agent`
   - `/agent set <agent_id>`
   - `/agent clear`
   - `/mode`
   - `/mode set <simple|multi|fibre>`
+  - `/display`
+  - `/display set <compact|verbose>`
 
 真正的 agent 定义、工具、skills 和行为仍然来自 Sage runtime 已保存的 agent 配置。
+
+## Display 模式
+
+Terminal transcript 现在支持两种展示模式：
+
+- `compact`：默认模式。隐藏内部工具噪音、压缩摘要，并把 phase 名映射成更短的用户视角标签。
+- `verbose`：用于排查问题。会恢复内部工具步骤、step 编号和原始 phase 名。
+
+你可以在启动时指定，也可以在 TUI 内切换：
+
+```bash
+sage-terminal --display verbose
+```
+
+```text
+/display set compact
+/display set verbose
+```
 
 ## Workspace 行为
 


### PR DESCRIPTION
## Summary
  - stabilize sage-terminal transcript rendering with compact and verbose golden coverage
  - add startup-level display mode selection so transcript behavior is configurable before launch
  - document and lock down the terminal display flow to reduce regression risk

  ## What Changed
  - add --display <compact|verbose> to sage-terminal startup parsing and initialization
  - wire startup display mode through the terminal app state and welcome banner
  - add compact and verbose transcript golden fixtures for stable completion summaries
  - extend app, startup, and interaction tests to cover display mode startup and switching
  - refresh TUI docs to explain display modes and startup/runtime usage

  ## Validation
  - cargo test startup::tests --quiet
  - cargo test app::tests --quiet
  - cargo test terminal::tests::interaction --quiet
  - cargo test ui::tests --quiet
  - cargo test backend::tests::contract --quiet
  - cargo fmt --check
  - cargo build --offline