### PR TITLE
Prioritize agent response language setting

### DIFF
--- a/common/services/chat_service.py
+++ b/common/services/chat_service.py
@@ -642,7 +642,15 @@ async def populate_request_from_agent_config(
         if agent_config.get("moreSuggest") is not None and request.more_suggest is None:
             request.more_suggest = agent_config.get("moreSuggest")
         if agent_config.get("systemContext") is not None:
-            _merge_dict(request, "system_context", agent_config.get("systemContext"))
+            agent_system_context = agent_config.get("systemContext")
+            _merge_dict(request, "system_context", agent_system_context)
+            if (
+                isinstance(agent_system_context, dict)
+                and agent_system_context.get("response_language") is not None
+            ):
+                if request.system_context is None:
+                    request.system_context = {}
+                request.system_context["response_language"] = agent_system_context["response_language"]
         if agent_config.get("systemPrefix") is not None:
             request.system_prefix = agent_config.get("systemPrefix")
         if agent_config.get("memoryType") is not None:

--- a/tests/common/services/test_chat_service_skill_owner.py
+++ b/tests/common/services/test_chat_service_skill_owner.py
@@ -115,3 +115,63 @@ def test_populate_request_records_agent_owner_user_id(tmp_path, monkeypatch):
     assert request.agent_owner_user_id == "owner_user"
     assert request.user_id == "caller_user"
     assert request.available_skills == ["schedule-management"]
+
+
+def test_populate_request_agent_response_language_overrides_page_setting(tmp_path, monkeypatch):
+    cfg = _server_cfg(tmp_path)
+    monkeypatch.setattr(config, "_GLOBAL_STARTUP_CONFIG", cfg, raising=False)
+
+    agent = SimpleNamespace(
+        name="Ling",
+        user_id="owner_user",
+        config={
+            "availableTools": [],
+            "maxLoopCount": 3,
+            "systemContext": {
+                "response_language": "zh-CN",
+                "business_key": "agent_value",
+            },
+        },
+    )
+    provider = SimpleNamespace(
+        base_url="http://model.local",
+        api_key="key",
+        model="model",
+        max_tokens=None,
+        temperature=0.3,
+        top_p=0.9,
+        presence_penalty=0.0,
+        max_model_len=64000,
+        supports_multimodal=True,
+        supports_structured_output=False,
+    )
+
+    class FakeAgentConfigDao:
+        async def get_by_id(self, agent_id):
+            return agent
+
+    class FakeLLMProviderDao:
+        async def get_default(self):
+            return provider
+
+    async def fake_register_extra_mcp_tools(request):
+        return None
+
+    monkeypatch.setattr(chat_service, "AgentConfigDao", FakeAgentConfigDao)
+    monkeypatch.setattr(chat_service, "LLMProviderDao", FakeLLMProviderDao)
+    monkeypatch.setattr(chat_service, "_register_extra_mcp_tools", fake_register_extra_mcp_tools)
+
+    request = StreamRequest(
+        messages=[Message(role="user", content="hi")],
+        user_id="caller_user",
+        agent_id="agent_1",
+        system_context={
+            "response_language": "en-US",
+            "business_key": "request_value",
+        },
+    )
+
+    asyncio.run(chat_service.populate_request_from_agent_config(request))
+
+    assert request.system_context["response_language"] == "zh-CN"
+    assert request.system_context["business_key"] == "request_value"


### PR DESCRIPTION
## Summary
- keep the existing request/system_context merge behavior for agent config
- let agent systemContext.response_language override the page-provided response_language when both are present
- add a focused regression test for the response_language priority rule

## Tests
- .venv/bin/pytest tests/common/services/test_chat_service_skill_owner.py::test_populate_request_agent_response_language_overrides_page_setting