### PR TITLE
Add runtime tool expansion recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+2026-05-08 12:15 新增通用 tool_expand_tools：仅恢复 tool_suggestion 二次筛选遗漏，不突破 ToolProxy/agent_mode 边界；Simple/TaskExecutor 未提供工具拒绝提示走 PromptManager，并返回 available_expandable_tools；补单测与中英文架构文档。
+
 2026-05-06 16:25 助手非空串才拼接；token 扣图后回灌 ratio 取末次；重复/拒绝下轮 auto；压缩兼容 max_completion_tokens。
 
 2026-05-06 14:45 新增 tool_baseline：按可用列表补齐基线工具；IDENTITY.md 改用 agent_identity_extension 与中英提示；接入 simple/task/tool suggestion；单测 3 条。

--- a/docs/en/architecture/ARCHITECTURE_SAGENTS_TOOL_SKILL.md
+++ b/docs/en/architecture/ARCHITECTURE_SAGENTS_TOOL_SKILL.md
@@ -224,6 +224,34 @@ flowchart LR
 
 The tool/skill layer answers "what is available"; suggestion Agents answer "what should we use this turn", so we don't have to stuff every schema into the context.
 
+### 3.1 Runtime Tool Expansion
+
+`tool_suggestion` only narrows the tool schemas sent to the model for the current turn. It does not change the session-level `ToolProxy` permission boundary. If the model tries to call a tool that was not provided in the current LLM request but is still within the current Agent's allowed tools, the execution layer rejects that call and instructs the model to call the protocol tool `tool_expand_tools` first.
+
+`tool_expand_tools` accepts exact tool names only:
+
+```json
+{
+  "tool_names": ["file_read", "search_memory"]
+}
+```
+
+Expansion is validated against `session_context.tool_manager.list_all_tools_name()`, which is the current Agent's allowed tool set. It does not consult the global base `ToolManager` directly and cannot bypass entry `available_tools`, the `ToolProxy` whitelist, or `agent_mode` restrictions.
+
+Tool result shape:
+
+```json
+{
+  "success": true,
+  "expanded_tools": ["file_read"],
+  "invalid_tools": ["unknown_tool"],
+  "already_selected_tools": ["search_memory"],
+  "available_expandable_tools": ["file_write"]
+}
+```
+
+The policy is partial success: valid tools are added to `audit_status.suggested_tools` immediately and `audit_status.tools_expanded = true` is set; the next execution loop refreshes the tool schemas. Invalid tools are not added, and the model can use `available_expandable_tools` to choose another currently expandable tool.
+
 ## 4. Startup vs Runtime
 
 ```mermaid

--- a/docs/zh/architecture/ARCHITECTURE_SAGENTS_TOOL_SKILL.md
+++ b/docs/zh/architecture/ARCHITECTURE_SAGENTS_TOOL_SKILL.md
@@ -204,6 +204,34 @@ flowchart LR
 
 工具/技能层负责“有什么”，建议 Agent 负责“这次用什么”。这样不用一次把全部 schema 塞进上下文。
 
+### 3.1 运行期工具扩展（Tool Expansion）
+
+`tool_suggestion` 只会缩小本轮下发给模型的工具 schema，不会改变会话级 `ToolProxy` 权限边界。若模型尝试调用一个当前 LLM 请求未提供、但仍属于当前 Agent 允许范围的工具，执行层会拒绝本次越权调用，并提示模型先调用协议工具 `tool_expand_tools`。
+
+`tool_expand_tools` 只接受准确工具名：
+
+```json
+{
+  "tool_names": ["file_read", "search_memory"]
+}
+```
+
+扩展校验基于 `session_context.tool_manager.list_all_tools_name()`，即当前 Agent 已被允许使用的工具全集；它不会访问底层全局 `ToolManager`，也不能突破入口 `available_tools`、`ToolProxy` 白名单或 `agent_mode` 限制。
+
+工具返回结构：
+
+```json
+{
+  "success": true,
+  "expanded_tools": ["file_read"],
+  "invalid_tools": ["unknown_tool"],
+  "already_selected_tools": ["search_memory"],
+  "available_expandable_tools": ["file_write"]
+}
+```
+
+策略是“部分成功”：合法工具会立即加入 `audit_status.suggested_tools`，并设置 `audit_status.tools_expanded = true`；下一轮执行 Agent 会刷新本轮工具 schema。非法工具不会加入，模型可根据 `available_expandable_tools` 选择其他当前仍可扩展的工具。
+
 ## 4. 启动期 vs 运行期
 
 ```mermaid

--- a/sagents/agent/simple_agent.py
+++ b/sagents/agent/simple_agent.py
@@ -8,6 +8,7 @@ from sagents.tool.tool_manager import ToolManager
 from sagents.utils.prompt_manager import PromptManager
 from sagents.utils.content_saver import save_agent_response_content
 from sagents.tool.tool_baseline import augment_with_baseline_tools
+from sagents.tool.tool_expansion import TOOL_EXPAND_TOOLS, should_expose_tool_expansion
 import json
 import uuid
 from copy import deepcopy
@@ -214,6 +215,8 @@ class SimpleAgent(AgentBase):
         # 而不应阻止模型主动调用该工具来终止本轮。
         available_tool_names = [tool['function']['name'] for tool in tools_json]
         selected_tools = set(augment_with_baseline_tools(suggested_tools, available_tool_names))
+        if should_expose_tool_expansion(suggested_tools, selected_tools, available_tool_names):
+            selected_tools.add(TOOL_EXPAND_TOOLS)
         
         tools_suggest_json = [
             tool for tool in tools_json
@@ -718,6 +721,20 @@ class SimpleAgent(AgentBase):
             if current_turn_status_only:
                 logger.info("SimpleAgent: 上一轮纯文本无工具调用，本轮仅开放 turn_status 并启用 tool_choice=required")
 
+            if session_context.audit_status.pop("tools_expanded", False) and tool_manager:
+                refreshed_suggested_tools = session_context.audit_status.get('suggested_tools', [])
+                if not refreshed_suggested_tools:
+                    try:
+                        tools_list = tool_manager.list_tools_simplified()
+                        refreshed_suggested_tools = [t.get('name', '') for t in tools_list if t.get('name')]
+                    except Exception:
+                        refreshed_suggested_tools = []
+                tools_json = self._prepare_tools(tool_manager, refreshed_suggested_tools, session_context)
+                logger.info(
+                    "SimpleAgent: 工具扩展后已刷新本轮工具列表: "
+                    f"{[tool['function']['name'] for tool in tools_json]}"
+                )
+
             # 调用LLM
             should_break = False
             current_tools_json = self._turn_status_tools_only(tools_json) if current_turn_status_only else tools_json
@@ -1068,12 +1085,14 @@ class SimpleAgent(AgentBase):
                     logger.warning(
                         f"SimpleAgent: 模型返回未提供的工具 {sorted(invalid_tool_names)}，拒绝执行"
                     )
+                    unavailable_tools_label = ', '.join(sorted(name for name in invalid_tool_names if name))
+                    rejection_template = PromptManager().get_agent_prompt_auto(
+                        'unavailable_tool_expansion_message',
+                        language=session_context.get_language(),
+                    )
                     yield ([MessageChunk(
                         role=MessageRole.ASSISTANT.value,
-                        content=(
-                            "模型尝试调用当前请求未提供的工具，已拒绝执行以避免越权或循环。"
-                            f"违规工具：{', '.join(sorted(name for name in invalid_tool_names if name))}"
-                        ),
+                        content=rejection_template.format(tools=unavailable_tools_label),
                         type=MessageType.ERROR.value,
                         agent_name=self.agent_name,
                     )], False)

--- a/sagents/agent/task_executor_agent.py
+++ b/sagents/agent/task_executor_agent.py
@@ -8,6 +8,7 @@ from sagents.tool.tool_manager import ToolManager
 from sagents.utils.prompt_manager import PromptManager
 from sagents.utils.content_saver import save_agent_response_content
 from sagents.tool.tool_baseline import augment_with_baseline_tools
+from sagents.tool.tool_expansion import TOOL_EXPAND_TOOLS, should_expose_tool_expansion
 import uuid
 import os
 
@@ -189,6 +190,34 @@ TaskExecutorAgent: 任务执行智能体，负责根据任务描述和要求，�
 
         # 处理工具调用
         if len(tool_calls) > 0:
+            allowed_tool_names = {
+                (tool.get('function') or {}).get('name') or ""
+                for tool in tools_json
+            }
+            invalid_tool_names = {
+                (tool_call.get("function") or {}).get("name") or ""
+                for tool_call in tool_calls.values()
+                if ((tool_call.get("function") or {}).get("name") or "") not in allowed_tool_names
+            }
+            if invalid_tool_names:
+                logger.warning(
+                    f"TaskExecutorAgent: 模型返回未提供的工具 {sorted(invalid_tool_names)}，拒绝执行"
+                )
+                live_ctx = self._get_live_session_context(session_id)
+                language = live_ctx.get_language() if live_ctx is not None else "en"
+                unavailable_tools_label = ', '.join(sorted(name for name in invalid_tool_names if name))
+                rejection_template = PromptManager().get_agent_prompt_auto(
+                    'unavailable_tool_expansion_message',
+                    language=language,
+                )
+                yield [MessageChunk(
+                    role=MessageRole.ASSISTANT.value,
+                    content=rejection_template.format(tools=unavailable_tools_label),
+                    message_type=MessageType.ERROR.value,
+                    agent_name=self.agent_name,
+                )]
+                return
+
             # 根据环境变量控制 emit_tool_call_message
             # 如果 SAGE_EMIT_TOOL_CALL_ON_COMPLETE=true，则参数完整时才返回工具调用消息
             emit_on_complete = os.environ.get("SAGE_EMIT_TOOL_CALL_ON_COMPLETE", "false").lower() == "true"
@@ -255,7 +284,10 @@ TaskExecutorAgent: 任务执行智能体，负责根据任务描述和要求，�
             if 'load_skill' not in suggested_tools:
                 suggested_tools.append('load_skill')
 
+        has_effective_suggestions = bool(suggested_tools)
         suggested_tools = augment_with_baseline_tools(suggested_tools, available_tool_names)
+        if has_effective_suggestions and should_expose_tool_expansion(suggested_tools, suggested_tools, available_tool_names):
+            suggested_tools.append(TOOL_EXPAND_TOOLS)
         
         if suggested_tools:
             tools_suggest_json = [

--- a/sagents/prompts/agent_base_prompts.py
+++ b/sagents/prompts/agent_base_prompts.py
@@ -28,6 +28,36 @@ agent_identity_extension_hint = {
     ),
 }
 
+
+# 模型调用了本轮未提供的工具时的可恢复反馈。
+# 占位符 {tools} 会被替换为违规工具名（逗号分隔）。
+unavailable_tool_expansion_message = {
+    "zh": (
+        "模型尝试调用当前请求未提供的工具，已拒绝执行以避免越权或循环。"
+        "违规工具：{tools}。"
+        "如果这些工具确实属于当前任务所需，请先调用 "
+        "tool_expand_tools({{\"tool_names\": [...]}}) 扩展准确工具名，"
+        "扩展成功后再重新调用原工具；如果扩展返回 invalid_tools，"
+        "说明这些工具不在当前 Agent 允许范围内，请改用已有工具或向用户说明受限。"
+    ),
+    "en": (
+        "The model attempted to call tools that were not provided for the current request, "
+        "so execution was rejected to avoid privilege bypass or loops. Unavailable tools: {tools}. "
+        "If these tools are truly needed for the task, first call "
+        "tool_expand_tools({{\"tool_names\": [...]}}) with exact tool names, then retry the original tool call "
+        "after expansion succeeds. If expansion returns invalid_tools, those tools are outside the current "
+        "agent's allowed tool boundary; use available tools instead or explain the limitation to the user."
+    ),
+    "pt": (
+        "O modelo tentou chamar ferramentas que não foram fornecidas para a solicitação atual, "
+        "então a execução foi rejeitada para evitar desvio de permissões ou loops. Ferramentas indisponíveis: {tools}. "
+        "Se essas ferramentas forem realmente necessárias para a tarefa, primeiro chame "
+        "tool_expand_tools({{\"tool_names\": [...]}}) com nomes exatos de ferramentas e, após a expansão ter sucesso, "
+        "tente novamente a chamada original. Se a expansão retornar invalid_tools, essas ferramentas estão fora "
+        "do limite permitido para o Agent atual; use ferramentas disponíveis ou explique a limitação ao usuário."
+    ),
+}
+
 # 智能体介绍模板
 agent_intro_template = {
     "zh": """

--- a/sagents/tool/impl/tool_expansion_tool.py
+++ b/sagents/tool/impl/tool_expansion_tool.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from ..tool_base import tool
+from ..tool_expansion import TOOL_EXPAND_TOOLS
+from sagents.utils.logger import logger
+
+
+class ToolExpansionTool:
+    """Expand the current LLM-visible tool set within the agent's allowed tools."""
+
+    @tool(
+        description_i18n={
+            "zh": (
+                "扩展当前请求可见的工具集。仅当你尝试调用的工具未出现在当前工具列表中，"
+                "但该工具可能属于当前任务所需时使用。只能按准确工具名扩展，且不能突破当前 Agent "
+                "被允许使用的工具范围。扩展成功后，请重新调用原本需要的工具。"
+            ),
+            "en": (
+                "Expand the tools visible to the current request. Use this only when a needed tool is missing "
+                "from the current tool list. Expansion requires exact tool names and cannot exceed the tools "
+                "allowed for the current agent. After expansion succeeds, call the originally needed tool again."
+            ),
+        },
+        param_description_i18n={
+            "tool_names": {
+                "zh": "需要扩展的准确工具名列表",
+                "en": "Exact tool names to expand",
+            },
+            "session_id": {
+                "zh": "会话ID（必填，自动注入）",
+                "en": "Session ID (required, auto-injected)",
+            },
+        },
+        param_schema={
+            "tool_names": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Exact tool names to expand",
+            },
+            "session_id": {"type": "string", "description": "Session ID"},
+        },
+    )
+    async def tool_expand_tools(
+        self,
+        tool_names: List[str],
+        session_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        session_context = self._get_session_context(session_id)
+        if not session_context or not getattr(session_context, "tool_manager", None):
+            return {
+                "success": False,
+                "expanded_tools": [],
+                "invalid_tools": list(tool_names or []),
+                "already_selected_tools": [],
+                "error": "Session context or tool manager is not available",
+            }
+
+        requested = self._normalize_tool_names(tool_names)
+        allowed_tools = set(session_context.tool_manager.list_all_tools_name())
+        suggested_tools = list((session_context.audit_status or {}).get("suggested_tools") or [])
+        selected = set(suggested_tools)
+        available_expandable_tools = sorted(
+            name for name in allowed_tools
+            if name and name != TOOL_EXPAND_TOOLS and name not in selected
+        )
+
+        expanded_tools: List[str] = []
+        invalid_tools: List[str] = []
+        already_selected_tools: List[str] = []
+
+        for name in requested:
+            if name == TOOL_EXPAND_TOOLS:
+                already_selected_tools.append(name)
+                continue
+            if name not in allowed_tools:
+                invalid_tools.append(name)
+                continue
+            if name in selected:
+                already_selected_tools.append(name)
+                continue
+            suggested_tools.append(name)
+            selected.add(name)
+            expanded_tools.append(name)
+
+        if expanded_tools:
+            session_context.audit_status["suggested_tools"] = suggested_tools
+            session_context.audit_status["tools_expanded"] = True
+
+        logger.info(
+            "ToolExpansionTool: "
+            f"requested={requested} expanded={expanded_tools} invalid={invalid_tools} "
+            f"already={already_selected_tools} session={session_id}"
+        )
+
+        return {
+            "success": bool(expanded_tools),
+            "expanded_tools": expanded_tools,
+            "invalid_tools": invalid_tools,
+            "already_selected_tools": already_selected_tools,
+            "available_expandable_tools": [
+                name for name in available_expandable_tools if name not in expanded_tools
+            ],
+        }
+
+    @staticmethod
+    def _normalize_tool_names(tool_names: Optional[List[str]]) -> List[str]:
+        if isinstance(tool_names, str):
+            tool_names = [tool_names]
+        normalized: List[str] = []
+        seen = set()
+        for item in tool_names or []:
+            name = str(item or "").strip()
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            normalized.append(name)
+        return normalized
+
+    @staticmethod
+    def _get_session_context(session_id: Optional[str]):
+        if not session_id:
+            return None
+        try:
+            from sagents.utils.agent_session_helper import get_live_session_context
+
+            return get_live_session_context(session_id, log_prefix="ToolExpansionTool")
+        except Exception as exc:
+            logger.warning(f"ToolExpansionTool: failed to resolve session_context: {exc}")
+            return None

--- a/sagents/tool/tool_expansion.py
+++ b/sagents/tool/tool_expansion.py
@@ -1,0 +1,33 @@
+"""Shared helpers for runtime tool expansion."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Set
+
+
+TOOL_EXPAND_TOOLS = "tool_expand_tools"
+
+
+def should_expose_tool_expansion(
+    suggested_tools: Iterable[str],
+    selected_tool_names: Iterable[str],
+    allowed_tool_names: Iterable[str],
+) -> bool:
+    """Return whether the expansion tool should be exposed to the model.
+
+    Expansion only makes sense when the execution layer narrowed the current
+    request tools below the agent's allowed tool boundary.
+    """
+
+    suggested: List[str] = [name for name in (suggested_tools or []) if name]
+    if not suggested:
+        return False
+
+    allowed: Set[str] = {name for name in (allowed_tool_names or []) if name}
+    if TOOL_EXPAND_TOOLS not in allowed:
+        return False
+
+    selected: Set[str] = {name for name in (selected_tool_names or []) if name}
+    allowed_actions = allowed - {TOOL_EXPAND_TOOLS}
+    selected_actions = selected - {TOOL_EXPAND_TOOLS}
+    return len(selected_actions) < len(allowed_actions)

--- a/sagents/tool/tool_proxy.py
+++ b/sagents/tool/tool_proxy.py
@@ -1,5 +1,6 @@
 from typing import List, Dict, Any, Optional, Union
 from .tool_manager import ToolManager
+from .tool_expansion import TOOL_EXPAND_TOOLS
 from sagents.utils.logger import logger
 
 class ToolProxy:
@@ -43,6 +44,11 @@ class ToolProxy:
             if _os.environ.get("SAGE_AGENT_STATUS_PROTOCOL_ENABLED", "true").lower() != "false":
                 if "turn_status" in all_tools_names:
                     self._available_tools.add("turn_status")
+
+            # 协议性工具：tool_expand_tools 只用于恢复 tool suggestion 二次筛选遗漏的工具。
+            # 它必须在入口白名单内可见，真正是否下发给模型由执行层按"是否被二次收窄"判断。
+            if TOOL_EXPAND_TOOLS in all_tools_names:
+                self._available_tools.add(TOOL_EXPAND_TOOLS)
 
             # 工具捆绑组：组内任何一个被勾选，组内全部解锁（共享后台任务注册表，缺一个就废）。
             _TOOL_BUNDLES: List[set] = [

--- a/tests/sagents/agent/test_tool_expansion_prepare.py
+++ b/tests/sagents/agent/test_tool_expansion_prepare.py
@@ -1,0 +1,126 @@
+from types import SimpleNamespace
+import asyncio
+
+from sagents.context.messages.message import MessageType
+from sagents.agent.simple_agent import SimpleAgent
+from sagents.agent.task_executor_agent import TaskExecutorAgent
+from sagents.tool.tool_base import tool
+from sagents.tool.tool_manager import ToolManager
+
+
+class _DummyModel:
+    pass
+
+
+class _StubTools:
+    @tool()
+    def alpha_tool(self):
+        """alpha"""
+        return "alpha"
+
+    @tool()
+    def beta_tool(self):
+        """beta"""
+        return "beta"
+
+    @tool()
+    def tool_expand_tools(self, tool_names: list[str] = None):
+        """expand"""
+        return tool_names or []
+
+
+def _tool_manager():
+    tm = ToolManager(isolated=True, is_auto_discover=False)
+    tm.register_tools_from_object(_StubTools())
+    return tm
+
+
+def _session_context():
+    return SimpleNamespace(
+        get_language=lambda: "en",
+        effective_skill_manager=None,
+    )
+
+
+def _names(tools_json):
+    return [tool["function"]["name"] for tool in tools_json]
+
+
+def test_simple_agent_exposes_expansion_when_suggestion_narrows_allowed_tools():
+    tools_json = SimpleAgent(_DummyModel(), {})._prepare_tools(
+        _tool_manager(),
+        ["alpha_tool"],
+        _session_context(),
+    )
+
+    assert _names(tools_json) == ["alpha_tool", "tool_expand_tools"]
+
+
+def test_simple_agent_does_not_expose_expansion_when_suggestion_is_not_narrowed():
+    tools_json = SimpleAgent(_DummyModel(), {})._prepare_tools(
+        _tool_manager(),
+        ["alpha_tool", "beta_tool"],
+        _session_context(),
+    )
+
+    assert _names(tools_json) == ["alpha_tool", "beta_tool"]
+
+
+def test_task_executor_exposes_expansion_when_suggestion_narrows_allowed_tools():
+    tools_json = TaskExecutorAgent(_DummyModel(), {})._prepare_tools(
+        _tool_manager(),
+        ["alpha_tool"],
+        _session_context(),
+    )
+
+    assert _names(tools_json) == ["alpha_tool", "tool_expand_tools"]
+
+
+def test_task_executor_rejects_tool_not_in_current_llm_tools(monkeypatch):
+    agent = TaskExecutorAgent(_DummyModel(), {})
+    monkeypatch.setattr(agent, "_get_live_session_context", lambda session_id: _session_context())
+
+    async def _fake_llm_streaming(*args, **kwargs):
+        yield SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        tool_calls=[
+                            SimpleNamespace(
+                                id="call_1",
+                                index=0,
+                                type="function",
+                                function=SimpleNamespace(
+                                    name="beta_tool",
+                                    arguments='{"x": 1}',
+                                ),
+                            )
+                        ],
+                        content=None,
+                    )
+                )
+            ]
+        )
+
+    monkeypatch.setattr(agent, "_call_llm_streaming", _fake_llm_streaming)
+    out = []
+    tools_json = [
+        tool for tool in _tool_manager().get_openai_tools()
+        if tool["function"]["name"] in {"alpha_tool", "tool_expand_tools"}
+    ]
+
+    async def _collect_with_filtered_tools():
+        async for chunks in agent._call_llm_and_process_response(
+            messages_input=[],
+            tools_json=tools_json,
+            tool_manager=_tool_manager(),
+            session_id="s1",
+        ):
+            out.extend(chunks)
+
+    asyncio.run(_collect_with_filtered_tools())
+
+    errors = [item for item in out if item.message_type == MessageType.ERROR.value]
+    assert len(errors) == 1
+    assert "tool_expand_tools" in errors[0].content
+    assert "beta_tool" in errors[0].content

--- a/tests/sagents/tool/impl/test_tool_expansion_tool.py
+++ b/tests/sagents/tool/impl/test_tool_expansion_tool.py
@@ -1,0 +1,130 @@
+import asyncio
+from types import SimpleNamespace
+
+from sagents.tool.impl.tool_expansion_tool import ToolExpansionTool
+
+
+class _AllowedToolManager:
+    def __init__(self, names):
+        self._names = list(names)
+
+    def list_all_tools_name(self):
+        return list(self._names)
+
+
+def _ctx(allowed, suggested):
+    return SimpleNamespace(
+        tool_manager=_AllowedToolManager(allowed),
+        audit_status={"suggested_tools": list(suggested)},
+    )
+
+
+def _patch_ctx(monkeypatch, ctx):
+    import sagents.utils.agent_session_helper as helper
+
+    monkeypatch.setattr(helper, "get_live_session_context", lambda *args, **kwargs: ctx)
+
+
+def test_expands_tool_within_current_agent_allowed_boundary(monkeypatch):
+    ctx = _ctx(
+        allowed=["alpha_tool", "beta_tool", "tool_expand_tools"],
+        suggested=["alpha_tool"],
+    )
+    _patch_ctx(monkeypatch, ctx)
+
+    out = asyncio.run(ToolExpansionTool().tool_expand_tools(["beta_tool"], session_id="s1"))
+
+    assert out["success"] is True
+    assert out["expanded_tools"] == ["beta_tool"]
+    assert out["invalid_tools"] == []
+    assert out["already_selected_tools"] == []
+    assert out["available_expandable_tools"] == []
+    assert ctx.audit_status["suggested_tools"] == ["alpha_tool", "beta_tool"]
+    assert ctx.audit_status["tools_expanded"] is True
+
+
+def test_invalid_tool_name_returns_available_expandable_tools(monkeypatch):
+    ctx = _ctx(
+        allowed=["alpha_tool", "beta_tool", "gamma_tool", "tool_expand_tools"],
+        suggested=["alpha_tool"],
+    )
+    _patch_ctx(monkeypatch, ctx)
+
+    out = asyncio.run(ToolExpansionTool().tool_expand_tools(["missing_tool"], session_id="s1"))
+
+    assert out["success"] is False
+    assert out["expanded_tools"] == []
+    assert out["invalid_tools"] == ["missing_tool"]
+    assert out["already_selected_tools"] == []
+    assert out["available_expandable_tools"] == ["beta_tool", "gamma_tool"]
+    assert ctx.audit_status["suggested_tools"] == ["alpha_tool"]
+    assert "tools_expanded" not in ctx.audit_status
+
+
+def test_rejects_tool_outside_current_agent_allowed_boundary(monkeypatch):
+    ctx = _ctx(
+        allowed=["alpha_tool", "tool_expand_tools"],
+        suggested=["alpha_tool"],
+    )
+    _patch_ctx(monkeypatch, ctx)
+
+    out = asyncio.run(ToolExpansionTool().tool_expand_tools(["beta_tool"], session_id="s1"))
+
+    assert out["success"] is False
+    assert out["expanded_tools"] == []
+    assert out["invalid_tools"] == ["beta_tool"]
+    assert out["available_expandable_tools"] == []
+    assert ctx.audit_status["suggested_tools"] == ["alpha_tool"]
+    assert "tools_expanded" not in ctx.audit_status
+
+
+def test_reports_already_selected_tool_without_setting_refresh(monkeypatch):
+    ctx = _ctx(
+        allowed=["alpha_tool", "tool_expand_tools"],
+        suggested=["alpha_tool"],
+    )
+    _patch_ctx(monkeypatch, ctx)
+
+    out = asyncio.run(ToolExpansionTool().tool_expand_tools(["alpha_tool"], session_id="s1"))
+
+    assert out["success"] is False
+    assert out["already_selected_tools"] == ["alpha_tool"]
+    assert out["available_expandable_tools"] == []
+    assert ctx.audit_status["suggested_tools"] == ["alpha_tool"]
+    assert "tools_expanded" not in ctx.audit_status
+
+
+def test_accepts_single_string_tool_name(monkeypatch):
+    ctx = _ctx(
+        allowed=["alpha_tool", "beta_tool", "tool_expand_tools"],
+        suggested=["alpha_tool"],
+    )
+    _patch_ctx(monkeypatch, ctx)
+
+    out = asyncio.run(ToolExpansionTool().tool_expand_tools("beta_tool", session_id="s1"))
+
+    assert out["success"] is True
+    assert out["expanded_tools"] == ["beta_tool"]
+
+
+def test_mixed_valid_invalid_and_already_selected_names(monkeypatch):
+    ctx = _ctx(
+        allowed=["alpha_tool", "beta_tool", "gamma_tool", "tool_expand_tools"],
+        suggested=["alpha_tool"],
+    )
+    _patch_ctx(monkeypatch, ctx)
+
+    out = asyncio.run(
+        ToolExpansionTool().tool_expand_tools(
+            ["alpha_tool", "beta_tool", "missing_tool"],
+            session_id="s1",
+        )
+    )
+
+    assert out["success"] is True
+    assert out["expanded_tools"] == ["beta_tool"]
+    assert out["invalid_tools"] == ["missing_tool"]
+    assert out["already_selected_tools"] == ["alpha_tool"]
+    assert out["available_expandable_tools"] == ["gamma_tool"]
+    assert ctx.audit_status["suggested_tools"] == ["alpha_tool", "beta_tool"]
+    assert ctx.audit_status["tools_expanded"] is True

--- a/tests/sagents/tool/test_tool_proxy_bundles.py
+++ b/tests/sagents/tool/test_tool_proxy_bundles.py
@@ -35,10 +35,18 @@ class _StubTurnStatus:
         return status
 
 
+class _StubToolExpansion:
+    @tool()
+    def tool_expand_tools(self, tool_names: list[str] = None):
+        """expand"""
+        return tool_names or []
+
+
 def _build_proxy(available):
     tm = ToolManager(isolated=True, is_auto_discover=False)
     tm.register_tools_from_object(_StubShellTools())
     tm.register_tools_from_object(_StubTurnStatus())
+    tm.register_tools_from_object(_StubToolExpansion())
     return ToolProxy(tool_managers=[tm], available_tools=available)
 
 
@@ -46,6 +54,12 @@ def test_turn_status_force_injected_when_whitelist_set():
     proxy = _build_proxy(available=["execute_shell_command"])
     names = {t["name"] for t in proxy.list_tools()}
     assert "turn_status" in names
+
+
+def test_tool_expand_tools_force_injected_when_whitelist_set():
+    proxy = _build_proxy(available=["execute_shell_command"])
+    names = {t["name"] for t in proxy.list_tools()}
+    assert "tool_expand_tools" in names
 
 
 def test_shell_bundle_unlocks_all_three_when_only_one_selected():


### PR DESCRIPTION
## Summary
- add tool_expand_tools to recover tools omitted by tool suggestion without bypassing ToolProxy boundaries
- expose expansion only when suggested tools narrow the current allowed tool set
- add recoverable unavailable-tool prompts, docs, changelog, and tests

## Tests
- python -m py_compile sagents/tool/impl/tool_expansion_tool.py sagents/tool/tool_expansion.py sagents/agent/simple_agent.py sagents/agent/task_executor_agent.py sagents/prompts/agent_base_prompts.py
- python -m pytest tests/sagents/agent/test_tool_expansion_prepare.py tests/sagents/tool/test_tool_proxy_bundles.py tests/sagents/tool/impl/test_tool_expansion_tool.py