### PR TITLE
Fix tool schema required defaults

### DIFF
--- a/sagents/tool/mcp_tool_base.py
+++ b/sagents/tool/mcp_tool_base.py
@@ -180,8 +180,8 @@ def sage_mcp_tool(
             # Handle defaults
             if param.default == inspect.Parameter.empty:
                 required.append(param_name)
-            else:
-                pass
+            elif "default" not in param_info:
+                param_info["default"] = param.default
 
             parameters[param_name] = param_info
 

--- a/sagents/tool/tool_base.py
+++ b/sagents/tool/tool_base.py
@@ -124,6 +124,8 @@ def tool(
 
             if param.default == inspect.Parameter.empty:
                 required.append(name)
+            elif "default" not in param_info:
+                param_info["default"] = param.default
 
             parameters[name] = param_info
         _t_params_end = time.perf_counter() if _profile else None

--- a/sagents/tool/tool_schema.py
+++ b/sagents/tool/tool_schema.py
@@ -172,81 +172,20 @@ def convert_spec_to_openai_format(
         if isinstance(localized_returns.get("properties"), dict):
             _apply_prop_i18n(localized_returns["properties"], rdi_map)
 
-    # In strict mode, ALL properties must be in required, and every nested object
-    # must also have additionalProperties: false with a complete required array.
     # These top-level context fields are auto-injected and must not be exposed to the LLM.
     _AUTO_INJECT_PARAMS = {"session_id", "user_id"}
 
-    def _enforce_strict_schema(node: Any) -> None:
-        """Recursively enforce OpenAI strict-mode constraints on all nested object schemas.
-
-        Rules applied:
-        - oneOf / allOf → replaced with anyOf (strict mode only permits anyOf)
-        - Objects with properties: add additionalProperties=false; make ALL keys required;
-          optional properties (absent from original required) are wrapped as anyOf:[type, null]
-        - Bare objects (no properties): converted to string type with JSON-format hint
-        - Arrays: recurse into items
-        - anyOf members: recurse into each member
-        """
-        if not isinstance(node, dict):
-            return
-
-        # Replace forbidden combiners with anyOf
-        for forbidden in ("oneOf", "allOf"):
-            if forbidden in node:
-                node["anyOf"] = node.pop(forbidden)
-
-        if node.get("type") == "object":
-            if "properties" in node and isinstance(node["properties"], dict):
-                node["additionalProperties"] = False
-                original_required = set(node.get("required", []))
-                for prop_key, prop_node in node["properties"].items():
-                    _enforce_strict_schema(prop_node)
-                    if prop_key not in original_required:
-                        # Optional nested property: wrap as nullable
-                        desc = prop_node.pop("description", "")
-                        inner = dict(prop_node)
-                        prop_node.clear()
-                        prop_node["anyOf"] = [inner, {"type": "null"}]
-                        if desc:
-                            prop_node["description"] = desc
-                node["required"] = list(node["properties"].keys())
-            else:
-                # Free-form dict — not representable in strict mode; convert to string.
-                original_desc = node.get("description", "")
-                node.clear()
-                node["type"] = "string"
-                node["description"] = (
-                    (original_desc + " " if original_desc else "")
-                    + "(Pass as a JSON object string, e.g. '{\"key\": \"value\"}')"
-                ).strip()
-            return  # children already handled above
-
-        if node.get("type") == "array" and "items" in node:
-            _enforce_strict_schema(node["items"])
-
-        # Recurse into anyOf members (handles oneOf→anyOf converted nodes too)
-        if "anyOf" in node and isinstance(node["anyOf"], list):
-            for member in node["anyOf"]:
-                _enforce_strict_schema(member)
-
-    strictly_required = set(getattr(tool_spec, "required", []))
     schema_params = {k: v for k, v in localized_params.items() if k not in _AUTO_INJECT_PARAMS}
 
-    for key, param_node in schema_params.items():
-        _enforce_strict_schema(param_node)
-        if key not in strictly_required:
-            # Strict mode requires ALL properties in required.
-            # For optional params, wrap as anyOf: [type, null] so the LLM can pass null.
-            desc = param_node.pop("description", "")
-            inner = dict(param_node)
-            param_node.clear()
-            param_node["anyOf"] = [inner, {"type": "null"}]
-            if desc:
-                param_node["description"] = desc
+    def _has_default(schema: Any) -> bool:
+        return isinstance(schema, dict) and "default" in schema
 
-    # Now all schema_params are required (optional ones accept null).
-    schema_required = list(schema_params.keys())
+    raw_required = set(getattr(tool_spec, "required", []) or [])
+    schema_required = [
+        key
+        for key, schema in schema_params.items()
+        if key in raw_required or not _has_default(schema)
+    ]
 
     return {
         "type": "function",
@@ -259,7 +198,7 @@ def convert_spec_to_openai_format(
                 "required": schema_required,
                 "additionalProperties": False,
             },
-            "strict": True,
+            "strict": False,
             **({"returns": localized_returns} if localized_returns else {}),
         },
     }

--- a/tests/sagents/tool/test_mcp_tool_schema_display.py
+++ b/tests/sagents/tool/test_mcp_tool_schema_display.py
@@ -44,7 +44,7 @@ class TestMcpToolSchemaDisplay(unittest.TestCase):
         self.assertNotIn("anyOf", display_tool["parameters"]["count"])
         self.assertEqual(display_tool["input_schema"]["required"], ["query"])
 
-    def test_openai_schema_still_uses_strict_nullable_optional_params(self):
+    def test_openai_schema_uses_default_to_keep_params_optional(self):
         tm = ToolManager(is_auto_discover=False, isolated=True)
         tm.tools = {}
 
@@ -53,6 +53,9 @@ class TestMcpToolSchemaDisplay(unittest.TestCase):
             "properties": {
                 "query": {"type": "string"},
                 "count": {"type": "integer", "default": 10},
+                "source": {"type": "string"},
+                "session_id": {"type": "string"},
+                "user_id": {"type": "string"},
             },
             "required": ["query"],
         }
@@ -71,9 +74,11 @@ class TestMcpToolSchemaDisplay(unittest.TestCase):
 
         params = tm.get_openai_tools()[0]["function"]["parameters"]
 
-        self.assertEqual(set(params["required"]), {"query", "count"})
-        self.assertEqual(params["properties"]["count"]["anyOf"][0]["type"], "integer")
-        self.assertEqual(params["properties"]["count"]["anyOf"][1]["type"], "null")
+        self.assertEqual(set(params["properties"].keys()), {"query", "count", "source"})
+        self.assertEqual(set(params["required"]), {"query", "source"})
+        self.assertEqual(params["properties"]["count"]["type"], "integer")
+        self.assertNotIn("anyOf", params["properties"]["count"])
+        self.assertFalse(tm.get_openai_tools()[0]["function"]["strict"])
 
 
 if __name__ == "__main__":

--- a/tests/sagents/tool/test_tool_context_injection.py
+++ b/tests/sagents/tool/test_tool_context_injection.py
@@ -185,6 +185,52 @@ class TestToolContextInjection(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(set(params["properties"].keys()), {"foo"})
         self.assertEqual(params["required"], ["foo"])
 
+    def test_defaulted_params_are_optional_in_openai_schema(self):
+        tool = McpToolSpec(
+            name="remote_echo",
+            description="echo",
+            description_i18n={},
+            func=None,
+            parameters={
+                "foo": {"type": "string"},
+                "limit": {"type": "integer", "default": 5},
+                "format": {"type": "string"},
+            },
+            required=["foo"],
+            server_name="remote",
+            server_params=StreamableHttpServerParameters(url="http://example.invalid"),
+        )
+
+        openai_tool = convert_spec_to_openai_format(tool)
+        params = openai_tool["function"]["parameters"]
+
+        self.assertEqual(set(params["required"]), {"foo", "format"})
+        self.assertEqual(params["properties"]["limit"]["default"], 5)
+        self.assertNotIn("anyOf", params["properties"]["limit"])
+        self.assertFalse(openai_tool["function"]["strict"])
+
+    def test_internal_tool_schema_uses_same_default_rule(self):
+        tool = ToolSpec(
+            name="local_echo",
+            description="echo",
+            description_i18n={},
+            func=echo_kwargs,
+            parameters={
+                "foo": {"type": "string"},
+                "limit": {"type": "integer", "default": 5},
+                "format": {"type": "string"},
+                "session_id": {"type": "string"},
+            },
+            required=["foo"],
+        )
+
+        openai_tool = convert_spec_to_openai_format(tool)
+        params = openai_tool["function"]["parameters"]
+
+        self.assertEqual(set(params["properties"].keys()), {"foo", "limit", "format"})
+        self.assertEqual(set(params["required"]), {"foo", "format"})
+        self.assertFalse(openai_tool["function"]["strict"])
+
     async def test_tool_service_passes_user_id_to_tool_manager(self):
         fake_manager = type("FakeManager", (), {})()
         fake_manager.tools = {"basic_tool": object()}


### PR DESCRIPTION
## Summary
- make OpenAI tool schema required fields reflect explicit required plus fields without defaults
- hide auto-injected session_id/user_id from model-facing schemas
- preserve Python defaults in internal Sage and Sage MCP tool schemas
- stop forcing optional fields into nullable strict-required form

## Tests
- python -m pytest tests/sagents/tool/test_mcp_tool_schema_display.py tests/sagents/tool/test_tool_context_injection.py