### PR TITLE
feat(shell): await_shell guidance and next_action in tool responses

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -1,0 +1,3 @@
+# Change log
+
+- **2026-05-07** execute_shell：工具文案与后台/超时返回增加 `next_action`，引导在必等结果时立即 `await_shell`；单测覆盖。

--- a/sagents/tool/impl/execute_command_tool.py
+++ b/sagents/tool/impl/execute_command_tool.py
@@ -655,17 +655,20 @@ class ExecuteCommandTool:
                 "在沙箱中执行 Shell 命令；支持两段式执行。"
                 "block_until_ms=0 立即放后台并返回 task_id；>0 阻塞至命令结束或到点（默认 30000）。"
                 "若到点未结束，返回 task_id + tail_output；命令最终完成时系统会通过 "
-                "<system_reminder> 主动通知，你不需要轮询，起完命令请优先去做下一步工作。"
-                "若必须等待，可用 await_shell 并传入较大的 block_until_ms（>=60000），"
-                "或用 kill_shell 终止。"
+                "<system_reminder> 主动通知。若还有不依赖该命令结果的工作，起完命令后请先做下一步。"
+                "若当前用户请求必须等这个命令结果才能完成，必须立即调用 await_shell，"
+                "不要只回复“正在等待/稍后检查”。await_shell 请传入较大的 block_until_ms（>=60000），"
+                "必要时用 kill_shell 终止。"
             ),
             "en": (
                 "Execute a shell command in sandbox with two-stage support. "
                 "block_until_ms=0 backgrounds the command and returns immediately with a task_id. "
                 ">0 blocks until completion or deadline (default 30000). On deadline, returns task_id + tail_output. "
-                "Eventual completion is pushed via <system_reminder>; you do NOT need to poll. "
-                "After spawning, prefer to do the next step rather than waiting. "
-                "If you must wait, use await_shell with a generous block_until_ms (>=60000), or kill_shell to terminate."
+                "Eventual completion is pushed via <system_reminder>. "
+                "If there is independent work, do that after spawning. "
+                "If the current user request depends on this command's result, you MUST call await_shell immediately; "
+                "do not merely say you are waiting or will check later. "
+                "Use await_shell with a generous block_until_ms (>=60000), or kill_shell to terminate."
             ),
         },
         param_description_i18n={
@@ -776,7 +779,17 @@ class ExecuteCommandTool:
                     "output_file": log_path,
                     "tail_output": tail,
                     "command": command,
-                    "message": f"已在后台启动，task_id={task_id}",
+                    "message": (
+                        f"Started in the background with task_id={task_id}; the command is still running."
+                    ),
+                    "next_action": {
+                        "if_result_required": "call await_shell immediately",
+                        "await_shell_args": {
+                            "task_id": task_id,
+                            "block_until_ms": max(60000, _suggest_next_block_ms(0)),
+                        },
+                        "do_not": "do not answer with waiting/progress text only",
+                    },
                 }
 
             finished, exit_code = await self._wait_for_finish(
@@ -814,10 +827,16 @@ class ExecuteCommandTool:
                 "suggested_next_block_ms": _suggest_next_block_ms(running_ms),
                 "command": command,
                 "message": (
-                    f"达到 block_until_ms={block_until_ms}，命令仍在运行。"
-                    "完成时会通过 <system_reminder> 主动通知，无需轮询；"
-                    "如必须等待，可用 await_shell 并传入较大 block_until_ms。"
+                    f"The command is still running after block_until_ms={block_until_ms}."
                 ),
+                "next_action": {
+                    "if_result_required": "call await_shell immediately",
+                    "await_shell_args": {
+                        "task_id": task_id,
+                        "block_until_ms": max(60000, _suggest_next_block_ms(running_ms)),
+                    },
+                    "do_not": "do not answer with waiting/progress text only",
+                },
             }
         finally:
             echo_footer(None)
@@ -932,6 +951,7 @@ class ExecuteCommandTool:
             }
         tail = await self._read_tail(sandbox, task_info, max_bytes=8192)
         running_ms_after = int((time.time() - task_info.get("started_at", time.time())) * 1000)
+        next_block_ms = _suggest_next_block_ms(running_ms_after)
         return {
             "success": True,
             "status": "running",
@@ -940,9 +960,20 @@ class ExecuteCommandTool:
             "output_file": task_info.get("log_path"),
             "matched_pattern": bool(pattern),
             "running_for_ms": running_ms_after,
-            "suggested_next_block_ms": _suggest_next_block_ms(running_ms_after),
+            "suggested_next_block_ms": next_block_ms,
             "block_until_ms_requested": requested_block_until_ms,
             "block_until_ms_used": block_until_ms,
+            "message": (
+                f"The task is still running after await_shell waited block_until_ms={block_until_ms}."
+            ),
+            "next_action": {
+                "if_result_required": "call await_shell again",
+                "await_shell_args": {
+                    "task_id": task_id,
+                    "block_until_ms": next_block_ms,
+                },
+                "do_not": "do not answer with waiting/progress text only",
+            },
         }
 
     @tool(

--- a/tests/sagents/tool/impl/test_execute_shell_completion_event.py
+++ b/tests/sagents/tool/impl/test_execute_shell_completion_event.py
@@ -126,7 +126,7 @@ async def test_await_shell_adaptive_rewrite_under_30s_block(shell_env, monkeypat
 
     captured: dict = {}
 
-    async def fake_wait(self, sandbox, info, block_until_ms, pattern=None):
+    async def fake_wait(self, sandbox, info, block_until_ms, pattern=None, emit_progress=False):
         captured["block_until_ms"] = block_until_ms
         return False, None  # 强制 running
 
@@ -144,6 +144,10 @@ async def test_await_shell_adaptive_rewrite_under_30s_block(shell_env, monkeypat
     assert captured["block_until_ms"] == 60_000
     assert out["running_for_ms"] >= 35_000
     assert out["suggested_next_block_ms"] >= 30_000
+    assert out["next_action"]["if_result_required"] == "call await_shell again"
+    assert out["next_action"]["await_shell_args"]["task_id"] == task_id
+    assert out["next_action"]["await_shell_args"]["block_until_ms"] == out["suggested_next_block_ms"]
+    assert out["next_action"]["do_not"] == "do not answer with waiting/progress text only"
 
     await tool.kill_shell(task_id=task_id, session_id="sid_A")
 

--- a/tests/sagents/tool/impl/test_execute_shell_integration.py
+++ b/tests/sagents/tool/impl/test_execute_shell_integration.py
@@ -106,6 +106,10 @@ async def test_background_then_await_completes(shell_env):
     assert started["status"] == "running"
     task_id = started["task_id"]
     assert task_id in ExecuteCommandTool._BG_TASKS
+    assert started["next_action"]["if_result_required"] == "call await_shell immediately"
+    assert started["next_action"]["await_shell_args"]["task_id"] == task_id
+    assert started["next_action"]["await_shell_args"]["block_until_ms"] >= 60000
+    assert started["next_action"]["do_not"] == "do not answer with waiting/progress text only"
 
     awaited = await tool.await_shell(task_id=task_id, block_until_ms=5000, session_id="s1")
     assert awaited["status"] == "completed"
@@ -142,6 +146,10 @@ async def test_blocking_deadline_returns_running_then_kill(shell_env):
     )
     assert out["status"] == "running"
     assert out["task_id"] in ExecuteCommandTool._BG_TASKS
+    assert out["next_action"]["if_result_required"] == "call await_shell immediately"
+    assert out["next_action"]["await_shell_args"]["task_id"] == out["task_id"]
+    assert out["next_action"]["await_shell_args"]["block_until_ms"] >= 60000
+    assert out["next_action"]["do_not"] == "do not answer with waiting/progress text only"
 
     killed = await tool.kill_shell(task_id=out["task_id"], session_id="s1")
     assert killed["success"] is True


### PR DESCRIPTION
## Summary
- Tighten execute_shell / await_shell tool descriptions (zh/en): when the user request depends on command output, the model must call `await_shell` immediately instead of only saying it will wait.
- For background start, blocking deadline timeout, and running `await_shell` responses, add structured `next_action` (with suggested `await_shell` args) plus clearer English `message` fields.
- Update integration and completion-event tests; extend fake_wait signature for `emit_progress`.

## Testing
- `pytest tests/sagents/tool/impl/test_execute_shell_completion_event.py tests/sagents/tool/impl/test_execute_shell_integration.py` (5 passed, skipped items unchanged).

Made with [Cursor](https://cursor.com)