### PR TITLE
fix：修复 Session 上下文预算配置的持久化与模型切换同步

### DIFF
--- a/sagents/agent/fibre/orchestrator.py
+++ b/sagents/agent/fibre/orchestrator.py
@@ -1349,9 +1349,8 @@ class FibreOrchestrator:
         # Let's manually ensure context, similar to run_stream logic but without execution
         sub_agent_system_context = copy.deepcopy(agent_def.system_context)
         
-        # Inherit context_budget_config from parent session
         parent_context = parent_session.session_context if parent_session and parent_session.session_context else None
-        # context_budget_config is passed to MessageManager, not stored in SessionContext
+        # Let SessionRuntime derive context_budget_config from the sub-agent model_config.
         context_budget_config = None
         
         # Merge parent session's system_context (excluding specific keys)

--- a/sagents/agent/simple_agent.py
+++ b/sagents/agent/simple_agent.py
@@ -600,7 +600,8 @@ class SimpleAgent(AgentBase):
             messages_for_complete = messages_input
 
         # 压缩消息，避免 token 超限
-        budget = min(session_context.message_manager.context_budget_manager.budget_info.get('active_budget', 3000), 3000)
+        budget_info = session_context.message_manager.context_budget_manager.budget_info or {}
+        budget = min(budget_info.get('active_budget', 3000), 3000)
         messages_for_complete = MessageManager.compress_messages(messages_for_complete, budget)
 
         clean_messages = MessageManager.convert_messages_to_dict_for_request(messages_for_complete)

--- a/sagents/context/messages/context_budget.py
+++ b/sagents/context/messages/context_budget.py
@@ -95,7 +95,7 @@ class ContextBudgetManager:
                 f"ContextBudgetManager: agent_config过长({agent_config_tokens}), "
                 f"超过模型最大长度({self.max_model_len})"
             )
-            return {
+            budget_info = {
                 'agent_config_tokens': agent_config_tokens,
                 'available_tokens': 0,
                 'history_budget': 0,
@@ -103,6 +103,8 @@ class ContextBudgetManager:
                 'max_new_tokens': 0,
                 'max_model_len': self.max_model_len
             }
+            self.budget_info = budget_info
+            return budget_info
         
         # 按比例分配
         budget_info = {

--- a/sagents/context/session_context.py
+++ b/sagents/context/session_context.py
@@ -137,6 +137,57 @@ class SessionContext:
         except Exception as e:
             logger.warning(f"SessionContext: 清理过期任务失败: {e}")
 
+    @staticmethod
+    def _normalize_context_budget_config(context_budget_config: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        if not isinstance(context_budget_config, dict):
+            return {}
+        allowed_keys = {
+            "max_model_len",
+            "history_ratio",
+            "active_ratio",
+            "max_new_message_ratio",
+        }
+        return {
+            key: value
+            for key, value in context_budget_config.items()
+            if key in allowed_keys and value is not None
+        }
+
+    def _effective_context_budget_config(self) -> Dict[str, Any]:
+        manager = self.message_manager.context_budget_manager
+        return {
+            "max_model_len": manager.max_model_len,
+            "history_ratio": manager.history_ratio,
+            "active_ratio": manager.active_ratio,
+            "max_new_message_ratio": manager.max_new_message_ratio,
+        }
+
+    def update_context_budget_config(self, context_budget_config: Optional[Dict[str, Any]]) -> None:
+        """Refresh budget settings on a reused/restored SessionContext."""
+        incoming = self._normalize_context_budget_config(context_budget_config)
+        if not incoming:
+            return
+
+        manager = self.message_manager.context_budget_manager
+        current_config = self._effective_context_budget_config()
+        next_config = dict(current_config)
+        next_config.update(incoming)
+
+        if next_config == current_config:
+            self.context_budget_config = next_config
+            return
+
+        manager.max_model_len = next_config["max_model_len"]
+        manager.history_ratio = next_config["history_ratio"]
+        manager.active_ratio = next_config["active_ratio"]
+        manager.max_new_message_ratio = next_config["max_new_message_ratio"]
+        manager.budget_info = None
+        self.context_budget_config = next_config
+        logger.info(
+            f"SessionContext: 更新 context_budget_config, "
+            f"max_model_len={manager.max_model_len}"
+        )
+
     def _init_runtime_state(self, context_budget_config: Optional[Dict[str, Any]] = None):
         # 运行期状态容器（与 I/O、会话生命周期绑定）
         self.llm_requests_logs: List[Dict[str, Any]] = []
@@ -146,6 +197,7 @@ class SessionContext:
         self.end_time = None
         self._status = SessionStatus.IDLE
         self.message_manager = MessageManager(context_budget_config=context_budget_config)
+        self.context_budget_config = self._effective_context_budget_config()
         # pending_user_injections：运行中等待被下一次 LLM 请求消费的"引导用户消息"。
         # 不进入持久化快照，会话销毁即释放。
         self.pending_user_injections: List[MessageChunk] = []
@@ -935,7 +987,8 @@ class SessionContext:
             llm_config = {
                 "model": model_config.get("model", ""),
                 "maxTokens": model_config.get("max_tokens", ""),
-                "temperature": model_config.get("temperature", "")
+                "temperature": model_config.get("temperature", ""),
+                "max_model_len": model_config.get("max_model_len"),
             }
 
         self.agent_config = {
@@ -1355,6 +1408,7 @@ class SessionContext:
                 "system_context": make_serializable(self.system_context),
                 "audit_status": make_serializable(self.audit_status),
                 "tokens_usage_info": self.get_tokens_usage_info(),
+                "context_budget_config": make_serializable(self._effective_context_budget_config()),
 
                 # Agent 配置
                 "agent_config": make_serializable(self.agent_config)

--- a/sagents/context/session_context.py
+++ b/sagents/context/session_context.py
@@ -185,7 +185,9 @@ class SessionContext:
         self.context_budget_config = next_config
         logger.info(
             f"SessionContext: 更新 context_budget_config, "
-            f"max_model_len={manager.max_model_len}"
+            f"session_id={self.session_id}, "
+            f"old_max_model_len={current_config.get('max_model_len')}, "
+            f"new_max_model_len={manager.max_model_len}"
         )
 
     def _init_runtime_state(self, context_budget_config: Optional[Dict[str, Any]] = None):

--- a/sagents/session_runtime.py
+++ b/sagents/session_runtime.py
@@ -73,6 +73,22 @@ def delete_session_run_lock(session_id: str):
     lock_manager.delete_lock_ref(session_id)
 
 
+def _context_budget_config_from_model(
+    context_budget_config: Optional[Dict[str, Any]],
+    model_config: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    effective_config = dict(context_budget_config or {})
+    if "max_model_len" not in effective_config and effective_config.get("maxModelLen"):
+        effective_config["max_model_len"] = effective_config.get("maxModelLen")
+    if "max_model_len" not in effective_config:
+        max_model_len = None
+        if isinstance(model_config, dict):
+            max_model_len = model_config.get("max_model_len") or model_config.get("maxModelLen")
+        if max_model_len:
+            effective_config["max_model_len"] = max_model_len
+    return effective_config or None
+
+
 class Session:
     def __init__(self, session_id: str, enable_obs: bool = True, sandbox_type: str = "local"):
         self.session_id = session_id
@@ -253,6 +269,12 @@ class Session:
             try:
                 agent_config = snapshot.get("agent_config") or {}
                 system_context = snapshot.get("system_context") or {}
+                context_budget_config = snapshot.get("context_budget_config")
+                llm_config = agent_config.get("llm_config") if isinstance(agent_config, dict) else {}
+                context_budget_config = _context_budget_config_from_model(
+                    context_budget_config if isinstance(context_budget_config, dict) else None,
+                    llm_config if isinstance(llm_config, dict) else None,
+                )
                 self.session_context = SessionContext(
                     session_id=str(snapshot.get("session_id") or self.session_id),
                     user_id=str(snapshot.get("user_id") or ""),
@@ -261,7 +283,7 @@ class Session:
                     sandbox_agent_workspace=snapshot.get("sandbox_agent_workspace"),
                     volume_mounts=None,
                     sandbox_id=None,
-                    context_budget_config=None,
+                    context_budget_config=context_budget_config,
                     system_context=system_context if isinstance(system_context, dict) else {},
                     tool_manager=None,
                     skill_manager=None,
@@ -445,8 +467,11 @@ class Session:
             if parent_session_id:
                 logger.info(f"SessionRuntime: 从 system_context 中提取 parent_session_id={parent_session_id}")
 
+        context_budget_config = _context_budget_config_from_model(context_budget_config, self.model_config)
+
         if self.session_context:
             self._cache_session_workspace(session_id, self.session_context)
+            self.session_context.update_context_budget_config(context_budget_config)
             if tool_manager:
                 self.session_context.tool_manager = tool_manager
             if skill_manager:

--- a/sagents/session_runtime.py
+++ b/sagents/session_runtime.py
@@ -80,12 +80,28 @@ def _context_budget_config_from_model(
     effective_config = dict(context_budget_config or {})
     if "max_model_len" not in effective_config and effective_config.get("maxModelLen"):
         effective_config["max_model_len"] = effective_config.get("maxModelLen")
+        logger.debug(
+            f"SessionRuntime: normalized context_budget_config maxModelLen="
+            f"{effective_config['max_model_len']}"
+        )
     if "max_model_len" not in effective_config:
         max_model_len = None
         if isinstance(model_config, dict):
             max_model_len = model_config.get("max_model_len") or model_config.get("maxModelLen")
         if max_model_len:
             effective_config["max_model_len"] = max_model_len
+            logger.debug(
+                f"SessionRuntime: derived context_budget_config from model_config, "
+                f"max_model_len={max_model_len}"
+            )
+    elif isinstance(model_config, dict):
+        model_max_model_len = model_config.get("max_model_len") or model_config.get("maxModelLen")
+        if model_max_model_len and model_max_model_len != effective_config.get("max_model_len"):
+            logger.debug(
+                f"SessionRuntime: using explicit context_budget_config, "
+                f"max_model_len={effective_config.get('max_model_len')}, "
+                f"model_config_max_model_len={model_max_model_len}"
+            )
     return effective_config or None
 
 
@@ -271,10 +287,18 @@ class Session:
                 system_context = snapshot.get("system_context") or {}
                 context_budget_config = snapshot.get("context_budget_config")
                 llm_config = agent_config.get("llm_config") if isinstance(agent_config, dict) else {}
+                has_persisted_budget_config = isinstance(context_budget_config, dict)
                 context_budget_config = _context_budget_config_from_model(
                     context_budget_config if isinstance(context_budget_config, dict) else None,
                     llm_config if isinstance(llm_config, dict) else None,
                 )
+                if context_budget_config:
+                    restore_source = "context_budget_config" if has_persisted_budget_config else "legacy llm_config"
+                    logger.info(
+                        f"SessionRuntime: restored context_budget_config from {restore_source}, "
+                        f"session_id={self.session_id}, "
+                        f"max_model_len={context_budget_config.get('max_model_len')}"
+                    )
                 self.session_context = SessionContext(
                     session_id=str(snapshot.get("session_id") or self.session_id),
                     user_id=str(snapshot.get("user_id") or ""),

--- a/tests/sagents/context/test_context_budget_config.py
+++ b/tests/sagents/context/test_context_budget_config.py
@@ -1,0 +1,107 @@
+import asyncio
+
+from sagents.context.messages.context_budget import ContextBudgetManager
+from sagents.context.session_context import SessionContext, SessionStatus
+from sagents.session_runtime import Session
+
+
+def test_overflow_budget_is_persisted_on_manager():
+    manager = ContextBudgetManager(
+        max_model_len=10,
+        history_ratio=0.2,
+        active_ratio=0.3,
+        max_new_message_ratio=0.5,
+    )
+
+    budget = manager.calculate_budget({"large_config": "x" * 200})
+
+    assert budget["active_budget"] == 0
+    assert manager.budget_info == budget
+
+
+def test_session_context_updates_reused_budget_config():
+    context = SessionContext(
+        session_id="s1",
+        user_id="u1",
+        agent_id="a1",
+        session_root_space="/tmp",
+        context_budget_config={"max_model_len": 40000},
+    )
+
+    context.update_context_budget_config({"max_model_len": 210000})
+
+    manager = context.message_manager.context_budget_manager
+    assert manager.max_model_len == 210000
+    assert manager.budget_info is None
+    assert context.context_budget_config["max_model_len"] == 210000
+
+
+def test_session_persisted_state_restores_context_budget_config(tmp_path):
+    context = SessionContext(
+        session_id="s1",
+        user_id="u1",
+        agent_id="a1",
+        session_root_space=str(tmp_path),
+        context_budget_config={"max_model_len": 210000},
+    )
+    context.session_workspace = str(tmp_path)
+    context.save(session_status=SessionStatus.COMPLETED)
+
+    session = Session(session_id="s1", enable_obs=False)
+    assert session.load_persisted_state(str(tmp_path)) is True
+
+    manager = session.session_context.message_manager.context_budget_manager
+    assert manager.max_model_len == 210000
+
+
+def test_reused_session_context_uses_model_config_max_model_len():
+    session = Session(session_id="s1", enable_obs=False)
+    session.model_config = {"max_model_len": 40000}
+    context = SessionContext(
+        session_id="s1",
+        user_id="u1",
+        agent_id="a1",
+        session_root_space="/tmp",
+        context_budget_config={"max_model_len": 40000},
+    )
+    context.sandbox = object()
+    session.session_context = context
+
+    session.model_config = {"max_model_len": 64000}
+    asyncio.run(session._ensure_session_context(
+        session_id="s1",
+        user_id="u1",
+        system_context=None,
+        context_budget_config=None,
+        tool_manager=None,
+        skill_manager=None,
+    ))
+
+    manager = session.session_context.message_manager.context_budget_manager
+    assert manager.max_model_len == 64000
+
+
+def test_reused_session_context_normalizes_camel_case_budget_config():
+    session = Session(session_id="s1", enable_obs=False)
+    session.model_config = {}
+    context = SessionContext(
+        session_id="s1",
+        user_id="u1",
+        agent_id="a1",
+        session_root_space="/tmp",
+        context_budget_config={"max_model_len": 40000},
+    )
+    context.sandbox = object()
+    session.session_context = context
+
+    asyncio.run(session._ensure_session_context(
+        session_id="s1",
+        user_id="u1",
+        system_context=None,
+        context_budget_config={"maxModelLen": 128000},
+        tool_manager=None,
+        skill_manager=None,
+    ))
+
+    manager = session.session_context.message_manager.context_budget_manager
+    assert manager.max_model_len == 128000

--- a/tests/sagents/tool/impl/test_memory_index_fts.py
+++ b/tests/sagents/tool/impl/test_memory_index_fts.py
@@ -6,6 +6,8 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import pytest
+
 
 def _load_memory_index_module():
     repo_root = Path(__file__).resolve().parents[4]
@@ -807,6 +809,7 @@ class TestMemoryIndexFTS(unittest.TestCase):
             self.assertEqual(len(results), 2)
             self.assertEqual(results[0].path, "/workspace/app/cli/memory_search.py")
 
+    @pytest.mark.timeout(120)
     def test_search_latency_stays_reasonable_on_moderate_synthetic_corpus(self):
         with TemporaryDirectory() as tmp_dir:
             index_path = Path(tmp_dir) / "memory_index.pkl"
@@ -985,6 +988,7 @@ class TestMemoryIndexFTS(unittest.TestCase):
             self.assertEqual(len(results), 2)
             self.assertEqual(results[0].path, "/workspace/app/cli/doctor_config.py")
 
+    @pytest.mark.timeout(120)
     def test_index_build_and_batch_search_latency_stay_reasonable(self):
         with TemporaryDirectory() as tmp_dir:
             index_path = Path(tmp_dir) / "memory_index.pkl"


### PR DESCRIPTION
## 概述

修复上下文预算配置在 session 复用、恢复以及切换模型时没有正确同步的问题，确保 `max_model_len` 等预算参数能够被持久化、恢复，并跟随当前模型配置更新。

## 主要改动

- 将有效的 `context_budget_config` 持久化到 `session_context.json`。
- 恢复历史 session 时读取并还原 `context_budget_config`。
- 兼容旧 session 数据：如果没有 `context_budget_config`，则从 `agent_config.llm_config.max_model_len` / `maxModelLen` 兜底恢复。
- 复用已有 `SessionContext` 时，更新最新的上下文预算配置。
- 当调用方没有显式传 `context_budget_config.max_model_len` 时，自动从当前 `model_config.max_model_len` 推导。
- 兼容 `maxModelLen` 驼峰字段，并统一归一化为 `max_model_len`。
- 上下文预算配置变更时，清空旧的 `budget_info` 缓存，避免继续使用过期预算。
- 修复 `SimpleAgent` 在 `budget_info is None` 时可能读取失败的问题。
- 修复 `ContextBudgetManager` 在 agent config 超长场景下没有保存 0 预算结果的问题。
- 新增上下文预算相关测试，覆盖溢出预算、session 复用、持久化恢复、模型切换、驼峰字段归一化等场景。
- 给部分耗时的 memory index FTS 性能测试增加 timeout 标记。

## 背景

之前复用或恢复 session 时，`MessageManager` 内部的上下文预算可能仍然使用旧配置。尤其是同一个 session 切换模型时，可能出现：

- 从大上下文模型切到小上下文模型后，仍按旧的大 `max_model_len` 计算预算，导致压缩不够积极。
- 从小上下文模型切到大上下文模型后，仍按旧的小预算计算，导致上下文窗口利用不足。

本次改动让上下文预算跟随 session 状态和当前模型配置保持一致。
