### PR TITLE
Harden sandbox path guards

### DIFF
--- a/sagents/agent/self_check_agent.py
+++ b/sagents/agent/self_check_agent.py
@@ -76,6 +76,15 @@ class SelfCheckAgent(AgentBase):
                 )
                 continue
 
+            workspace_issue = self._validate_reference_in_workspace(
+                session_context,
+                normalized_path,
+                original_file_path=original_file_path,
+            )
+            if workspace_issue:
+                issues.append(workspace_issue)
+                continue
+
             file_path = normalized_path
             checked_files.append(file_path)
             file_issues = await self._validate_file(
@@ -101,9 +110,13 @@ class SelfCheckAgent(AgentBase):
                     role=MessageRole.ASSISTANT.value,
                     content=content,
                     message_id=str(uuid.uuid4()),
-                    message_type=MessageType.OBSERVATION.value,
+                    message_type=MessageType.AGENT_EXECUTION_ERROR.value,
                     agent_name=self.agent_name,
-                    metadata={"self_check_passed": False, "checked_files": checked_files},
+                    metadata={
+                        "self_check_passed": False,
+                        "checked_files": checked_files,
+                        "error_type": MessageType.AGENT_EXECUTION_ERROR.value,
+                    },
                 )
             ]
             return
@@ -216,6 +229,61 @@ class SelfCheckAgent(AgentBase):
 
     def _is_concrete_absolute_file_reference(self, file_path: str) -> bool:
         return os.path.isabs(file_path) and not self._is_ambiguous_root_file_reference(file_path)
+
+    def _validate_reference_in_workspace(
+        self,
+        session_context: SessionContext,
+        file_path: str,
+        original_file_path: Optional[str] = None,
+    ) -> Optional[str]:
+        sandbox = session_context.sandbox
+        if sandbox is not None and hasattr(sandbox, "is_path_allowed"):
+            try:
+                if sandbox.is_path_allowed(file_path, operation="read"):
+                    return None
+                return (
+                    "文件路径超出可访问工作区，不能作为最终产物引用: "
+                    f"{original_file_path or file_path}"
+                )
+            except Exception as e:
+                logger.warning(f"SelfCheckAgent: sandbox path permission check failed {file_path}: {e}")
+
+        allowed_roots = self._fallback_allowed_roots(session_context)
+        if not allowed_roots:
+            return None
+
+        normalized = os.path.realpath(os.path.abspath(file_path))
+        for root in allowed_roots:
+            try:
+                if os.path.commonpath([normalized, root]) == root:
+                    return None
+            except ValueError:
+                continue
+
+        return (
+            "文件路径超出可访问工作区，不能作为最终产物引用: "
+            f"{original_file_path or file_path}"
+        )
+
+    def _fallback_allowed_roots(self, session_context: SessionContext) -> List[str]:
+        roots: List[str] = []
+        candidates = [
+            getattr(session_context, "sandbox_agent_workspace", None),
+            (getattr(session_context, "system_context", {}) or {}).get("private_workspace"),
+        ]
+        external_paths = getattr(session_context, "external_paths", None)
+        if external_paths is None:
+            external_paths = (getattr(session_context, "system_context", {}) or {}).get("external_paths")
+        if isinstance(external_paths, str):
+            candidates.append(external_paths)
+        elif isinstance(external_paths, list):
+            candidates.extend(str(path) for path in external_paths if path)
+
+        for candidate in candidates:
+            if not candidate:
+                continue
+            roots.append(os.path.realpath(os.path.abspath(str(candidate))))
+        return sorted(set(roots))
 
     async def _validate_file(
         self,

--- a/sagents/utils/sandbox/providers/local/filesystem.py
+++ b/sagents/utils/sandbox/providers/local/filesystem.py
@@ -49,6 +49,11 @@ class SandboxFileSystem:
         host_first = [(host, virtual) for virtual, host in items]
         return sorted(host_first, key=lambda item: len(item[0]), reverse=True)
 
+    def add_mapping(self, virtual_path: str, host_path: str) -> None:
+        """Add or replace an extra virtual-to-host path mapping."""
+        normalized_virtual = virtual_path.rstrip(os.sep).rstrip("/") or os.sep
+        self._mappings[normalized_virtual] = os.path.abspath(host_path)
+
     def _normalize_input_path(self, path: str) -> str:
         """Normalize common local-path variants before mapping."""
         if not path:

--- a/sagents/utils/sandbox/providers/local/local.py
+++ b/sagents/utils/sandbox/providers/local/local.py
@@ -82,6 +82,71 @@ class LocalSandboxProvider(ISandboxHandle):
         # 不进 bwrap/seatbelt，方便长跑任务管理）
         self._bg_runner = HostBackgroundRunner()
 
+    def _allowed_path_roots(self) -> List[tuple[str, bool]]:
+        """Return allowed host roots as ``(path, read_only)`` pairs."""
+        roots: List[tuple[str, bool]] = []
+
+        if self._volume_mounts:
+            for mount in self._volume_mounts:
+                roots.append((
+                    os.path.realpath(os.path.abspath(mount.host_path)),
+                    bool(getattr(mount, "read_only", False)),
+                ))
+        elif self._file_system is not None:
+            roots.append((os.path.realpath(os.path.abspath(self._file_system.host_path)), False))
+        elif self._sandbox_agent_workspace:
+            roots.append((os.path.realpath(self._sandbox_agent_workspace), False))
+
+        # ``allowed_paths`` is kept for compatibility with callers that pass extra
+        # explicit roots outside VolumeMount, but it is not normally populated.
+        for path in self._allowed_paths or []:
+            roots.append((os.path.realpath(os.path.expanduser(path)), False))
+
+        deduped: Dict[str, bool] = {}
+        for root, read_only in roots:
+            if not root:
+                continue
+            deduped[root] = deduped.get(root, True) and read_only
+        return sorted(deduped.items(), key=lambda item: len(item[0]), reverse=True)
+
+    def _path_under_root(self, path: str, root: str) -> bool:
+        try:
+            return os.path.commonpath([path, root]) == root
+        except ValueError:
+            return False
+
+    def _validate_host_path_allowed(self, host_path: str, operation: str = "read") -> str:
+        """Ensure a resolved host path is inside the workspace or explicit mounts."""
+        actual = os.path.realpath(os.path.abspath(host_path))
+        write_operation = operation in {"write", "delete", "mkdir"}
+        for root, read_only in self._allowed_path_roots():
+            if self._path_under_root(actual, root):
+                if write_operation and read_only:
+                    raise PermissionError(f"Path is read-only in sandbox: {host_path}")
+                return actual
+
+        allowed = ", ".join(root for root, _ in self._allowed_path_roots()) or "<none>"
+        raise PermissionError(
+            f"Access denied: path outside sandbox workspace or mounted paths: {host_path}. "
+            f"Allowed roots: {allowed}"
+        )
+
+    def is_path_allowed(self, path: str, operation: str = "read") -> bool:
+        """Public containment check used by deterministic validators."""
+        if not path:
+            return False
+        if self._file_system is None:
+            # Best effort before initialization: validate against the configured
+            # workspace/mount roots without forcing async setup from sync callers.
+            host_path = path
+        else:
+            host_path = self.to_host_path(path)
+        try:
+            self._validate_host_path_allowed(host_path, operation=operation)
+            return True
+        except PermissionError:
+            return False
+
     async def _ensure_initialized(self):
         """确保沙箱已初始化"""
         if self._file_system is None:
@@ -299,8 +364,10 @@ class LocalSandboxProvider(ISandboxHandle):
 
     def add_mount(self, host_path: str, sandbox_path: str) -> None:
         """动态添加路径映射"""
+        mount = VolumeMount(host_path=host_path, mount_path=sandbox_path)
+        self._volume_mounts.append(mount)
         if self._file_system:
-            self._file_system.add_mapping(sandbox_path, host_path)
+            self._file_system.add_mapping(mount.mount_path, mount.host_path)
 
     def remove_mount(self, sandbox_path: str) -> None:
         """动态移除路径映射"""
@@ -333,7 +400,10 @@ class LocalSandboxProvider(ISandboxHandle):
         host_workdir = (
             self.to_host_path(workdir) if workdir else self.to_host_path(self._sandbox_agent_workspace)
         )
+        host_workdir = self._validate_host_path_allowed(host_workdir, operation="read")
         host_log_dir = self.to_host_path(log_dir) if log_dir else None
+        if host_log_dir:
+            host_log_dir = self._validate_host_path_allowed(host_log_dir, operation="write")
         return self._bg_runner.start(
             converted,
             workdir=host_workdir,
@@ -528,6 +598,7 @@ class LocalSandboxProvider(ISandboxHandle):
         actual_workdir = (
             self.to_host_path(workdir) if workdir else self.to_host_path(self._sandbox_agent_workspace)
         )
+        actual_workdir = self._validate_host_path_allowed(actual_workdir, operation="read")
 
         # 转换命令中的虚拟路径为宿主机路径
         converted_command = self._convert_paths_in_command(command)
@@ -734,6 +805,7 @@ class LocalSandboxProvider(ISandboxHandle):
         actual_workdir = (
             self.to_host_path(workdir) if workdir else self.to_host_path(self._sandbox_agent_workspace)
         )
+        actual_workdir = self._validate_host_path_allowed(actual_workdir, operation="read")
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
             f.write(code)
@@ -858,6 +930,7 @@ class LocalSandboxProvider(ISandboxHandle):
         """读取文件"""
         await self._ensure_initialized_async()
         actual_path = self.to_host_path(path)
+        actual_path = self._validate_host_path_allowed(actual_path, operation="read")
         return await asyncio.to_thread(self._read_file_sync, actual_path, encoding)
 
     async def write_file(
@@ -870,12 +943,14 @@ class LocalSandboxProvider(ISandboxHandle):
         """写入文件"""
         await self._ensure_initialized_async()
         actual_path = self.to_host_path(path)
+        actual_path = self._validate_host_path_allowed(actual_path, operation="write")
         await asyncio.to_thread(self._write_file_sync, actual_path, content, encoding, mode)
 
     async def file_exists(self, path: str) -> bool:
         """检查文件是否存在"""
         await self._ensure_initialized_async()
         actual_path = self.to_host_path(path)
+        actual_path = self._validate_host_path_allowed(actual_path, operation="read")
         return await asyncio.to_thread(os.path.exists, actual_path)
 
     async def get_mtime(self, path: str) -> float:
@@ -887,6 +962,7 @@ class LocalSandboxProvider(ISandboxHandle):
         """
         await self._ensure_initialized_async()
         actual_path = self.to_host_path(path)
+        actual_path = self._validate_host_path_allowed(actual_path, operation="read")
         try:
             if not await asyncio.to_thread(os.path.exists, actual_path):
                 return 0
@@ -903,18 +979,21 @@ class LocalSandboxProvider(ISandboxHandle):
         """列出目录内容"""
         await self._ensure_initialized_async()
         actual_path = self.to_host_path(path)
+        actual_path = self._validate_host_path_allowed(actual_path, operation="read")
         return await asyncio.to_thread(self._list_directory_sync, actual_path, include_hidden)
 
     async def ensure_directory(self, path: str) -> None:
         """确保目录存在"""
         await self._ensure_initialized_async()
         actual_path = self.to_host_path(path)
+        actual_path = self._validate_host_path_allowed(actual_path, operation="mkdir")
         await asyncio.to_thread(os.makedirs, actual_path, exist_ok=True)
 
     async def delete_file(self, path: str) -> None:
         """删除文件"""
         await self._ensure_initialized_async()
         actual_path = self.to_host_path(path)
+        actual_path = self._validate_host_path_allowed(actual_path, operation="delete")
         await asyncio.to_thread(self._delete_path_sync, actual_path)
 
     async def get_file_tree(
@@ -934,6 +1013,8 @@ class LocalSandboxProvider(ISandboxHandle):
         if self._file_system:
             # 转换虚拟路径为宿主机路径
             host_root_path = self.to_host_path(root_path) if root_path else None
+            if host_root_path:
+                host_root_path = self._validate_host_path_allowed(host_root_path, operation="read")
             return await self._file_system.get_file_tree_compact(
                 include_hidden=include_hidden,
                 root_path=host_root_path,
@@ -961,6 +1042,7 @@ class LocalSandboxProvider(ISandboxHandle):
         target_root = (
             self.to_host_path(root_path) if root_path else self.to_host_path(self._sandbox_agent_workspace)
         )
+        target_root = self._validate_host_path_allowed(target_root, operation="read")
         
         if not os.path.exists(target_root):
             return ""
@@ -1030,6 +1112,7 @@ class LocalSandboxProvider(ISandboxHandle):
         
         # 转换沙箱虚拟路径为宿主机路径
         host_dest_path = self.to_host_path(sandbox_dest_path)
+        host_dest_path = self._validate_host_path_allowed(host_dest_path, operation="write")
         
         try:
             copied = await asyncio.to_thread(

--- a/sagents/utils/sandbox/providers/passthrough/passthrough.py
+++ b/sagents/utils/sandbox/providers/passthrough/passthrough.py
@@ -56,6 +56,7 @@ class PassthroughSandboxProvider(ISandboxHandle):
         self._sandbox_id = sandbox_id
         self._sandbox_agent_workspace = sandbox_agent_workspace
         self._volume_mounts = volume_mounts or []
+        self._allowed_paths: List[str] = []
 
         # 路径映射表，支持动态修改
         self._dynamic_mounts: Dict[str, str] = {}
@@ -109,6 +110,59 @@ class PassthroughSandboxProvider(ISandboxHandle):
         mappings = self._iter_virtual_mappings()
         host_first = [(host, virtual) for virtual, host in mappings]
         return sorted(host_first, key=lambda item: len(item[0]), reverse=True)
+
+    def _allowed_path_roots(self) -> List[tuple[str, bool]]:
+        roots: List[tuple[str, bool]] = []
+        if self._dynamic_mounts:
+            volume_read_only = {
+                os.path.realpath(os.path.abspath(mount.host_path)): bool(getattr(mount, "read_only", False))
+                for mount in self._volume_mounts
+            }
+            for host_path in self._dynamic_mounts.values():
+                root = os.path.realpath(os.path.abspath(host_path))
+                roots.append((root, volume_read_only.get(root, False)))
+        elif self._sandbox_agent_workspace:
+            roots.append((os.path.realpath(os.path.abspath(self._sandbox_agent_workspace)), False))
+
+        for path in self._allowed_paths:
+            roots.append((os.path.realpath(os.path.abspath(os.path.expanduser(path))), False))
+
+        deduped: Dict[str, bool] = {}
+        for root, read_only in roots:
+            if not root:
+                continue
+            deduped[root] = deduped.get(root, True) and read_only
+        return sorted(deduped.items(), key=lambda item: len(item[0]), reverse=True)
+
+    def _path_under_root(self, path: str, root: str) -> bool:
+        try:
+            return os.path.commonpath([path, root]) == root
+        except ValueError:
+            return False
+
+    def _validate_host_path_allowed(self, host_path: str, operation: str = "read") -> str:
+        actual = os.path.realpath(os.path.abspath(host_path))
+        write_operation = operation in {"write", "delete", "mkdir"}
+        for root, read_only in self._allowed_path_roots():
+            if self._path_under_root(actual, root):
+                if write_operation and read_only:
+                    raise PermissionError(f"Path is read-only in passthrough sandbox: {host_path}")
+                return actual
+
+        allowed = ", ".join(root for root, _ in self._allowed_path_roots()) or "<none>"
+        raise PermissionError(
+            f"Access denied: path outside sandbox workspace or mounted paths: {host_path}. "
+            f"Allowed roots: {allowed}"
+        )
+
+    def is_path_allowed(self, path: str, operation: str = "read") -> bool:
+        if not path:
+            return False
+        try:
+            self._validate_host_path_allowed(self.to_host_path(path), operation=operation)
+            return True
+        except PermissionError:
+            return False
 
     def remove_mount(self, sandbox_path: str) -> None:
         """动态移除路径映射"""
@@ -199,7 +253,10 @@ class PassthroughSandboxProvider(ISandboxHandle):
         host_workdir = self.to_host_path(workdir) if workdir else self.to_host_path(
             self._sandbox_agent_workspace
         )
+        host_workdir = self._validate_host_path_allowed(host_workdir, operation="read")
         host_log_dir = self.to_host_path(log_dir) if log_dir else None
+        if host_log_dir:
+            host_log_dir = self._validate_host_path_allowed(host_log_dir, operation="write")
         return self._bg_runner.start(
             converted,
             workdir=host_workdir,
@@ -231,19 +288,18 @@ class PassthroughSandboxProvider(ISandboxHandle):
         self._bg_runner.cleanup(task_id)
 
     def add_allowed_paths(self, paths: List[str]) -> None:
-        """添加允许访问的路径列表 - 直通模式无限制，空实现"""
-        # 直通模式没有访问限制，不需要实现
-        pass
+        """添加允许访问的路径列表"""
+        for path in paths:
+            if path not in self._allowed_paths:
+                self._allowed_paths.append(path)
 
     def remove_allowed_paths(self, paths: List[str]) -> None:
-        """移除允许访问的路径列表 - 直通模式无限制，空实现"""
-        # 直通模式没有访问限制，不需要实现
-        pass
+        """移除允许访问的路径列表"""
+        self._allowed_paths = [path for path in self._allowed_paths if path not in paths]
 
     def get_allowed_paths(self) -> List[str]:
-        """获取当前允许访问的路径列表 - 直通模式返回空列表"""
-        # 直通模式没有访问限制，返回空列表
-        return []
+        """获取当前允许访问的路径列表"""
+        return list(self._allowed_paths)
 
     def _convert_paths_in_command(self, command: str) -> str:
         """Convert virtual paths to host paths in command string
@@ -346,6 +402,7 @@ class PassthroughSandboxProvider(ISandboxHandle):
             cwd = self.to_host_path(workdir)
         else:
             cwd = self.to_host_path(self._sandbox_agent_workspace)
+        cwd = self._validate_host_path_allowed(cwd, operation="read")
 
         # 为 npm/npx 配置项目级缓存，避免写入用户主目录 ~/.npm 导致权限问题
         npm_cache_dir = os.path.join(os.path.expanduser("~"), ".sage", ".npm-cache")
@@ -452,6 +509,7 @@ class PassthroughSandboxProvider(ISandboxHandle):
     async def read_file(self, path: str, encoding: str = "utf-8") -> str:
         """读取文件"""
         host_path = self.to_host_path(path)
+        host_path = self._validate_host_path_allowed(host_path, operation="read")
         return await asyncio.to_thread(self._read_file_sync, host_path, encoding)
 
     async def write_file(
@@ -463,16 +521,19 @@ class PassthroughSandboxProvider(ISandboxHandle):
     ) -> None:
         """写入文件"""
         host_path = self.to_host_path(path)
+        host_path = self._validate_host_path_allowed(host_path, operation="write")
         await asyncio.to_thread(self._write_file_sync, host_path, content, encoding, mode)
 
     async def file_exists(self, path: str) -> bool:
         """检查文件是否存在"""
         host_path = self.to_host_path(path)
+        host_path = self._validate_host_path_allowed(host_path, operation="read")
         return await asyncio.to_thread(os.path.exists, host_path)
 
     async def get_mtime(self, path: str) -> float:
         """直通模式直接读取宿主机 mtime。"""
         host_path = self.to_host_path(path)
+        host_path = self._validate_host_path_allowed(host_path, operation="read")
         try:
             if not await asyncio.to_thread(os.path.exists, host_path):
                 return 0
@@ -484,16 +545,19 @@ class PassthroughSandboxProvider(ISandboxHandle):
     async def list_directory(self, path: str, include_hidden: bool = False) -> List[FileInfo]:
         """列出目录内容"""
         host_path = self.to_host_path(path)
+        host_path = self._validate_host_path_allowed(host_path, operation="read")
         return await asyncio.to_thread(self._list_directory_sync, host_path, include_hidden)
 
     async def ensure_directory(self, path: str) -> None:
         """确保目录存在"""
         host_path = self.to_host_path(path)
+        host_path = self._validate_host_path_allowed(host_path, operation="mkdir")
         await asyncio.to_thread(os.makedirs, host_path, exist_ok=True)
 
     async def get_file_info(self, path: str) -> Optional[FileInfo]:
         """获取文件信息"""
         host_path = self.to_host_path(path)
+        host_path = self._validate_host_path_allowed(host_path, operation="read")
         if not await asyncio.to_thread(os.path.exists, host_path):
             return None
         stat = await asyncio.to_thread(os.stat, host_path)
@@ -508,11 +572,13 @@ class PassthroughSandboxProvider(ISandboxHandle):
     async def delete_file(self, path: str) -> None:
         """删除文件"""
         host_path = self.to_host_path(path)
+        host_path = self._validate_host_path_allowed(host_path, operation="delete")
         await asyncio.to_thread(self._delete_path_sync, host_path)
 
     async def copy_from_host(self, host_path: str, sandbox_path: str) -> None:
         """从宿主机复制文件到沙箱"""
         target_path = self.to_host_path(sandbox_path)
+        target_path = self._validate_host_path_allowed(target_path, operation="write")
         await asyncio.to_thread(self._copy_from_host_sync, host_path, target_path)
 
     async def execute_python(
@@ -532,6 +598,7 @@ class PassthroughSandboxProvider(ISandboxHandle):
         actual_workdir = (
             self.to_host_path(workdir) if workdir else self.to_host_path(self._sandbox_agent_workspace)
         )
+        actual_workdir = self._validate_host_path_allowed(actual_workdir, operation="read")
 
         # 创建临时文件存储代码
         with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
@@ -599,6 +666,7 @@ class PassthroughSandboxProvider(ISandboxHandle):
         actual_workdir = (
             self.to_host_path(workdir) if workdir else self.to_host_path(self._sandbox_agent_workspace)
         )
+        actual_workdir = self._validate_host_path_allowed(actual_workdir, operation="read")
 
         # 检查是否有 node 环境
         try:
@@ -663,6 +731,7 @@ class PassthroughSandboxProvider(ISandboxHandle):
             target_path = self.to_host_path(root_path)
         else:
             target_path = self._sandbox_agent_workspace
+        target_path = self._validate_host_path_allowed(target_path, operation="read")
 
         if not os.path.exists(target_path):
             return ""

--- a/tests/sagents/test_self_check_agent_paths.py
+++ b/tests/sagents/test_self_check_agent_paths.py
@@ -30,6 +30,7 @@ def _load_self_check_agent(monkeypatch):
 
     class MessageType:
         OBSERVATION = _EnumValue("observation")
+        AGENT_EXECUTION_ERROR = _EnumValue("agent_execution_error")
 
     class MessageChunk:
         def __init__(self, **kwargs):
@@ -131,6 +132,7 @@ def test_non_absolute_markdown_link_returns_guidance(monkeypatch):
     assert session_context.audit_status["self_check_passed"] is False
     assert "必须使用绝对路径 Markdown 链接" in chunks[0].content
     assert "`README.md`" in chunks[0].content
+    assert chunks[0].message_type == "agent_execution_error"
 
 
 def test_absolute_markdown_link_checks_file_existence(monkeypatch):
@@ -162,3 +164,48 @@ def test_absolute_markdown_link_checks_file_existence(monkeypatch):
 
     assert session_context.audit_status["self_check_passed"] is False
     assert "文件不存在: /tmp/project/README.md" in chunks[0].content
+    assert chunks[0].message_type == "agent_execution_error"
+
+
+def test_absolute_markdown_link_outside_workspace_is_execution_error(monkeypatch, tmp_path):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+
+    workspace = tmp_path / "agents" / "user_1" / "agent_1"
+    outside = tmp_path / "agents" / "user_1" / "reports" / "out.md"
+
+    class DummySandbox:
+        def is_path_allowed(self, path, operation="read"):
+            return str(path).startswith(str(workspace))
+
+        async def file_exists(self, path):
+            return True
+
+        async def read_file(self, path, encoding="utf-8"):
+            return ""
+
+    session_context = SimpleNamespace(
+        audit_status={},
+        sandbox=DummySandbox(),
+        sandbox_agent_workspace=str(workspace),
+        system_context={"private_workspace": str(workspace)},
+        message_manager=SimpleNamespace(
+            messages=[
+                _make_message("user", "请生成结果"),
+                _make_message("assistant", f"[out.md](file://{outside})"),
+            ]
+        ),
+    )
+
+    async def collect():
+        chunks = []
+        async for batch in agent.run_stream(session_context):
+            chunks.extend(batch)
+        return chunks
+
+    chunks = asyncio.run(collect())
+
+    assert session_context.audit_status["self_check_passed"] is False
+    assert "文件路径超出可访问工作区" in chunks[0].content
+    assert str(outside) in chunks[0].content
+    assert chunks[0].message_type == "agent_execution_error"

--- a/tests/sagents/utils/sandbox/test_local_provider_path_permissions.py
+++ b/tests/sagents/utils/sandbox/test_local_provider_path_permissions.py
@@ -1,0 +1,96 @@
+import asyncio
+
+import pytest
+
+from sagents.utils.sandbox.config import VolumeMount
+from sagents.utils.sandbox.providers.local.local import LocalSandboxProvider
+
+
+def test_local_provider_rejects_file_write_outside_workspace(tmp_path):
+    workspace = tmp_path / "agents" / "user_1" / "agent_1"
+    workspace.mkdir(parents=True)
+    outside = tmp_path / "agents" / "user_1" / "reports" / "out.md"
+
+    provider = LocalSandboxProvider(
+        sandbox_id="test",
+        sandbox_agent_workspace=str(workspace),
+        volume_mounts=[VolumeMount(str(workspace), str(workspace))],
+        macos_isolation_mode="subprocess",
+        linux_isolation_mode="subprocess",
+    )
+
+    with pytest.raises(PermissionError, match="outside sandbox workspace"):
+        asyncio.run(provider.write_file(str(outside), "nope"))
+
+    assert not outside.exists()
+
+
+def test_local_provider_allows_workspace_and_explicit_mount(tmp_path):
+    workspace = tmp_path / "agents" / "user_1" / "agent_1"
+    external = tmp_path / "external"
+    workspace.mkdir(parents=True)
+    external.mkdir()
+
+    provider = LocalSandboxProvider(
+        sandbox_id="test",
+        sandbox_agent_workspace=str(workspace),
+        volume_mounts=[
+            VolumeMount(str(workspace), str(workspace)),
+            VolumeMount(str(external), str(external)),
+        ],
+        macos_isolation_mode="subprocess",
+        linux_isolation_mode="subprocess",
+    )
+
+    workspace_file = workspace / "data" / "ok.md"
+    external_file = external / "ok.md"
+
+    asyncio.run(provider.write_file(str(workspace_file), "workspace"))
+    asyncio.run(provider.write_file(str(external_file), "external"))
+
+    assert workspace_file.read_text() == "workspace"
+    assert external_file.read_text() == "external"
+
+
+def test_local_provider_allows_dynamic_mount_after_initialize(tmp_path):
+    workspace = tmp_path / "workspace"
+    external = tmp_path / "external"
+    workspace.mkdir()
+    external.mkdir()
+
+    provider = LocalSandboxProvider(
+        sandbox_id="test",
+        sandbox_agent_workspace=str(workspace),
+        volume_mounts=[VolumeMount(str(workspace), str(workspace))],
+        macos_isolation_mode="subprocess",
+        linux_isolation_mode="subprocess",
+    )
+
+    asyncio.run(provider.initialize())
+    provider.add_mount(str(external), str(external))
+
+    mounted_file = external / "ok.md"
+    asyncio.run(provider.write_file(str(mounted_file), "mounted"))
+
+    assert mounted_file.read_text() == "mounted"
+
+
+def test_local_provider_rejects_write_to_read_only_mount(tmp_path):
+    workspace = tmp_path / "workspace"
+    readonly = workspace / "readonly"
+    workspace.mkdir()
+    readonly.mkdir()
+
+    provider = LocalSandboxProvider(
+        sandbox_id="test",
+        sandbox_agent_workspace=str(workspace),
+        volume_mounts=[
+            VolumeMount(str(workspace), str(workspace)),
+            VolumeMount(str(readonly), str(readonly), read_only=True),
+        ],
+        macos_isolation_mode="subprocess",
+        linux_isolation_mode="subprocess",
+    )
+
+    with pytest.raises(PermissionError, match="read-only"):
+        asyncio.run(provider.write_file(str(readonly / "blocked.md"), "blocked"))

--- a/tests/sagents/utils/sandbox/test_passthrough_provider_path_permissions.py
+++ b/tests/sagents/utils/sandbox/test_passthrough_provider_path_permissions.py
@@ -1,0 +1,67 @@
+import asyncio
+
+import pytest
+
+from sagents.utils.sandbox.config import VolumeMount
+from sagents.utils.sandbox.providers.passthrough.passthrough import PassthroughSandboxProvider
+
+
+def test_passthrough_provider_rejects_file_write_outside_workspace(tmp_path):
+    workspace = tmp_path / "agents" / "user_1" / "agent_1"
+    workspace.mkdir(parents=True)
+    outside = tmp_path / "agents" / "user_1" / "reports" / "out.md"
+
+    provider = PassthroughSandboxProvider(
+        sandbox_id="test",
+        sandbox_agent_workspace=str(workspace),
+        volume_mounts=[VolumeMount(str(workspace), str(workspace))],
+    )
+
+    with pytest.raises(PermissionError, match="outside sandbox workspace"):
+        asyncio.run(provider.write_file(str(outside), "nope"))
+
+    assert not outside.exists()
+
+
+def test_passthrough_provider_allows_workspace_and_explicit_mount(tmp_path):
+    workspace = tmp_path / "agents" / "user_1" / "agent_1"
+    external = tmp_path / "external"
+    workspace.mkdir(parents=True)
+    external.mkdir()
+
+    provider = PassthroughSandboxProvider(
+        sandbox_id="test",
+        sandbox_agent_workspace=str(workspace),
+        volume_mounts=[
+            VolumeMount(str(workspace), str(workspace)),
+            VolumeMount(str(external), str(external)),
+        ],
+    )
+
+    workspace_file = workspace / "data" / "ok.md"
+    external_file = external / "ok.md"
+
+    asyncio.run(provider.write_file(str(workspace_file), "workspace"))
+    asyncio.run(provider.write_file(str(external_file), "external"))
+
+    assert workspace_file.read_text() == "workspace"
+    assert external_file.read_text() == "external"
+
+
+def test_passthrough_provider_rejects_write_to_read_only_mount(tmp_path):
+    workspace = tmp_path / "workspace"
+    readonly = workspace / "readonly"
+    workspace.mkdir()
+    readonly.mkdir()
+
+    provider = PassthroughSandboxProvider(
+        sandbox_id="test",
+        sandbox_agent_workspace=str(workspace),
+        volume_mounts=[
+            VolumeMount(str(workspace), str(workspace)),
+            VolumeMount(str(readonly), str(readonly), read_only=True),
+        ],
+    )
+
+    with pytest.raises(PermissionError, match="read-only"):
+        asyncio.run(provider.write_file(str(readonly / "blocked.md"), "blocked"))


### PR DESCRIPTION
## Summary
- enforce allowed-root checks for local and passthrough sandbox file operations
- add self-check validation for final artifact paths outside the workspace
- emit self-check failures as agent_execution_error messages
- add regression coverage for workspace, external mount, dynamic mount, and read-only mount behavior

## Testing
- python -m pytest tests/sagents/test_self_check_agent_paths.py tests/sagents/utils/sandbox/test_local_provider_path_permissions.py tests/sagents/utils/sandbox/test_passthrough_provider_path_permissions.py tests/sagents/tool/impl/test_execute_command_tool.py
- python -m compileall -q sagents/agent/self_check_agent.py sagents/utils/sandbox/providers/local/filesystem.py sagents/utils/sandbox/providers/local/local.py sagents/utils/sandbox/providers/passthrough/passthrough.py
- git diff --check

## Notes
- Shell/code execution tools can still write outside allowed roots when running without OS-level isolation; this PR hardens the sandbox file API path, not arbitrary host subprocess writes.