### PR TITLE
Clarify task completion env behavior

### DIFF
--- a/docs/en/ENV_VARS.md
+++ b/docs/en/ENV_VARS.md
@@ -79,7 +79,7 @@ ref: env_vars
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `SAGE_AGENT_STATUS_PROTOCOL_ENABLED` | `true` | Enable the agent turn-status protocol (inject `turn_status` and require the LLM to report status explicitly) |
+| `SAGE_AGENT_STATUS_PROTOCOL_ENABLED` | `true` | Enable the agent turn-status protocol. When enabled, Sage injects `turn_status` and task completion is decided by the model calling that tool (`task_done`, `need_user_input`, `blocked`, or `continue_work`). When set to `false`, SimpleAgent falls back to the legacy rule-first + LLM `task_complete_judge` completion check. |
 | `SAGE_CLI_MAX_LOOP_COUNT` | — | Max loops per CLI turn |
 | `SAGE_SPLIT_SYSTEM` | `true` | Split the system message into stable / semi_stable / volatile segments to maximise prompt-cache hit rate |
 | `SAGE_STABLE_TOOLS_ORDER` | `true` | Sort the `tools` field by function name to stabilise the cache key |

--- a/docs/zh/ENV_VARS.md
+++ b/docs/zh/ENV_VARS.md
@@ -89,7 +89,7 @@ ref: env_vars
 
 | 变量                                             | 默认值     | 说明                                                                                                                                                                           |
 | ---------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `SAGE_AGENT_STATUS_PROTOCOL_ENABLED`           | `true`  | 是否启用 Agent 本轮状态协议（注入 `turn_status` 并要求模型显式报告状态）                                                                                                                     |
+| `SAGE_AGENT_STATUS_PROTOCOL_ENABLED`           | `true`  | 是否启用 Agent 本轮状态协议。启用时注入 `turn_status`，任务完成由模型调用该工具报告（`task_done` / `need_user_input` / `blocked` / `continue_work`）；设为 `false` 时，SimpleAgent 回退到旧的“规则优先 + LLM `task_complete_judge`”完成判断。 |
 | `SAGE_CLI_MAX_LOOP_COUNT`                      | —       | CLI 单轮最大循环次数                                                                                                                                                                 |
 | `SAGE_SPLIT_SYSTEM`                            | `true`  | 是否把 system message 拆成 stable / semi_stable / volatile 多段以提升 prompt cache 命中                                                                                              |
 | `SAGE_STABLE_TOOLS_ORDER`                      | `true`  | 是否对 `tools` 字段按 name 字典序排序，稳定 cache key                                                                                                                                      |


### PR DESCRIPTION
## Summary
- clarify that SAGE_AGENT_STATUS_PROTOCOL_ENABLED=true uses the turn_status tool protocol for completion
- document that setting it to false falls back to the legacy rule-first + LLM task_complete_judge path

## Tests
- docs-only change; not run