### PR TITLE
feat(sagents): baseline tools and identity prompt extension

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -1,3 +1,5 @@
+2026-05-06 14:45 新增 tool_baseline：按可用列表补齐基线工具；IDENTITY.md 改用 agent_identity_extension 与中英提示；接入 simple/task/tool suggestion；单测 3 条。
+
 2026-05-06 12:08 补全 MessageInput 词条：guidedPresetPressEnterAgain、pasteUploadFailed，server-web 与 desktop 中英 locales，修复 CI check:i18n。
 
 2026-05-05 10:35 引导功能PR：运行中注入与消费回执、rerun-stream guidance、流结束自动发送；desktop/server-web 引导区与文档；会话与 SAgent 对齐。

--- a/sagents/agent/agent_base.py
+++ b/sagents/agent/agent_base.py
@@ -717,7 +717,24 @@ class AgentBase(ABC):
                         if identity_content:
                             if len(identity_content) > 300:
                                 identity_content = identity_content[:300]+"……"
-                            stable_buf += f"<identity>\n{identity_content}\n</identity>\n"
+                            if language and str(language).lower().startswith("zh"):
+                                identity_hint = (
+                                    "以下内容是对 <role_definition> 的补充身份设定，"
+                                    "用于补充 agent 的人格、背景、工作方式或偏好；"
+                                    "它不替代主角色定义。"
+                                )
+                            else:
+                                identity_hint = (
+                                    "The following content supplements <role_definition> with additional "
+                                    "agent identity, personality, background, working style, or preferences; "
+                                    "it does not replace the primary role definition."
+                                )
+                            stable_buf += (
+                                "<agent_identity_extension>\n"
+                                f"{identity_hint}\n\n"
+                                f"{identity_content}\n"
+                                "</agent_identity_extension>\n"
+                            )
                     except Exception as e:
                         logger.debug(f"AgentBase: IDENTITY.md not found or error reading: {e}")
 

--- a/sagents/agent/agent_base.py
+++ b/sagents/agent/agent_base.py
@@ -717,18 +717,11 @@ class AgentBase(ABC):
                         if identity_content:
                             if len(identity_content) > 300:
                                 identity_content = identity_content[:300]+"……"
-                            if language and str(language).lower().startswith("zh"):
-                                identity_hint = (
-                                    "以下内容是对 <role_definition> 的补充身份设定，"
-                                    "用于补充 agent 的人格、背景、工作方式或偏好；"
-                                    "它不替代主角色定义。"
-                                )
-                            else:
-                                identity_hint = (
-                                    "The following content supplements <role_definition> with additional "
-                                    "agent identity, personality, background, working style, or preferences; "
-                                    "it does not replace the primary role definition."
-                                )
+                            identity_hint = prompt_manager.get_prompt(
+                                "agent_identity_extension_hint",
+                                agent="common",
+                                language=language or "en",
+                            )
                             stable_buf += (
                                 "<agent_identity_extension>\n"
                                 f"{identity_hint}\n\n"

--- a/sagents/agent/simple_agent.py
+++ b/sagents/agent/simple_agent.py
@@ -7,6 +7,7 @@ from sagents.context.session_context import SessionContext
 from sagents.tool.tool_manager import ToolManager
 from sagents.utils.prompt_manager import PromptManager
 from sagents.utils.content_saver import save_agent_response_content
+from sagents.tool.tool_baseline import augment_with_baseline_tools
 import json
 import uuid
 from copy import deepcopy
@@ -171,17 +172,17 @@ class SimpleAgent(AgentBase):
         # 获取所有工具
         tools_json = tool_manager.get_openai_tools(lang=session_context.get_language(), fallback_chain=["en"])
 
-        # 根据建议过滤工具
-        # 强制包含 todo / 终止工具 / 记忆工具，如果它们存在于可用工具中
+        # 根据建议过滤工具，并补齐基础工作台工具（仅限当前工具管理器真实可用的工具）。
         # turn_status 始终包含：即使协议被禁用，模型仍可能因提示词而调用它；
         # 若不包含则调用会被拒绝并触发错误→循环，导致相同文本重复出现。
         # SAGE_AGENT_STATUS_PROTOCOL_ENABLED=false 只控制"强制 turn_status_only 轮"的触发，
         # 而不应阻止模型主动调用该工具来终止本轮。
-        always_include = ['todo_write', 'search_memory', 'turn_status']
+        available_tool_names = [tool['function']['name'] for tool in tools_json]
+        selected_tools = set(augment_with_baseline_tools(suggested_tools, available_tool_names))
         
         tools_suggest_json = [
             tool for tool in tools_json
-            if tool['function']['name'] in suggested_tools or tool['function']['name'] in always_include
+            if tool['function']['name'] in selected_tools
         ]
         
         if tools_suggest_json:

--- a/sagents/agent/task_executor_agent.py
+++ b/sagents/agent/task_executor_agent.py
@@ -7,6 +7,7 @@ from sagents.context.session_context import SessionContext
 from sagents.tool.tool_manager import ToolManager
 from sagents.utils.prompt_manager import PromptManager
 from sagents.utils.content_saver import save_agent_response_content
+from sagents.tool.tool_baseline import augment_with_baseline_tools
 import uuid
 import os
 
@@ -253,6 +254,8 @@ TaskExecutorAgent: 任务执行智能体，负责根据任务描述和要求，�
         if suggested_tools and sm and sm.list_skills():
             if 'load_skill' not in suggested_tools:
                 suggested_tools.append('load_skill')
+
+        suggested_tools = augment_with_baseline_tools(suggested_tools, available_tool_names)
         
         if suggested_tools:
             tools_suggest_json = [

--- a/sagents/agent/tool_suggestion_agent.py
+++ b/sagents/agent/tool_suggestion_agent.py
@@ -17,6 +17,7 @@ from sagents.context.messages.message_manager import MessageManager
 from sagents.context.session_context import SessionContext
 from sagents.tool.tool_manager import ToolManager
 from sagents.tool.tool_proxy import ToolProxy
+from sagents.tool.tool_baseline import augment_with_baseline_tools
 from sagents.utils.logger import logger
 from sagents.utils.prompt_manager import PromptManager
 
@@ -187,6 +188,11 @@ class ToolSuggestionAgent(AgentBase):
                         if tool['name'] == tool_name:
                             suggested_tool_names.append(tool_name)
                             break
+
+            suggested_tool_names = augment_with_baseline_tools(
+                suggested_tool_names,
+                [tool['name'] for tool in available_tools]
+            )
 
             # 移除complete_task工具
             if 'complete_task' in suggested_tool_names:

--- a/sagents/prompts/agent_base_prompts.py
+++ b/sagents/prompts/agent_base_prompts.py
@@ -9,6 +9,25 @@ AgentBase通用指令定义
 # Agent标识符 - 标识这个prompt文件对应的agent类型
 AGENT_IDENTIFIER = "common"
 
+# IDENTITY.md 作为额外身份扩展注入时的说明
+agent_identity_extension_hint = {
+    "zh": (
+        "以下内容是对 <role_definition> 的补充身份设定，"
+        "用于补充 agent 的人格、背景、工作方式或偏好；"
+        "它不替代主角色定义。"
+    ),
+    "en": (
+        "The following content supplements <role_definition> with additional "
+        "agent identity, personality, background, working style, or preferences; "
+        "it does not replace the primary role definition."
+    ),
+    "pt": (
+        "O conteúdo a seguir complementa <role_definition> com identidade, "
+        "personalidade, contexto, estilo de trabalho ou preferências adicionais do agente; "
+        "ele não substitui a definição principal de função."
+    ),
+}
+
 # 智能体介绍模板
 agent_intro_template = {
     "zh": """

--- a/sagents/tool/tool_baseline.py
+++ b/sagents/tool/tool_baseline.py
@@ -1,0 +1,40 @@
+"""Shared baseline tool selection helpers."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Set
+
+
+BASELINE_EXECUTION_TOOLS = (
+    "todo_write",
+    "todo_read",
+    "search_memory",
+    "turn_status",
+    "file_read",
+    "file_write",
+    "file_update",
+    "glob",
+    "list_dir",
+    "execute_shell_command",
+    "await_shell",
+    "kill_shell",
+)
+
+
+def augment_with_baseline_tools(
+    suggested_tools: Iterable[str],
+    available_tool_names: Iterable[str],
+) -> List[str]:
+    """Return suggested tools plus baseline execution tools that actually exist."""
+
+    available: Set[str] = {name for name in available_tool_names if name}
+    selected: List[str] = []
+    seen: Set[str] = set()
+
+    for name in list(suggested_tools or []) + list(BASELINE_EXECUTION_TOOLS):
+        if not name or name in seen or name not in available:
+            continue
+        selected.append(name)
+        seen.add(name)
+
+    return selected

--- a/tests/sagents/agent/test_tool_baseline.py
+++ b/tests/sagents/agent/test_tool_baseline.py
@@ -1,0 +1,28 @@
+from sagents.tool.tool_baseline import augment_with_baseline_tools
+
+
+def test_augment_with_baseline_tools_keeps_suggestion_and_existing_baselines():
+    tools = augment_with_baseline_tools(
+        ["custom_tool"],
+        ["custom_tool", "file_read", "file_write", "turn_status"],
+    )
+
+    assert tools == ["custom_tool", "turn_status", "file_read", "file_write"]
+
+
+def test_augment_with_baseline_tools_does_not_add_unavailable_tools():
+    tools = augment_with_baseline_tools(
+        ["custom_tool"],
+        ["custom_tool"],
+    )
+
+    assert tools == ["custom_tool"]
+
+
+def test_augment_with_baseline_tools_deduplicates_existing_baseline_suggestion():
+    tools = augment_with_baseline_tools(
+        ["file_read", "custom_tool", "file_read"],
+        ["custom_tool", "file_read", "turn_status"],
+    )
+
+    assert tools == ["file_read", "custom_tool", "turn_status"]


### PR DESCRIPTION
## Summary
- Add `tool_baseline.py` with `BASELINE_EXECUTION_TOOLS` and `augment_with_baseline_tools()` so SimpleAgent, TaskExecutorAgent, and ToolSuggestionAgent always expose baseline execution tools that exist in the current tool manager.
- Wrap IDENTITY.md content in `<agent_identity_extension>` with zh/en hints so it supplements `<role_definition>` rather than replacing it.

## Testing
- `pytest tests/sagents/agent/test_tool_baseline.py` (3 passed)


Made with [Cursor](https://cursor.com)