### PR TITLE
Add terminal run control flows

### DIFF
--- a/app/terminal/src/app/commands/agent.rs
+++ b/app/terminal/src/app/commands/agent.rs
@@ -1,17 +1,22 @@
 use crate::app::{App, MessageKind};
+use crate::display_policy::DisplayMode;
 
 const VALID_AGENT_MODES: &[&str] = &["simple", "multi", "fibre"];
 
 impl App {
-    pub fn apply_startup_agent_options(
+    pub fn apply_startup_options(
         &mut self,
         agent_id: Option<String>,
         agent_mode: Option<String>,
+        display_mode: Option<DisplayMode>,
         workspace: Option<std::path::PathBuf>,
     ) {
         self.selected_agent_id = agent_id.filter(|value| !value.trim().is_empty());
         if let Some(mode) = agent_mode {
             self.agent_mode = mode;
+        }
+        if let Some(display_mode) = display_mode {
+            self.display_mode = display_mode;
         }
         self.set_workspace_override(workspace);
     }

--- a/app/terminal/src/app/commands/dispatch.rs
+++ b/app/terminal/src/app/commands/dispatch.rs
@@ -303,6 +303,22 @@ impl App {
                     SubmitAction::Handled
                 }
             },
+            "/interrupt" => match (parts.next(), parts.next()) {
+                (None, None) => SubmitAction::Interrupt,
+                _ => {
+                    self.queue_message(MessageKind::System, "Usage: /interrupt");
+                    self.status = format!("invalid command  {}", self.session_id);
+                    SubmitAction::Handled
+                }
+            },
+            "/retry" => match (parts.next(), parts.next()) {
+                (None, None) => SubmitAction::RetryLastTask,
+                _ => {
+                    self.queue_message(MessageKind::System, "Usage: /retry");
+                    self.status = format!("invalid command  {}", self.session_id);
+                    SubmitAction::Handled
+                }
+            },
             "/status" => {
                 self.queue_message(
                     MessageKind::System,

--- a/app/terminal/src/app/commands/dispatch.rs
+++ b/app/terminal/src/app/commands/dispatch.rs
@@ -1,5 +1,6 @@
 use crate::app::{App, MessageKind, SubmitAction};
 use crate::app_preview::provider_help_text;
+use crate::display_policy::display_mode_name;
 use crate::slash_command;
 
 use super::agent::normalize_agent_mode;
@@ -313,7 +314,7 @@ impl App {
                             .clone()
                             .unwrap_or_else(|| "(default)".to_string()),
                         self.agent_mode,
-                        super::display::display_mode_name(self.display_mode),
+                        display_mode_name(self.display_mode),
                         self.max_loop_count,
                         if self.selected_skills.is_empty() {
                             "(none)".to_string()

--- a/app/terminal/src/app/commands/display.rs
+++ b/app/terminal/src/app/commands/display.rs
@@ -1,5 +1,5 @@
 use crate::app::{App, MessageKind};
-use crate::display_policy::DisplayMode;
+use crate::display_policy::{display_mode_name, DisplayMode};
 
 impl App {
     pub fn set_display_mode(&mut self, mode: DisplayMode) {
@@ -25,12 +25,5 @@ pub(crate) fn parse_display_mode(value: &str) -> Option<DisplayMode> {
         "compact" => Some(DisplayMode::Compact),
         "verbose" => Some(DisplayMode::Verbose),
         _ => None,
-    }
-}
-
-pub(crate) fn display_mode_name(mode: DisplayMode) -> &'static str {
-    match mode {
-        DisplayMode::Compact => "compact",
-        DisplayMode::Verbose => "verbose",
     }
 }

--- a/app/terminal/src/app/commands/session.rs
+++ b/app/terminal/src/app/commands/session.rs
@@ -16,6 +16,8 @@ impl App {
         self.first_output_latency = None;
         self.last_request_duration = None;
         self.last_first_output_latency = None;
+        self.last_submitted_task = None;
+        self.current_task = None;
         self.active_tools.clear();
         self.pending_history_lines.clear();
         self.committed_history_lines.clear();

--- a/app/terminal/src/app/input.rs
+++ b/app/terminal/src/app/input.rs
@@ -14,21 +14,32 @@ impl App {
             return self.handle_command(&text);
         }
 
-        self.queue_message(crate::app::MessageKind::User, text.clone());
+        self.begin_task_submission(text.clone(), true);
+        SubmitAction::RunTask(text)
+    }
+
+    pub(crate) fn begin_task_submission(&mut self, task: String, queue_user_message: bool) {
+        if queue_user_message {
+            self.queue_message(crate::app::MessageKind::User, task.clone());
+        }
+        self.last_submitted_task = Some(task.clone());
+        self.current_task = Some(task);
         self.busy = true;
         self.live_message = None;
         self.live_message_had_history = false;
         self.request_started_at = Some(std::time::Instant::now());
         self.first_output_latency = None;
         self.last_request_duration = None;
+        self.last_first_output_latency = None;
+        self.pending_backend_stats = None;
         self.active_phase = None;
         self.active_tools.clear();
+        self.tool_step_seq = 0;
         self.status = format!("running  {}", self.session_id);
-        SubmitAction::RunTask(text)
     }
 
     pub fn insert_char(&mut self, ch: char) {
-        if self.busy {
+        if self.busy && !(self.input.starts_with('/') || ch == '/') {
             return;
         }
         self.input.insert(self.input_cursor, ch);
@@ -37,7 +48,10 @@ impl App {
     }
 
     pub fn insert_text(&mut self, text: &str) {
-        if self.busy || text.is_empty() {
+        if text.is_empty() {
+            return;
+        }
+        if self.busy && !(self.input.starts_with('/') || text.starts_with('/')) {
             return;
         }
         self.input.insert_str(self.input_cursor, text);
@@ -50,7 +64,7 @@ impl App {
     }
 
     pub fn backspace(&mut self) {
-        if self.busy || self.input_cursor == 0 {
+        if (self.busy && !self.input.starts_with('/')) || self.input_cursor == 0 {
             return;
         }
         let prev = previous_boundary(&self.input, self.input_cursor);
@@ -60,7 +74,7 @@ impl App {
     }
 
     pub fn delete(&mut self) {
-        if self.busy || self.input_cursor >= self.input.len() {
+        if (self.busy && !self.input.starts_with('/')) || self.input_cursor >= self.input.len() {
             return;
         }
         let next = next_boundary(&self.input, self.input_cursor);
@@ -69,18 +83,30 @@ impl App {
     }
 
     pub fn move_cursor_left(&mut self) {
+        if self.busy && !self.input.starts_with('/') {
+            return;
+        }
         self.input_cursor = previous_boundary(&self.input, self.input_cursor);
     }
 
     pub fn move_cursor_right(&mut self) {
+        if self.busy && !self.input.starts_with('/') {
+            return;
+        }
         self.input_cursor = next_boundary(&self.input, self.input_cursor);
     }
 
     pub fn move_cursor_home(&mut self) {
+        if self.busy && !self.input.starts_with('/') {
+            return;
+        }
         self.input_cursor = 0;
     }
 
     pub fn move_cursor_end(&mut self) {
+        if self.busy && !self.input.starts_with('/') {
+            return;
+        }
         self.input_cursor = self.input.len();
     }
 

--- a/app/terminal/src/app/runtime.rs
+++ b/app/terminal/src/app/runtime.rs
@@ -148,6 +148,7 @@ impl App {
             &self.session_id,
             self.selected_agent_id.as_deref(),
             &self.agent_mode,
+            self.display_mode,
             self.max_loop_count,
             &self.workspace_label,
         )
@@ -292,6 +293,7 @@ impl App {
             &self.session_id,
             self.selected_agent_id.as_deref(),
             &self.agent_mode,
+            self.display_mode,
             self.max_loop_count,
             &self.workspace_label,
         );

--- a/app/terminal/src/app/runtime.rs
+++ b/app/terminal/src/app/runtime.rs
@@ -39,6 +39,7 @@ impl App {
 
     pub fn complete_request(&mut self) {
         self.busy = false;
+        self.current_task = None;
         let backend_stats = self.pending_backend_stats.take();
         self.last_request_duration = backend_stats
             .as_ref()
@@ -82,6 +83,7 @@ impl App {
 
     pub fn fail_request(&mut self, message: impl Into<String>) {
         self.busy = false;
+        self.current_task = None;
         let backend_stats = self.pending_backend_stats.take();
         self.last_request_duration = backend_stats
             .as_ref()
@@ -122,6 +124,56 @@ impl App {
         }
         self.queue_message(MessageKind::System, message.into());
         self.status = format!("error  {}", self.session_id);
+    }
+
+    pub fn interrupt_request(&mut self) {
+        if !self.busy {
+            return;
+        }
+
+        let had_partial_output = self
+            .live_message
+            .as_ref()
+            .map(|(_, text)| !text.trim().is_empty())
+            .unwrap_or(false);
+        let had_visible_output = had_partial_output
+            || self.live_message_had_history
+            || self.first_output_latency.is_some();
+        let backend_stats = self.pending_backend_stats.take();
+        self.last_request_duration = backend_stats
+            .as_ref()
+            .and_then(|stats| duration_from_seconds(stats.elapsed_seconds))
+            .or_else(|| self.request_started_at.map(|started| started.elapsed()));
+        self.last_first_output_latency = backend_stats
+            .as_ref()
+            .and_then(|stats| duration_from_seconds(stats.first_output_seconds))
+            .or(self.first_output_latency);
+        let completion_summary = request_timing_summary(
+            self.last_request_duration,
+            self.last_first_output_latency,
+            backend_stats.as_ref(),
+        );
+        self.busy = false;
+        self.current_task = None;
+        self.request_started_at = None;
+        self.first_output_latency = None;
+        self.active_phase = None;
+        self.active_tools.clear();
+        self.flush_live_message();
+
+        let mut lines = Vec::new();
+        if let Some(summary) = completion_summary {
+            lines.push(format!("interrupted • {summary}"));
+        } else {
+            lines.push("interrupted".to_string());
+        }
+        if had_visible_output {
+            lines.push("partial output preserved • /retry available".to_string());
+        } else {
+            lines.push("/retry available".to_string());
+        }
+        self.queue_message(MessageKind::Process, lines.join("\n"));
+        self.status = format!("interrupted  {}", self.session_id);
     }
 
     pub fn rendered_live_lines(&self) -> Vec<Line<'static>> {

--- a/app/terminal/src/app/state.rs
+++ b/app/terminal/src/app/state.rs
@@ -12,6 +12,8 @@ pub enum SubmitAction {
     Noop,
     Handled,
     RunTask(String),
+    Interrupt,
+    RetryLastTask,
     OpenSessionPicker {
         mode: SessionPickerMode,
         limit: usize,
@@ -155,6 +157,8 @@ pub struct App {
     pub selected_skills: Vec<String>,
     pub selected_model: Option<String>,
     pub display_mode: DisplayMode,
+    pub(crate) last_submitted_task: Option<String>,
+    pub(crate) current_task: Option<String>,
     pub pending_history_lines: Vec<Line<'static>>,
     pub(crate) committed_history_lines: Vec<Line<'static>>,
     pub live_message: Option<(MessageKind, String)>,
@@ -205,6 +209,8 @@ impl App {
             selected_skills: Vec::new(),
             selected_model: None,
             display_mode: DisplayMode::Compact,
+            last_submitted_task: None,
+            current_task: None,
             pending_history_lines: Vec::new(),
             committed_history_lines: Vec::new(),
             live_message: None,
@@ -248,6 +254,8 @@ impl App {
         self.pending_backend_stats = None;
         self.active_phase = None;
         self.active_tools.clear();
+        self.last_submitted_task = None;
+        self.current_task = None;
         self.tool_step_seq = 0;
         self.pending_history_lines.clear();
         self.committed_history_lines.clear();

--- a/app/terminal/src/app/tests.rs
+++ b/app/terminal/src/app/tests.rs
@@ -2,6 +2,8 @@
 mod agent;
 #[path = "tests/display.rs"]
 mod display;
+#[path = "tests/golden.rs"]
+mod golden;
 #[path = "tests/popup.rs"]
 mod popup;
 #[path = "tests/sessions.rs"]

--- a/app/terminal/src/app/tests.rs
+++ b/app/terminal/src/app/tests.rs
@@ -6,6 +6,8 @@ mod display;
 mod golden;
 #[path = "tests/popup.rs"]
 mod popup;
+#[path = "tests/run_control.rs"]
+mod run_control;
 #[path = "tests/sessions.rs"]
 mod sessions;
 #[path = "tests/surfaces.rs"]

--- a/app/terminal/src/app/tests/agent.rs
+++ b/app/terminal/src/app/tests/agent.rs
@@ -1,4 +1,5 @@
 use crate::app::{App, SubmitAction};
+use crate::display_policy::DisplayMode;
 use std::path::PathBuf;
 
 #[test]
@@ -36,32 +37,36 @@ fn mode_command_updates_agent_mode_and_requests_restart() {
 }
 
 #[test]
-fn startup_agent_options_apply_without_emitting_messages() {
+fn startup_options_apply_without_emitting_messages() {
     let mut app = App::new();
 
-    app.apply_startup_agent_options(
+    app.apply_startup_options(
         Some("agent_demo".to_string()),
         Some("multi".to_string()),
+        Some(DisplayMode::Verbose),
         None,
     );
 
     assert_eq!(app.selected_agent_id.as_deref(), Some("agent_demo"));
     assert_eq!(app.agent_mode, "multi");
+    assert_eq!(app.display_mode, DisplayMode::Verbose);
     assert_eq!(app.workspace_label, "~/.sage");
 }
 
 #[test]
-fn startup_agent_options_apply_explicit_workspace_override() {
+fn startup_options_apply_explicit_workspace_override() {
     let mut app = App::new();
 
-    app.apply_startup_agent_options(
+    app.apply_startup_options(
         Some("agent_demo".to_string()),
         Some("multi".to_string()),
+        Some(DisplayMode::Compact),
         Some(PathBuf::from("/tmp/demo-workspace")),
     );
 
     assert_eq!(app.selected_agent_id.as_deref(), Some("agent_demo"));
     assert_eq!(app.agent_mode, "multi");
+    assert_eq!(app.display_mode, DisplayMode::Compact);
     assert_eq!(
         app.workspace_override_path(),
         Some(PathBuf::from("/tmp/demo-workspace").as_path())

--- a/app/terminal/src/app/tests/fixtures/compact_completion.txt
+++ b/app/terminal/src/app/tests/fixtures/compact_completion.txt
@@ -1,0 +1,4 @@
+• Process
+  │ tools • execute_shell_command • 60ms • internal tools ×4
+  │ phases • planning 500ms • memory 500ms • response 700ms
+  │ completed • total 1.2s • ttft 180ms • tokens 30

--- a/app/terminal/src/app/tests/fixtures/verbose_completion.txt
+++ b/app/terminal/src/app/tests/fixtures/verbose_completion.txt
@@ -1,0 +1,9 @@
+• Process
+  │ tools
+  │ step 1  completed search_memory • 20ms
+  │ step 2  completed turn_status • 600ms
+  │ step 3  completed search_memory • 20ms
+  │ step 4  completed turn_status • 600ms
+  │ step 5  completed execute_shell_command • 60ms
+  │ phases • ToolSuggestionAgent 500ms • MemoryRecallAgent 500ms • SimpleAgent 700ms
+  │ completed • total 1.2s • ttft 180ms • tokens 30

--- a/app/terminal/src/app/tests/golden.rs
+++ b/app/terminal/src/app/tests/golden.rs
@@ -1,0 +1,126 @@
+use super::super::App;
+use crate::backend::{BackendPhaseTiming, BackendStats, BackendToolStep};
+use crate::display_policy::DisplayMode;
+
+#[test]
+fn compact_completion_summary_matches_golden_fixture() {
+    let mut app = App::new();
+    app.display_mode = DisplayMode::Compact;
+    app.busy = true;
+    app.apply_backend_stats(sample_backend_stats());
+    app.complete_request();
+
+    assert_eq!(
+        render_pending_history(&app),
+        include_str!("fixtures/compact_completion.txt").trim_end()
+    );
+}
+
+#[test]
+fn verbose_completion_summary_matches_golden_fixture() {
+    let mut app = App::new();
+    app.display_mode = DisplayMode::Verbose;
+    app.busy = true;
+    app.apply_backend_stats(sample_backend_stats());
+    app.complete_request();
+
+    assert_eq!(
+        render_pending_history(&app),
+        include_str!("fixtures/verbose_completion.txt").trim_end()
+    );
+}
+
+fn render_pending_history(app: &App) -> String {
+    app.pending_history_lines
+        .iter()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim_end()
+        .to_string()
+}
+
+fn sample_backend_stats() -> BackendStats {
+    BackendStats {
+        elapsed_seconds: Some(1.25),
+        first_output_seconds: Some(0.18),
+        prompt_tokens: Some(10),
+        completion_tokens: Some(20),
+        total_tokens: Some(30),
+        tool_steps: vec![
+            BackendToolStep {
+                step: 1,
+                tool_name: "search_memory".to_string(),
+                tool_call_id: Some("call_1".to_string()),
+                status: "completed".to_string(),
+                started_at: Some(10.0),
+                finished_at: Some(10.02),
+                duration_ms: Some(20.0),
+            },
+            BackendToolStep {
+                step: 2,
+                tool_name: "turn_status".to_string(),
+                tool_call_id: Some("call_2".to_string()),
+                status: "completed".to_string(),
+                started_at: Some(10.02),
+                finished_at: Some(10.62),
+                duration_ms: Some(600.0),
+            },
+            BackendToolStep {
+                step: 3,
+                tool_name: "search_memory".to_string(),
+                tool_call_id: Some("call_3".to_string()),
+                status: "completed".to_string(),
+                started_at: Some(10.62),
+                finished_at: Some(10.64),
+                duration_ms: Some(20.0),
+            },
+            BackendToolStep {
+                step: 4,
+                tool_name: "turn_status".to_string(),
+                tool_call_id: Some("call_4".to_string()),
+                status: "completed".to_string(),
+                started_at: Some(10.64),
+                finished_at: Some(11.24),
+                duration_ms: Some(600.0),
+            },
+            BackendToolStep {
+                step: 5,
+                tool_name: "execute_shell_command".to_string(),
+                tool_call_id: Some("call_5".to_string()),
+                status: "completed".to_string(),
+                started_at: Some(11.24),
+                finished_at: Some(11.30),
+                duration_ms: Some(60.0),
+            },
+        ],
+        phase_timings: vec![
+            BackendPhaseTiming {
+                phase: "ToolSuggestionAgent".to_string(),
+                started_at: Some(9.8),
+                finished_at: Some(10.3),
+                duration_ms: Some(500.0),
+                segment_count: 1,
+            },
+            BackendPhaseTiming {
+                phase: "MemoryRecallAgent".to_string(),
+                started_at: Some(10.3),
+                finished_at: Some(10.8),
+                duration_ms: Some(500.0),
+                segment_count: 1,
+            },
+            BackendPhaseTiming {
+                phase: "SimpleAgent".to_string(),
+                started_at: Some(10.8),
+                finished_at: Some(11.5),
+                duration_ms: Some(700.0),
+                segment_count: 1,
+            },
+        ],
+    }
+}

--- a/app/terminal/src/app/tests/run_control.rs
+++ b/app/terminal/src/app/tests/run_control.rs
@@ -1,0 +1,109 @@
+use std::time::{Duration, Instant};
+
+use super::super::{App, SubmitAction};
+
+#[test]
+fn submit_input_tracks_last_and_current_task() {
+    let mut app = App::new();
+    app.input = "explain run control".to_string();
+    app.input_cursor = app.input.len();
+
+    let action = app.submit_input();
+
+    assert!(matches!(action, SubmitAction::RunTask(_)));
+    assert_eq!(
+        app.last_submitted_task.as_deref(),
+        Some("explain run control")
+    );
+    assert_eq!(app.current_task.as_deref(), Some("explain run control"));
+    assert!(app.busy);
+}
+
+#[test]
+fn interrupt_command_and_retry_command_parse_cleanly() {
+    let mut app = App::new();
+
+    assert!(matches!(
+        app.handle_command("/interrupt"),
+        SubmitAction::Interrupt
+    ));
+    assert!(matches!(
+        app.handle_command("/retry"),
+        SubmitAction::RetryLastTask
+    ));
+}
+
+#[test]
+fn interrupt_request_preserves_partial_output_and_retry_hint() {
+    let mut app = App::new();
+    app.begin_task_submission("draft answer".to_string(), true);
+    app.request_started_at = Some(Instant::now() - Duration::from_millis(1400));
+    app.first_output_latency = Some(Duration::from_millis(280));
+    app.append_assistant_chunk("partial answer");
+
+    app.interrupt_request();
+
+    assert!(!app.busy);
+    assert!(app.current_task.is_none());
+    assert_eq!(app.last_submitted_task.as_deref(), Some("draft answer"));
+
+    let rendered = app
+        .pending_history_lines
+        .iter()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("partial answer"));
+    assert!(rendered.contains("interrupted • total 1.4s"));
+    assert!(rendered.contains("ttft 280ms"));
+    assert!(rendered.contains("partial output preserved • /retry available"));
+}
+
+#[test]
+fn interrupt_request_without_partial_output_still_offers_retry() {
+    let mut app = App::new();
+    app.begin_task_submission("draft answer".to_string(), true);
+    app.request_started_at = Some(Instant::now() - Duration::from_millis(900));
+
+    app.interrupt_request();
+
+    let rendered = app
+        .pending_history_lines
+        .iter()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("interrupted • total 900ms"));
+    assert!(rendered.contains("/retry available"));
+    assert!(!rendered.contains("partial output preserved"));
+}
+
+#[test]
+fn begin_task_submission_resets_request_runtime_state() {
+    let mut app = App::new();
+    app.first_output_latency = Some(Duration::from_millis(10));
+    app.last_request_duration = Some(Duration::from_secs(2));
+    app.last_first_output_latency = Some(Duration::from_millis(30));
+    app.active_phase = Some("planning".to_string());
+    app.tool_step_seq = 5;
+
+    app.begin_task_submission("rerun".to_string(), false);
+
+    assert!(app.busy);
+    assert_eq!(app.current_task.as_deref(), Some("rerun"));
+    assert!(app.first_output_latency.is_none());
+    assert!(app.last_request_duration.is_none());
+    assert!(app.last_first_output_latency.is_none());
+    assert!(app.active_phase.is_none());
+    assert_eq!(app.tool_step_seq, 0);
+}

--- a/app/terminal/src/app/tests/welcome.rs
+++ b/app/terminal/src/app/tests/welcome.rs
@@ -13,6 +13,8 @@ fn welcome_banner_renders_in_idle_region_before_transcript() {
         .collect::<Vec<_>>()
         .join("\n");
     assert!(rendered.contains("Sage Terminal"));
+    assert!(rendered.contains("display: "));
+    assert!(rendered.contains("compact"));
     assert!(rendered.contains("Tip: "));
 }
 

--- a/app/terminal/src/app_render/welcome.rs
+++ b/app/terminal/src/app_render/welcome.rs
@@ -1,6 +1,8 @@
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
+use crate::display_policy::{display_mode_name, DisplayMode};
+
 use super::common::{
     accent_style, card_inner_width, subtle_body_style, truncate_middle,
     with_border_with_inner_width,
@@ -13,6 +15,7 @@ pub(crate) fn welcome_lines(
     session_id: &str,
     agent_id: Option<&str>,
     agent_mode: &str,
+    display_mode: DisplayMode,
     max_loop_count: u32,
     workspace_label: &str,
 ) -> Vec<Line<'static>> {
@@ -42,6 +45,9 @@ pub(crate) fn welcome_lines(
                 agent_mode.to_string(),
                 Style::default().fg(Color::Rgb(236, 240, 231)),
             ),
+            Span::raw("   "),
+            Span::styled("display: ", dim),
+            Span::styled(display_mode_name(display_mode), accent_style()),
             Span::raw("   "),
             Span::styled("agent: ", dim),
             Span::styled(

--- a/app/terminal/src/display_policy.rs
+++ b/app/terminal/src/display_policy.rs
@@ -4,6 +4,13 @@ pub(crate) enum DisplayMode {
     Verbose,
 }
 
+pub(crate) fn display_mode_name(mode: DisplayMode) -> &'static str {
+    match mode {
+        DisplayMode::Compact => "compact",
+        DisplayMode::Verbose => "verbose",
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ToolDisplayClass {
     UserFacing,

--- a/app/terminal/src/main.rs
+++ b/app/terminal/src/main.rs
@@ -33,9 +33,10 @@ fn main() -> Result<()> {
         }
     };
     let mut app = App::new();
-    app.apply_startup_agent_options(
+    app.apply_startup_options(
         startup_options.agent_id,
         startup_options.agent_mode,
+        startup_options.display_mode,
         startup_options.workspace.map(PathBuf::from),
     );
     let mut terminal = setup_terminal(&app)?;

--- a/app/terminal/src/slash_command.rs
+++ b/app/terminal/src/slash_command.rs
@@ -6,7 +6,7 @@ pub(crate) struct SlashCommandDef {
     pub(crate) example: &'static str,
 }
 
-const COMMANDS: [SlashCommandDef; 19] = [
+const COMMANDS: [SlashCommandDef; 21] = [
     SlashCommandDef {
         command: "/help",
         description: "Show available commands",
@@ -96,6 +96,18 @@ const COMMANDS: [SlashCommandDef; 19] = [
         description: "Switch transcript detail level",
         usage: "/display | /display show | /display set <compact|verbose>",
         example: "/display set verbose",
+    },
+    SlashCommandDef {
+        command: "/interrupt",
+        description: "Interrupt the active request",
+        usage: "/interrupt",
+        example: "/interrupt",
+    },
+    SlashCommandDef {
+        command: "/retry",
+        description: "Retry the last submitted task",
+        usage: "/retry",
+        example: "/retry",
     },
     SlashCommandDef {
         command: "/status",

--- a/app/terminal/src/startup/help.rs
+++ b/app/terminal/src/startup/help.rs
@@ -4,17 +4,17 @@ pub(crate) fn print_usage() {
 
 pub(crate) fn usage_text() -> &'static str {
     "Usage:
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>]
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] run <prompt>
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] chat <prompt>
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] config init [path] [--force]
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] doctor
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] doctor probe-provider
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] provider verify [key=value...]
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] sessions
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] sessions <limit>
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] sessions inspect <latest|session_id>
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] resume
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] resume latest
-  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--workspace <path>] resume <session_id>"
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>]
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] run <prompt>
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] chat <prompt>
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] config init [path] [--force]
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] doctor
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] doctor probe-provider
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] provider verify [key=value...]
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] sessions
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] sessions <limit>
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] sessions inspect <latest|session_id>
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] resume
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] resume latest
+  sage-terminal [--agent-id <id>] [--agent-mode <simple|multi|fibre>] [--display <compact|verbose>] [--workspace <path>] resume <session_id>"
 }

--- a/app/terminal/src/startup/mod.rs
+++ b/app/terminal/src/startup/mod.rs
@@ -1,3 +1,5 @@
+use crate::display_policy::DisplayMode;
+
 mod help;
 mod parse;
 #[cfg(test)]
@@ -7,6 +9,7 @@ mod tests;
 pub(crate) struct StartupOptions {
     pub(crate) agent_id: Option<String>,
     pub(crate) agent_mode: Option<String>,
+    pub(crate) display_mode: Option<DisplayMode>,
     pub(crate) workspace: Option<String>,
 }
 

--- a/app/terminal/src/startup/parse.rs
+++ b/app/terminal/src/startup/parse.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 
 use crate::app::{normalize_agent_mode, SessionPickerMode, SubmitAction};
+use crate::display_policy::DisplayMode;
 
 use super::help::usage_text;
 use super::StartupBehavior;
@@ -140,10 +141,25 @@ fn parse_global_options(args: &[String]) -> Result<(StartupOptions, Vec<String>)
                 options.workspace = Some(value.clone());
                 idx += 2;
             }
+            "--display" => {
+                let value = args
+                    .get(idx + 1)
+                    .ok_or_else(|| anyhow!("--display requires a value"))?;
+                options.display_mode = Some(parse_display_mode(value)?);
+                idx += 2;
+            }
             _ => break,
         }
     }
     Ok((options, args[idx..].to_vec()))
+}
+
+fn parse_display_mode(value: &str) -> Result<DisplayMode> {
+    match value.trim().to_lowercase().as_str() {
+        "compact" => Ok(DisplayMode::Compact),
+        "verbose" => Ok(DisplayMode::Verbose),
+        _ => Err(anyhow!("--display must be one of: compact, verbose")),
+    }
 }
 
 fn parse_config_init_args(args: &[String]) -> Result<(Option<String>, bool)> {

--- a/app/terminal/src/startup/tests.rs
+++ b/app/terminal/src/startup/tests.rs
@@ -1,5 +1,6 @@
 use super::{parse_startup_action, StartupBehavior};
 use crate::app::{SessionPickerMode, SubmitAction};
+use crate::display_policy::DisplayMode;
 
 #[test]
 fn parse_startup_action_defaults_to_plain_tui() {
@@ -214,6 +215,8 @@ fn parse_startup_action_supports_agent_options() {
         "agent_demo".to_string(),
         "--agent-mode".to_string(),
         "fibre".to_string(),
+        "--display".to_string(),
+        "verbose".to_string(),
         "run".to_string(),
         "inspect".to_string(),
     ])
@@ -224,6 +227,7 @@ fn parse_startup_action_supports_agent_options() {
             if prompt == "inspect"
             && options.agent_id.as_deref() == Some("agent_demo")
             && options.agent_mode.as_deref() == Some("fibre")
+            && options.display_mode == Some(DisplayMode::Verbose)
             && options.workspace.is_none()
     ));
 }
@@ -246,10 +250,34 @@ fn parse_startup_action_supports_workspace_option() {
 }
 
 #[test]
+fn parse_startup_action_supports_display_option() {
+    let action = parse_startup_action(vec![
+        "--display".to_string(),
+        "compact".to_string(),
+        "run".to_string(),
+        "inspect".to_string(),
+    ])
+    .expect("parse");
+    assert!(matches!(
+        action,
+        StartupBehavior::Run { action: Some(SubmitAction::RunTask(prompt)), options }
+            if prompt == "inspect"
+            && options.display_mode == Some(DisplayMode::Compact)
+    ));
+}
+
+#[test]
 fn parse_startup_action_rejects_invalid_agent_mode() {
     let err = parse_startup_action(vec!["--agent-mode".to_string(), "weird".to_string()])
         .expect_err("should fail");
     assert!(err.to_string().contains("simple, multi, fibre"));
+}
+
+#[test]
+fn parse_startup_action_rejects_invalid_display_mode() {
+    let err = parse_startup_action(vec!["--display".to_string(), "loud".to_string()])
+        .expect_err("should fail");
+    assert!(err.to_string().contains("compact, verbose"));
 }
 
 #[test]

--- a/app/terminal/src/terminal/actions.rs
+++ b/app/terminal/src/terminal/actions.rs
@@ -25,6 +25,8 @@ pub(super) fn handle_submit_action(
         SubmitAction::Noop => Ok(false),
         SubmitAction::Handled => Ok(true),
         SubmitAction::RunTask(task) => chat::run_task(app, backend, task),
+        SubmitAction::Interrupt => chat::interrupt_task(app, backend),
+        SubmitAction::RetryLastTask => chat::retry_last_task(app, backend),
         SubmitAction::OpenSessionPicker { mode, limit } => {
             sessions::open_session_picker(app, mode, limit)
         }

--- a/app/terminal/src/terminal/actions/chat.rs
+++ b/app/terminal/src/terminal/actions/chat.rs
@@ -24,3 +24,43 @@ pub(super) fn run_task(
     handle.send_prompt(&request.task)?;
     Ok(true)
 }
+
+pub(super) fn interrupt_task(app: &mut App, backend: &mut Option<BackendHandle>) -> Result<bool> {
+    if !app.busy {
+        app.push_message(
+            crate::app::MessageKind::System,
+            "no active request to interrupt",
+        );
+        app.set_status(format!("ready  {}", app.session_id));
+        return Ok(true);
+    }
+
+    if let Some(handle) = backend.take() {
+        handle.stop();
+    }
+    app.interrupt_request();
+    Ok(true)
+}
+
+pub(super) fn retry_last_task(app: &mut App, backend: &mut Option<BackendHandle>) -> Result<bool> {
+    if app.busy {
+        app.push_message(
+            crate::app::MessageKind::System,
+            "request still running; use /interrupt before /retry",
+        );
+        app.set_status(format!("busy  {}", app.session_id));
+        return Ok(true);
+    }
+
+    let Some(task) = app.last_submitted_task.clone() else {
+        app.push_message(
+            crate::app::MessageKind::System,
+            "no previous task available to retry",
+        );
+        app.set_status(format!("retry unavailable  {}", app.session_id));
+        return Ok(true);
+    };
+
+    app.begin_task_submission(task.clone(), true);
+    run_task(app, backend, task)
+}

--- a/app/terminal/src/terminal/keys.rs
+++ b/app/terminal/src/terminal/keys.rs
@@ -67,7 +67,7 @@ pub(super) fn handle_key(
             app.insert_newline();
         }
         KeyCode::Enter => {
-            if app.busy {
+            if app.busy && !app.input.starts_with('/') {
                 return Ok(false);
             }
             if app.active_surface_kind() == Some(ActiveSurfaceKind::Popup) {
@@ -113,6 +113,9 @@ pub(super) fn handle_key(
             }
         }
         KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            if app.busy {
+                return handle_submit_action(app, backend, crate::app::SubmitAction::Interrupt);
+            }
             app.should_quit = true
         }
         KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => app.clear_input(),
@@ -122,7 +125,7 @@ pub(super) fn handle_key(
         _ => return Ok(false),
     }
 
-    if !app.busy {
+    if !app.busy || app.input.starts_with('/') {
         sync_contextual_popup_data(app);
     }
     Ok(true)

--- a/app/terminal/src/terminal/tests/interaction.rs
+++ b/app/terminal/src/terminal/tests/interaction.rs
@@ -1,4 +1,10 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::app::{ActiveSurfaceKind, App, MessageKind, SubmitAction};
 use crate::slash_command;
@@ -230,4 +236,219 @@ fn display_command_switches_mode_through_normal_input_flow() {
         app.display_mode,
         crate::display_policy::DisplayMode::Verbose
     );
+}
+
+#[test]
+fn ctrl_c_interrupts_busy_request_instead_of_quitting() {
+    let mut app = App::new();
+    app.begin_task_submission("keep running".to_string(), true);
+    app.append_assistant_chunk("partial");
+    let mut backend = None;
+
+    let handled = handle_key(
+        &mut app,
+        KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL),
+        &mut backend,
+    )
+    .expect("ctrl-c while busy should not fail");
+
+    assert!(handled);
+    assert!(!app.should_quit);
+    assert!(!app.busy);
+    let rendered = app
+        .pending_history_lines
+        .iter()
+        .flat_map(|line| line.spans.iter())
+        .map(|span| span.content.as_ref())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("interrupted"));
+    assert!(rendered.contains("/retry available"));
+}
+
+#[test]
+fn interrupt_command_stops_busy_request_through_normal_input_flow() {
+    let mut app = App::new();
+    app.begin_task_submission("keep running".to_string(), true);
+    app.append_assistant_chunk("partial");
+    app.input = "/interrupt".to_string();
+    app.input_cursor = app.input.len();
+
+    let mut backend = None;
+    let handled = handle_key(
+        &mut app,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        &mut backend,
+    )
+    .expect("interrupt submit should not fail");
+
+    assert!(handled);
+    assert!(!app.busy);
+    assert!(!app.should_quit);
+    let rendered = app
+        .pending_history_lines
+        .iter()
+        .flat_map(|line| line.spans.iter())
+        .map(|span| span.content.as_ref())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("interrupted"));
+    assert!(rendered.contains("partial output preserved • /retry available"));
+}
+
+#[test]
+fn busy_state_allows_typing_slash_interrupt_command() {
+    let mut app = App::new();
+    app.begin_task_submission("keep running".to_string(), true);
+    let mut backend = None;
+
+    for ch in "/interrupt".chars() {
+        let handled = handle_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE),
+            &mut backend,
+        )
+        .expect("typing slash command while busy should not fail");
+        assert!(handled);
+    }
+
+    assert_eq!(app.input, "/interrupt");
+}
+
+#[test]
+fn retry_command_resubmits_last_task_through_backend() {
+    let _env_lock = lock_env();
+    let temp_dir = unique_temp_dir("terminal-retry");
+    fs::create_dir_all(&temp_dir).expect("temp dir should exist");
+    let script_path = write_fake_backend_script(&temp_dir);
+    let log_path = temp_dir.join("backend-prompts.log");
+    let _python_guard = EnvVarGuard::set("PYTHON", &script_path.display().to_string());
+    let _log_guard = EnvVarGuard::set("TEST_BACKEND_LOG", &log_path.display().to_string());
+
+    let mut app = App::new();
+    app.begin_task_submission("retry me".to_string(), true);
+    app.interrupt_request();
+    app.clear_input();
+    app.input = "/retry".to_string();
+    app.input_cursor = app.input.len();
+
+    let mut backend = None;
+    let handled = handle_key(
+        &mut app,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        &mut backend,
+    )
+    .expect("retry submit should not fail");
+
+    assert!(handled);
+    assert!(app.busy);
+    assert_eq!(app.current_task.as_deref(), Some("retry me"));
+
+    wait_for_prompt_log(&log_path, "retry me");
+    let prompts = fs::read_to_string(&log_path).expect("backend log should exist");
+    assert_eq!(prompts.lines().collect::<Vec<_>>(), vec!["retry me"]);
+}
+
+fn lock_env() -> MutexGuard<'static, ()> {
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = env::var(key).ok();
+        unsafe {
+            env::set_var(key, value);
+        }
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => unsafe {
+                env::set_var(self.key, value);
+            },
+            None => unsafe {
+                env::remove_var(self.key);
+            },
+        }
+    }
+}
+
+fn write_fake_backend_script(temp_dir: &Path) -> PathBuf {
+    let script_path = temp_dir.join("fake_backend.py");
+    fs::write(
+        &script_path,
+        r#"#!/usr/bin/env python3
+import json
+import os
+import sys
+
+log_path = os.environ.get("TEST_BACKEND_LOG")
+
+for raw in sys.stdin:
+    prompt = raw.rstrip("\n")
+    if log_path:
+        with open(log_path, "a", encoding="utf-8") as handle:
+            handle.write(prompt + "\n")
+    print(json.dumps({
+        "type": "assistant",
+        "role": "assistant",
+        "content": f"echo: {prompt}",
+    }), flush=True)
+    print(json.dumps({"type": "stream_end"}), flush=True)
+    print(json.dumps({
+        "type": "cli_stats",
+        "elapsed_seconds": 0.001,
+        "first_output_seconds": 0.001,
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    }), flush=True)
+"#,
+    )
+    .expect("script should be written");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(&script_path)
+            .expect("script metadata should exist")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions)
+            .expect("script permissions should be updated");
+    }
+    script_path
+}
+
+fn wait_for_prompt_log(log_path: &Path, expected_prompt: &str) {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < deadline {
+        if let Ok(contents) = fs::read_to_string(log_path) {
+            if contents.lines().any(|line| line == expected_prompt) {
+                return;
+            }
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    panic!("timed out waiting for prompt log entry: {expected_prompt}");
+}
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should move forward")
+        .as_nanos();
+    env::temp_dir().join(format!("sage-terminal-{label}-{suffix}"))
 }

--- a/app/terminal/src/terminal/tests/interaction.rs
+++ b/app/terminal/src/terminal/tests/interaction.rs
@@ -217,3 +217,17 @@ fn popup_visible_enter_submits_typed_slash_command_instead_of_selected_popup_ite
     assert!(handled);
     assert!(app.should_quit);
 }
+
+#[test]
+fn display_command_switches_mode_through_normal_input_flow() {
+    let mut app = App::new();
+    app.input = "/display set verbose".to_string();
+    app.input_cursor = app.input.len();
+
+    let action = app.submit_input();
+    assert!(matches!(action, SubmitAction::Handled));
+    assert_eq!(
+        app.display_mode,
+        crate::display_policy::DisplayMode::Verbose
+    );
+}

--- a/docs/en/applications/TUI.md
+++ b/docs/en/applications/TUI.md
@@ -121,6 +121,8 @@ The current TUI preview includes these core commands:
 - `/agent`
 - `/mode`
 - `/display`
+- `/interrupt`
+- `/retry`
 - `/new`
 - `/sessions`
 - `/resume`
@@ -174,6 +176,16 @@ sage-terminal --display verbose
 /display set compact
 /display set verbose
 ```
+
+## Run Control
+
+The terminal now supports basic in-session run control:
+
+- `/interrupt`: stop the active request without quitting the TUI
+- `/retry`: replay the last submitted task in the current session
+- `Ctrl+C` while a request is running: interrupt the request instead of exiting
+
+When an interruption happens, the transcript keeps any partial output that already arrived and adds a retry hint so the current turn can be resumed manually.
 
 ## Workspace Behavior
 

--- a/docs/en/applications/TUI.md
+++ b/docs/en/applications/TUI.md
@@ -83,6 +83,8 @@ Currently supported startup forms:
 
 ```bash
 sage-terminal
+sage-terminal --display compact
+sage-terminal --display verbose
 sage-terminal --agent-id agent_demo
 sage-terminal --agent-id agent_demo --agent-mode fibre
 sage-terminal --workspace /path/to/project
@@ -118,6 +120,7 @@ The current TUI preview includes these core commands:
 - `/help`
 - `/agent`
 - `/mode`
+- `/display`
 - `/new`
 - `/sessions`
 - `/resume`
@@ -142,14 +145,35 @@ Supported entrypoints:
 - startup flags:
   - `--agent-id <id>`
   - `--agent-mode <simple|multi|fibre>`
+  - `--display <compact|verbose>`
 - in-app commands:
   - `/agent`
   - `/agent set <agent_id>`
   - `/agent clear`
   - `/mode`
   - `/mode set <simple|multi|fibre>`
+  - `/display`
+  - `/display set <compact|verbose>`
 
 The actual agent definition, tools, skills, and behavior still come from the Sage runtime's stored agent configuration.
+
+## Display Modes
+
+Terminal transcript rendering supports two presentation modes:
+
+- `compact`: the default. Internal tool chatter is hidden, summaries are collapsed, and phase names are mapped to shorter user-facing labels.
+- `verbose`: restores internal tool steps, step numbers, and raw phase names for debugging.
+
+You can choose the mode either at startup or inside the TUI:
+
+```bash
+sage-terminal --display verbose
+```
+
+```text
+/display set compact
+/display set verbose
+```
 
 ## Workspace Behavior
 

--- a/docs/zh/applications/TUI.md
+++ b/docs/zh/applications/TUI.md
@@ -83,6 +83,8 @@ cargo build --release
 
 ```bash
 sage-terminal
+sage-terminal --display compact
+sage-terminal --display verbose
 sage-terminal --agent-id agent_demo
 sage-terminal --agent-id agent_demo --agent-mode fibre
 sage-terminal --workspace /path/to/project
@@ -118,6 +120,7 @@ cargo run --quiet --offline -- resume
 - `/help`
 - `/agent`
 - `/mode`
+- `/display`
 - `/new`
 - `/sessions`
 - `/resume`
@@ -142,14 +145,35 @@ TUI 现在可以覆盖运行时使用的 agent，但不会自己接管 agent 配
 - 启动参数：
   - `--agent-id <id>`
   - `--agent-mode <simple|multi|fibre>`
+  - `--display <compact|verbose>`
 - TUI 内命令：
   - `/agent`
   - `/agent set <agent_id>`
   - `/agent clear`
   - `/mode`
   - `/mode set <simple|multi|fibre>`
+  - `/display`
+  - `/display set <compact|verbose>`
 
 真正的 agent 定义、工具、skills 和行为仍然来自 Sage runtime 已保存的 agent 配置。
+
+## Display 模式
+
+Terminal transcript 现在支持两种展示模式：
+
+- `compact`：默认模式。隐藏内部工具噪音、压缩摘要，并把 phase 名映射成更短的用户视角标签。
+- `verbose`：用于排查问题。会恢复内部工具步骤、step 编号和原始 phase 名。
+
+你可以在启动时指定，也可以在 TUI 内切换：
+
+```bash
+sage-terminal --display verbose
+```
+
+```text
+/display set compact
+/display set verbose
+```
 
 ## Workspace 行为
 

--- a/docs/zh/applications/TUI.md
+++ b/docs/zh/applications/TUI.md
@@ -121,6 +121,8 @@ cargo run --quiet --offline -- resume
 - `/agent`
 - `/mode`
 - `/display`
+- `/interrupt`
+- `/retry`
 - `/new`
 - `/sessions`
 - `/resume`
@@ -174,6 +176,16 @@ sage-terminal --display verbose
 /display set compact
 /display set verbose
 ```
+
+## 运行控制
+
+现在 terminal 已经支持基础的会话内运行控制：
+
+- `/interrupt`：中断当前正在运行的请求，但不退出 TUI
+- `/retry`：在当前 session 里重新执行上一次提交的任务
+- 请求运行过程中按 `Ctrl+C`：中断当前请求，而不是直接退出程序
+
+发生中断时，transcript 会尽量保留已经收到的部分输出，并附带 retry 提示，方便继续当前轮次。
 
 ## Workspace 行为
 


### PR DESCRIPTION
## Summary
  - turn sage-terminal into a controllable runtime surface instead of a read-only transcript shell
  - add interrupt and retry flows for active terminal requests
  - make busy-state command handling and transcript semantics consistent for interrupted runs

  ## What Changed
  - add /interrupt and /retry slash commands to the terminal command surface
  - route busy Ctrl+C to request interruption instead of quitting the terminal
  - track the current and last submitted task so interrupted runs can be retried
  - preserve partial output on interruption and append retry-aware process summaries to the transcript
  - allow slash-command input while busy so in-session control commands remain usable during execution
  - extend terminal interaction and app tests to cover interrupt, retry, busy input, and backend resubmission behavior
  - update TUI documentation for run control behavior and shortcuts

  ## Validation
  - cargo test app::tests --quiet
  - cargo test terminal::tests::interaction --quiet
  - cargo test ui::tests --quiet
  - cargo test backend::tests::handle --quiet
  - cargo fmt --check
  - cargo build --offline