### PR TITLE
fix: Prevent partial streamed tool calls from poisoning retry history

### DIFF
--- a/sagents/agent/agent_base.py
+++ b/sagents/agent/agent_base.py
@@ -45,6 +45,14 @@ import httpx
 from openai.types.chat import chat_completion_chunk
 
 
+class PartialStreamConsumedError(RuntimeError):
+    """Raised when a streamed LLM response fails after chunks were yielded."""
+
+    def __init__(self, message: str, original_error: Exception):
+        super().__init__(message)
+        self.original_error = original_error
+
+
 class AgentBase(ABC):
     """
     智能体基类
@@ -201,6 +209,7 @@ class AgentBase(ABC):
         partial_stream_aborted = False
 
         while retry_count < max_retries:
+            attempt_yielded_chunks = False
             try:
                 attempt_chunks = []
                 first_token_time = None
@@ -398,6 +407,7 @@ class AgentBase(ABC):
                     # 显式让出控制权，确保在高吞吐量时不会饿死事件循环（如心跳检测）
                     await asyncio.sleep(0)
                     
+                    attempt_yielded_chunks = True
                     yield chunk
 
                 # 成功完成，跳出重试循环
@@ -433,6 +443,14 @@ class AgentBase(ABC):
                 is_read_error = isinstance(e, httpx.ReadError) or "read error" in error_message
                 # 检查是否是 token 超限错误
                 is_token_limit_error = "range of input length" in error_message or "token" in error_message and "exceed" in error_message
+
+                if attempt_yielded_chunks:
+                    message = (
+                        f"{self.__class__.__name__}: 流式响应已向上游输出部分 chunk，"
+                        f"遇到{('超时' if is_timeout else '网络/读取')}错误后不再透明重试，避免污染工具调用参数: {e}"
+                    )
+                    logger.warning(message)
+                    raise PartialStreamConsumedError(message, e) from e
 
                 if retry_count < max_retries and (is_rate_limit or is_connection_error or is_timeout or is_read_error):
                     wait_time = 2 ** retry_count  # 指数退避: 2, 4, 8 秒
@@ -498,6 +516,14 @@ class AgentBase(ABC):
                 ])
                 # 检查是否是 httpx 特定的超时或读取错误
                 is_httpx_error = isinstance(e, (httpx.ReadTimeout, httpx.ConnectTimeout, httpx.ReadError, httpx.ConnectError))
+
+                if attempt_yielded_chunks:
+                    message = (
+                        f"{self.__class__.__name__}: 流式响应已向上游输出部分 chunk，"
+                        f"遇到网络异常后不再透明重试，避免污染工具调用参数: {e}"
+                    )
+                    logger.warning(message)
+                    raise PartialStreamConsumedError(message, e) from e
 
                 if (is_network_error or is_httpx_error) and retry_count < max_retries:
                     # 使用指数退避 + 随机抖动，避免同时重试

--- a/sagents/agent/simple_agent.py
+++ b/sagents/agent/simple_agent.py
@@ -1,5 +1,5 @@
 from sagents.context.messages.message_manager import MessageManager
-from .agent_base import AgentBase
+from .agent_base import AgentBase, PartialStreamConsumedError
 from typing import Any, Dict, List, Optional, AsyncGenerator, Tuple, Union, cast
 from sagents.utils.logger import logger
 from sagents.context.messages.message import MessageChunk, MessageRole, MessageType
@@ -930,75 +930,112 @@ class SimpleAgent(AgentBase):
         last_tool_call_id = None
         full_content_accumulator = ""
         tool_calls_messages_id = str(uuid.uuid4())
+        emitted_tool_call_stream = False
         # 处理流式响应块
-        async for chunk in response:
-            # print(chunk)
-            if chunk is None:
-                logger.warning(f"Received None chunk from LLM response, skipping... chunk: {chunk}")
-                continue
-            if chunk.choices is None:
-                logger.warning(f"Received chunk with None choices from LLM response, skipping... chunk: {chunk}")
-                continue
-            if len(chunk.choices) == 0:
-                continue
-            
-            # 由于 AgentBase._call_llm_streaming 已经处理了 asyncio.sleep(0) 的让权
-            # 这里不需要重复让权，减少不必要的调度开销
+        try:
+            async for chunk in response:
+                # print(chunk)
+                if chunk is None:
+                    logger.warning(f"Received None chunk from LLM response, skipping... chunk: {chunk}")
+                    continue
+                if chunk.choices is None:
+                    logger.warning(f"Received chunk with None choices, skipping... chunk: {chunk}")
+                    continue
+                if len(chunk.choices) == 0:
+                    continue
 
-            if chunk.choices[0].delta.tool_calls:
-                self._handle_tool_calls_chunk(chunk, tool_calls, last_tool_call_id or "")
-                # 更新last_tool_call_id
-                for tool_call in chunk.choices[0].delta.tool_calls:
-                    if tool_call.id is not None and len(tool_call.id) > 0:
-                        last_tool_call_id = tool_call.id
+                # 由于 AgentBase._call_llm_streaming 已经处理了 asyncio.sleep(0) 的让权
+                # 这里不需要重复让权，减少不必要的调度开销
 
-                # 根据环境变量控制是否流式返回工具调用消息
-                # 如果 SAGE_EMIT_TOOL_CALL_ON_COMPLETE=true，则参数完整时才返回工具调用消息
-                emit_on_complete = os.environ.get("SAGE_EMIT_TOOL_CALL_ON_COMPLETE", "false").lower() == "true"
-                if not emit_on_complete:
-                    # 流式返回工具调用消息
-                    output_messages = [MessageChunk(
-                        role=MessageRole.ASSISTANT.value,
-                        tool_calls=chunk.choices[0].delta.tool_calls,
-                        message_id=tool_calls_messages_id,
-                        message_type=MessageType.TOOL_CALL.value,
-                        agent_name=self.agent_name
-                    )]
-                    yield (output_messages, False)
+                if chunk.choices[0].delta.tool_calls:
+                    self._handle_tool_calls_chunk(chunk, tool_calls, last_tool_call_id or "")
+                    # 更新last_tool_call_id
+                    for tool_call in chunk.choices[0].delta.tool_calls:
+                        if tool_call.id is not None and len(tool_call.id) > 0:
+                            last_tool_call_id = tool_call.id
+
+                    # 根据环境变量控制是否流式返回工具调用消息
+                    # 如果 SAGE_EMIT_TOOL_CALL_ON_COMPLETE=true，则参数完整时才返回工具调用消息
+                    emit_on_complete = os.environ.get("SAGE_EMIT_TOOL_CALL_ON_COMPLETE", "false").lower() == "true"
+                    if not emit_on_complete:
+                        emitted_tool_call_stream = True
+                        # 流式返回工具调用消息
+                        output_messages = [MessageChunk(
+                            role=MessageRole.ASSISTANT.value,
+                            tool_calls=chunk.choices[0].delta.tool_calls,
+                            message_id=tool_calls_messages_id,
+                            message_type=MessageType.TOOL_CALL.value,
+                            agent_name=self.agent_name
+                        )]
+                        yield (output_messages, False)
+                    else:
+                        # yield 一个空的消息块以避免生成器卡住
+                        output_messages = [MessageChunk(
+                            role=MessageRole.ASSISTANT.value,
+                            content="",
+                            message_id=content_response_message_id,
+                            message_type=MessageType.EMPTY.value
+                        )]
+                        yield (output_messages, False)
+
+                elif chunk.choices[0].delta.content:
+                    if len(chunk.choices[0].delta.content) > 0:
+                        content_piece = chunk.choices[0].delta.content
+                        full_content_accumulator += content_piece
+                        output_messages = [MessageChunk(
+                            role='assistant',
+                            content=content_piece,
+                            message_id=content_response_message_id,
+                            message_type=MessageType.DO_SUBTASK_RESULT.value,
+                            agent_name=self.agent_name
+                        )]
+                        yield (output_messages, False)
                 else:
-                    # yield 一个空的消息块以避免生成器卡住
-                    output_messages = [MessageChunk(
-                        role=MessageRole.ASSISTANT.value,
-                        content="",
-                        message_id=content_response_message_id,
-                        message_type=MessageType.EMPTY.value
-                    )]
-                    yield (output_messages, False)
+                    # 先判断chunk.choices[0].delta 是否有reasoning_content 这个变量，并且不是none
+                    if hasattr(chunk.choices[0].delta, 'reasoning_content') and chunk.choices[0].delta.reasoning_content is not None:
+                        output_messages = [MessageChunk(
+                            role='assistant',
+                            content=chunk.choices[0].delta.reasoning_content,
+                            message_id=reasoning_content_response_message_id,
+                            message_type=MessageType.REASONING_CONTENT.value,
+                            agent_name=self.agent_name
+                        )]
+                        yield (output_messages, False)
+        except PartialStreamConsumedError as exc:
+            recovery_messages: List[MessageChunk] = []
+            if emitted_tool_call_stream:
+                for tool_call_id, tool_call in tool_calls.items():
+                    real_tool_call_id = tool_call.get('id') or tool_call_id
+                    if not real_tool_call_id or real_tool_call_id.startswith("__tool_call_index_"):
+                        continue
+                    tool_name = (tool_call.get('function') or {}).get('name') or ""
+                    recovery_messages.append(MessageChunk(
+                        role=MessageRole.TOOL.value,
+                        content=json.dumps({
+                            "success": False,
+                            "status": "discarded",
+                            "error": "Partial streamed tool call discarded because the LLM stream ended before a complete response.",
+                        }, ensure_ascii=False),
+                        tool_call_id=real_tool_call_id,
+                        tool_name=tool_name,
+                        message_type=MessageType.TOOL_CALL_RESULT.value,
+                        agent_name=self.agent_name,
+                        metadata={"tool_name": tool_name, "partial_stream_discarded": True},
+                    ))
+            recovery_messages.append(MessageChunk(
+                role=MessageRole.ASSISTANT.value,
+                content=(
+                    "The model stream was interrupted while generating a tool call. "
+                    "The incomplete tool call was discarded to avoid corrupting the conversation history. "
+                    "Please retry the current operation."
+                ),
+                message_type=MessageType.ERROR.value,
+                agent_name=self.agent_name,
+                metadata={"partial_stream_discarded": True, "error": str(exc)},
+            ))
+            yield (recovery_messages, True)
+            return
 
-            elif chunk.choices[0].delta.content:
-                if len(chunk.choices[0].delta.content) > 0:
-                    content_piece = chunk.choices[0].delta.content
-                    full_content_accumulator += content_piece
-                    output_messages = [MessageChunk(
-                        role='assistant',
-                        content=content_piece,
-                        message_id=content_response_message_id,
-                        message_type=MessageType.DO_SUBTASK_RESULT.value,
-                        agent_name=self.agent_name
-                    )]
-                    yield (output_messages, False)
-            else:
-                # 先判断chunk.choices[0].delta 是否有reasoning_content 这个变量，并且不是none
-                if hasattr(chunk.choices[0].delta, 'reasoning_content') and chunk.choices[0].delta.reasoning_content is not None:
-                    output_messages = [MessageChunk(
-                        role='assistant',
-                        content=chunk.choices[0].delta.reasoning_content,
-                        message_id=reasoning_content_response_message_id,
-                        message_type=MessageType.REASONING_CONTENT.value,
-                        agent_name=self.agent_name
-                    )]
-                    yield (output_messages, False)
-        
         # 处理完所有chunk后，尝试保存内容
         if full_content_accumulator:
              try:

--- a/tests/sagents/test_llm_stream_retry.py
+++ b/tests/sagents/test_llm_stream_retry.py
@@ -1,0 +1,249 @@
+import pytest
+import httpx
+
+from openai.types.chat import chat_completion_chunk
+
+from sagents.agent.agent_base import AgentBase, PartialStreamConsumedError
+from sagents.agent.simple_agent import SimpleAgent
+from sagents.context.messages.message import MessageChunk, MessageRole, MessageType
+from sagents.context.messages.message_manager import MessageManager
+
+
+class DummyAgent(AgentBase):
+    async def run_stream(self, session_context):
+        if False:
+            yield []
+
+
+class FakeCompletions:
+    def __init__(self, attempts=None):
+        self.calls = 0
+        self.attempts = attempts
+
+    async def create(self, **kwargs):
+        self.calls += 1
+        if self.attempts is not None:
+            return self.attempts[self.calls - 1]()
+
+        async def first_attempt():
+            yield _tool_call_chunk("call_partial", '{"tasks')
+            raise httpx.ReadTimeout("stream stalled after partial tool call")
+
+        async def second_attempt():
+            yield _tool_call_chunk("call_retry", '{"tasks":[]}')
+
+        return first_attempt() if self.calls == 1 else second_attempt()
+
+
+class FakeChat:
+    def __init__(self, attempts=None):
+        self.completions = FakeCompletions(attempts=attempts)
+
+
+class FakeClient:
+    def __init__(self, attempts=None):
+        self.chat = FakeChat(attempts=attempts)
+
+
+def _tool_call_chunk(call_id, arguments):
+    return chat_completion_chunk.ChatCompletionChunk(
+        id="chunk",
+        object="chat.completion.chunk",
+        created=0,
+        model="gpt-test",
+        choices=[
+            chat_completion_chunk.Choice(
+                index=0,
+                delta=chat_completion_chunk.ChoiceDelta(
+                    tool_calls=[
+                        chat_completion_chunk.ChoiceDeltaToolCall(
+                            index=0,
+                            id=call_id,
+                            type="function",
+                            function=chat_completion_chunk.ChoiceDeltaToolCallFunction(
+                                name="todo_write",
+                                arguments=arguments,
+                            ),
+                        )
+                    ]
+                ),
+                finish_reason=None,
+            )
+        ],
+    )
+
+
+def _content_chunk(content, *, finish_reason=None):
+    return chat_completion_chunk.ChatCompletionChunk(
+        id="chunk",
+        object="chat.completion.chunk",
+        created=0,
+        model="gpt-test",
+        choices=[
+            chat_completion_chunk.Choice(
+                index=0,
+                delta=chat_completion_chunk.ChoiceDelta(content=content),
+                finish_reason=finish_reason,
+            )
+        ],
+    )
+
+
+def _attempt_raises_before_yield(exc):
+    async def attempt():
+        if False:
+            yield None
+        raise exc
+
+    return attempt
+
+
+def _attempt_yields_then_raises(chunk, exc):
+    async def attempt():
+        yield chunk
+        raise exc
+
+    return attempt
+
+
+def _attempt_yields(*chunks):
+    async def attempt():
+        for chunk in chunks:
+            yield chunk
+
+    return attempt
+
+
+@pytest.mark.asyncio
+async def test_streaming_call_does_not_retry_after_partial_chunk_is_yielded():
+    client = FakeClient()
+    agent = DummyAgent(model=client, model_config={"model": "gpt-test"})
+    messages = [MessageChunk(role=MessageRole.USER.value, content="run")]
+
+    chunks = []
+    with pytest.raises(PartialStreamConsumedError):
+        async for chunk in agent._call_llm_streaming(messages, enable_thinking=False):
+            chunks.append(chunk)
+
+    assert client.chat.completions.calls == 1
+    assert len(chunks) == 1
+    assert chunks[0].choices[0].delta.tool_calls[0].function.arguments == '{"tasks'
+
+
+@pytest.mark.asyncio
+async def test_streaming_call_still_retries_if_timeout_happens_before_any_chunk(monkeypatch):
+    async def fast_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr("sagents.agent.agent_base.asyncio.sleep", fast_sleep)
+    client = FakeClient(
+        attempts=[
+            _attempt_raises_before_yield(httpx.ReadTimeout("no bytes yet")),
+            _attempt_yields(_content_chunk("retry succeeded")),
+        ]
+    )
+    agent = DummyAgent(model=client, model_config={"model": "gpt-test"})
+    messages = [MessageChunk(role=MessageRole.USER.value, content="run")]
+
+    chunks = []
+    async for chunk in agent._call_llm_streaming(messages, enable_thinking=False):
+        chunks.append(chunk)
+
+    assert client.chat.completions.calls == 2
+    assert [chunk.choices[0].delta.content for chunk in chunks] == ["retry succeeded"]
+
+
+@pytest.mark.asyncio
+async def test_streaming_call_does_not_retry_after_text_chunk_is_yielded():
+    client = FakeClient(
+        attempts=[
+            _attempt_yields_then_raises(
+                _content_chunk("partial text"),
+                httpx.ReadTimeout("stream stalled after text"),
+            ),
+            _attempt_yields(_content_chunk("should not be used")),
+        ]
+    )
+    agent = DummyAgent(model=client, model_config={"model": "gpt-test"})
+    messages = [MessageChunk(role=MessageRole.USER.value, content="run")]
+
+    chunks = []
+    with pytest.raises(PartialStreamConsumedError):
+        async for chunk in agent._call_llm_streaming(messages, enable_thinking=False):
+            chunks.append(chunk)
+
+    assert client.chat.completions.calls == 1
+    assert [chunk.choices[0].delta.content for chunk in chunks] == ["partial text"]
+
+
+@pytest.mark.asyncio
+async def test_simple_agent_closes_streamed_partial_tool_call_when_stream_times_out():
+    client = FakeClient()
+    agent = SimpleAgent(model=client, model_config={"model": "gpt-test"})
+    agent._get_live_session = lambda session_id: None
+    messages = [MessageChunk(role=MessageRole.USER.value, content="run")]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "todo_write",
+                "description": "write todos",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+    chunks = []
+    async for chunk, is_complete in agent._call_llm_and_process_response(
+        messages_input=messages,
+        tools_json=tools,
+        tool_manager=None,
+        session_id="sid",
+    ):
+        chunks.extend(chunk)
+        if is_complete:
+            break
+
+    assert client.chat.completions.calls == 1
+    assert [chunk.role for chunk in chunks] == ["assistant", "tool", "assistant"]
+    assert chunks[0].tool_calls[0].id == "call_partial"
+    assert chunks[1].tool_call_id == "call_partial"
+    assert "discarded" in chunks[1].content.lower()
+    assert chunks[-1].role == "assistant"
+    assert len(MessageManager.convert_messages_to_dict_for_request(messages + chunks)) == 4
+
+
+@pytest.mark.asyncio
+async def test_simple_agent_does_not_add_synthetic_tool_result_when_tool_call_was_not_streamed(monkeypatch):
+    monkeypatch.setenv("SAGE_EMIT_TOOL_CALL_ON_COMPLETE", "true")
+    client = FakeClient()
+    agent = SimpleAgent(model=client, model_config={"model": "gpt-test"})
+    agent._get_live_session = lambda session_id: None
+    messages = [MessageChunk(role=MessageRole.USER.value, content="run")]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "todo_write",
+                "description": "write todos",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+    chunks = []
+    async for chunk, is_complete in agent._call_llm_and_process_response(
+        messages_input=messages,
+        tools_json=tools,
+        tool_manager=None,
+        session_id="sid",
+    ):
+        chunks.extend(chunk)
+        if is_complete:
+            break
+
+    non_empty = [chunk for chunk in chunks if chunk.message_type != MessageType.EMPTY.value]
+    assert client.chat.completions.calls == 1
+    assert [chunk.role for chunk in non_empty] == ["assistant"]
+    assert non_empty[0].message_type == MessageType.ERROR.value
+    assert "incomplete tool call was discarded" in non_empty[0].content


### PR DESCRIPTION
* 防止流式工具调用在超时重试时把半截参数拼进下一次响应，导致历史被裁切并触发重复工具调用循环。
