### PR TITLE
Add depth controls for agent workspace listing

### DIFF
--- a/app/desktop/core/routers/agent.py
+++ b/app/desktop/core/routers/agent.py
@@ -7,7 +7,7 @@ import re
 from typing import Any, Dict, List, Optional
 from pathlib import Path
 
-from fastapi import APIRouter, Request, UploadFile, File
+from fastapi import APIRouter, File, Request, UploadFile
 from fastapi.responses import FileResponse, StreamingResponse
 from loguru import logger
 import shutil
@@ -427,7 +427,12 @@ async def optimize(request: SystemPromptOptimizeRequest, http_request: Request):
 
 
 @agent_router.post("/{agent_id}/file_workspace")
-async def get_workspace(agent_id: str, request: Request):
+async def get_workspace(
+    agent_id: str,
+    request: Request,
+    path: Optional[str] = None,
+    max_depth: Optional[int] = None,
+):
     """获取指定Agent的文件工作空间"""
     user_home = Path.home()
     sage_home = user_home / ".sage"
@@ -435,7 +440,11 @@ async def get_workspace(agent_id: str, request: Request):
     logger.info(f"获取Agent {agent_id} 的工作空间路径：{workspace_path}")
     result = await agent_router_service.build_workspace_listing_response(
         agent_id=agent_id,
-        fetcher=lambda: agent_service.get_desktop_file_workspace(agent_id),
+        fetcher=lambda: agent_service.get_desktop_file_workspace(
+            agent_id,
+            path=path,
+            max_depth=max_depth,
+        ),
     )
     return await Response.succ(message=result["message"], data=result["data"])
 

--- a/app/server/routers/agent.py
+++ b/app/server/routers/agent.py
@@ -295,7 +295,13 @@ async def update_auth(agent_id: str, req: AuthorizationRequest, http_request: Re
     return await Response.succ(data={}, message="更新授权成功")
 
 @agent_router.post("/{agent_id}/file_workspace")
-async def get_workspace(agent_id: str, request: Request, session_id: Optional[str] = None):
+async def get_workspace(
+    agent_id: str,
+    request: Request,
+    session_id: Optional[str] = None,
+    path: Optional[str] = None,
+    max_depth: Optional[int] = None,
+):
     """获取指定会话的文件工作空间"""
     user_id = get_request_user_id(request)
     role = get_request_role(request)
@@ -309,7 +315,12 @@ async def get_workspace(agent_id: str, request: Request, session_id: Optional[st
     result = await agent_router_service.build_workspace_listing_response(
         agent_id=agent_id,
         user_id=user_id,
-        fetcher=lambda: agent_service.get_server_file_workspace(agent_id, user_id),
+        fetcher=lambda: agent_service.get_server_file_workspace(
+            agent_id,
+            user_id,
+            path=path,
+            max_depth=max_depth,
+        ),
     )
     files = result["data"].get("files", [])
     logger.bind(agent_id=agent_id).info(f"获取工作空间文件数量：{len(files)}")

--- a/common/services/agent_service.py
+++ b/common/services/agent_service.py
@@ -1098,11 +1098,19 @@ def get_desktop_agent_workspace_path(agent_id: str) -> Path:
     )
 
 
-async def get_server_file_workspace(agent_id: str, user_id: str) -> Dict[str, Any]:
+async def get_server_file_workspace(
+    agent_id: str,
+    user_id: str,
+    *,
+    path: Optional[str] = None,
+    max_depth: Optional[int] = None,
+) -> Dict[str, Any]:
     return await asyncio.to_thread(
         list_workspace_files,
         get_server_agent_workspace_path(agent_id, user_id),
         agent_id,
+        path,
+        max_depth,
     )
 
 
@@ -1136,11 +1144,18 @@ async def delete_server_agent_workspace(agent_id: str, user_id: str) -> Dict[str
     )
 
 
-async def get_desktop_file_workspace(agent_id: str) -> Dict[str, Any]:
+async def get_desktop_file_workspace(
+    agent_id: str,
+    *,
+    path: Optional[str] = None,
+    max_depth: Optional[int] = None,
+) -> Dict[str, Any]:
     return await asyncio.to_thread(
         list_workspace_files,
         get_desktop_agent_workspace_path(agent_id),
         agent_id,
+        path,
+        max_depth,
     )
 
 
@@ -1263,23 +1278,101 @@ def resolve_workspace_file_path(workspace_path: str | Path, file_path: str) -> s
     return full_file_abs
 
 
-def list_workspace_files(workspace_path: str | Path, agent_id: str) -> Dict[str, Any]:
+def _resolve_workspace_listing_path(
+    workspace_path: str | Path,
+    path: Optional[str],
+) -> Tuple[str, str]:
     workspace_str = os.fspath(workspace_path)
+    workspace_abs = os.path.normcase(os.path.abspath(workspace_str))
+    normalized_path = os.fspath(path or "").strip()
+
+    if os.path.isabs(normalized_path):
+        raise SageHTTPException(
+            detail="访问被拒绝：文件路径超出工作空间范围",
+            error_detail="Access denied: file path outside workspace",
+        )
+
+    listing_path = os.path.normpath(normalized_path) if normalized_path else ""
+    if listing_path == ".":
+        listing_path = ""
+
+    full_path = os.path.join(workspace_str, listing_path) if listing_path else workspace_str
+    full_path_abs = os.path.normcase(os.path.abspath(full_path))
+
+    try:
+        in_workspace = os.path.commonpath([workspace_abs, full_path_abs]) == workspace_abs
+    except ValueError:
+        in_workspace = False
+
+    if not in_workspace:
+        raise SageHTTPException(
+            detail="访问被拒绝：文件路径超出工作空间范围",
+            error_detail="Access denied: file path outside workspace",
+        )
+
+    return full_path_abs, listing_path
+
+
+def list_workspace_files(
+    workspace_path: str | Path,
+    agent_id: str,
+    path: Optional[str] = None,
+    max_depth: Optional[int] = None,
+) -> Dict[str, Any]:
+    workspace_str = os.fspath(workspace_path)
+    if max_depth is not None and max_depth < 0:
+        raise SageHTTPException(
+            detail="max_depth 必须大于等于 0",
+            error_detail="max_depth must be greater than or equal to 0",
+        )
+
+    listing_root = ""
+    listing_path = os.fspath(path or "").strip()
+    if workspace_str:
+        listing_root, listing_path = _resolve_workspace_listing_path(workspace_str, path)
+
     if not workspace_str or not os.path.exists(workspace_str):
         return {
             "agent_id": agent_id,
             "files": [],
+            "workspace_path": workspace_str,
+            "path": listing_path,
+            "max_depth": max_depth,
+            "truncated_by_depth": False,
             "message": "工作空间为空",
         }
 
+    if not os.path.exists(listing_root):
+        return {
+            "agent_id": agent_id,
+            "files": [],
+            "workspace_path": workspace_str,
+            "path": listing_path,
+            "max_depth": max_depth,
+            "truncated_by_depth": False,
+            "message": "工作空间为空",
+        }
+
+    if not os.path.isdir(listing_root):
+        raise SageHTTPException(
+            detail=f"路径不是目录: {listing_path or '.'}",
+            error_detail=f"Path is not a directory: {listing_path or '.'}",
+        )
+
+    workspace_abs = os.path.abspath(workspace_str)
     files: List[Dict[str, Any]] = []
-    for root, dirs, filenames in os.walk(workspace_str):
+    truncated_by_depth = False
+    for root, dirs, filenames in os.walk(listing_root):
         dirs[:] = [d for d in dirs if not d.startswith(".")]
         filenames = [f for f in filenames if not f.startswith(".")]
+        current_relative = os.path.relpath(root, listing_root)
+        current_depth = (
+            0 if current_relative == "." else len(Path(current_relative).parts)
+        )
 
         for filename in filenames:
             file_path = os.path.join(root, filename)
-            relative_path = os.path.relpath(file_path, workspace_str)
+            relative_path = os.path.relpath(file_path, workspace_abs)
             file_stat = os.stat(file_path)
             files.append(
                 {
@@ -1293,7 +1386,7 @@ def list_workspace_files(workspace_path: str | Path, agent_id: str) -> Dict[str,
 
         for dirname in dirs:
             dir_path = os.path.join(root, dirname)
-            relative_path = os.path.relpath(dir_path, workspace_str)
+            relative_path = os.path.relpath(dir_path, workspace_abs)
             files.append(
                 {
                     "name": dirname,
@@ -1304,10 +1397,19 @@ def list_workspace_files(workspace_path: str | Path, agent_id: str) -> Dict[str,
                 }
             )
 
+        if max_depth is not None and current_depth >= max_depth:
+            if dirs:
+                truncated_by_depth = True
+            dirs[:] = []
+
     logger.info(f"获取工作空间文件数量：{len(files)}")
     return {
         "agent_id": agent_id,
         "files": files,
+        "workspace_path": workspace_str,
+        "path": listing_path,
+        "max_depth": max_depth,
+        "truncated_by_depth": truncated_by_depth,
         "message": "获取文件列表成功",
     }
 

--- a/tests/common/services/test_agent_service_workspace_listing.py
+++ b/tests/common/services/test_agent_service_workspace_listing.py
@@ -1,0 +1,153 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+from starlette.requests import Request
+
+from app.desktop.core.routers import agent as desktop_agent_router
+from app.server.routers import agent as server_agent_router
+from common.core.exceptions import SageHTTPException
+from common.services import agent_service
+
+
+def _names(result):
+    return {item["path"] for item in result["files"]}
+
+
+def _build_workspace(tmp_path: Path) -> Path:
+    workspace = tmp_path / "workspace"
+    (workspace / "dir_a" / "dir_b").mkdir(parents=True)
+    (workspace / "root.txt").write_text("root", encoding="utf-8")
+    (workspace / "dir_a" / "a.txt").write_text("a", encoding="utf-8")
+    (workspace / "dir_a" / "dir_b" / "b.txt").write_text("b", encoding="utf-8")
+    (workspace / ".hidden_file").write_text("hidden", encoding="utf-8")
+    (workspace / ".hidden_dir").mkdir()
+    (workspace / ".hidden_dir" / "secret.txt").write_text("secret", encoding="utf-8")
+    return workspace
+
+
+def _fake_request(user_id: str = "user_a", role: str = "user") -> Request:
+    request = Request({"type": "http", "method": "POST", "path": "/", "headers": []})
+    request.state.user_claims = {"userid": user_id, "role": role}
+    return request
+
+
+def test_list_workspace_files_defaults_to_full_recursive_listing(tmp_path):
+    workspace = _build_workspace(tmp_path)
+
+    result = agent_service.list_workspace_files(workspace, "agent_demo")
+
+    assert _names(result) == {
+        "root.txt",
+        "dir_a",
+        "dir_a/a.txt",
+        "dir_a/dir_b",
+        "dir_a/dir_b/b.txt",
+    }
+    assert result["path"] == ""
+    assert result["max_depth"] is None
+    assert result["truncated_by_depth"] is False
+
+
+def test_list_workspace_files_max_depth_zero_returns_direct_children(tmp_path):
+    workspace = _build_workspace(tmp_path)
+
+    result = agent_service.list_workspace_files(workspace, "agent_demo", max_depth=0)
+
+    assert _names(result) == {"root.txt", "dir_a"}
+    assert result["max_depth"] == 0
+    assert result["truncated_by_depth"] is True
+
+
+def test_list_workspace_files_subdir_depth_zero_uses_workspace_relative_paths(tmp_path):
+    workspace = _build_workspace(tmp_path)
+
+    result = agent_service.list_workspace_files(
+        workspace,
+        "agent_demo",
+        path="dir_a",
+        max_depth=0,
+    )
+
+    assert _names(result) == {"dir_a/a.txt", "dir_a/dir_b"}
+    assert result["path"] == "dir_a"
+    assert result["max_depth"] == 0
+    assert result["truncated_by_depth"] is True
+
+
+@pytest.mark.parametrize("unsafe_path", ["../outside", "/tmp/outside"])
+def test_list_workspace_files_rejects_paths_outside_workspace(tmp_path, unsafe_path):
+    workspace = _build_workspace(tmp_path)
+
+    with pytest.raises(SageHTTPException):
+        agent_service.list_workspace_files(workspace, "agent_demo", path=unsafe_path)
+
+
+def test_server_workspace_route_passes_listing_depth_params(monkeypatch):
+    calls = {}
+
+    async def fake_get_server_file_workspace(
+        agent_id,
+        user_id,
+        *,
+        path=None,
+        max_depth=None,
+    ):
+        calls.update(
+            {
+                "agent_id": agent_id,
+                "user_id": user_id,
+                "path": path,
+                "max_depth": max_depth,
+            }
+        )
+        return {"agent_id": agent_id, "files": [], "message": "ok"}
+
+    monkeypatch.setattr(
+        server_agent_router.agent_service,
+        "get_server_file_workspace",
+        fake_get_server_file_workspace,
+    )
+
+    response = asyncio.run(
+        server_agent_router.get_workspace(
+            "agent_demo",
+            _fake_request(),
+            path="dir_a",
+            max_depth=0,
+        )
+    )
+
+    assert response.message == "ok"
+    assert calls == {
+        "agent_id": "agent_demo",
+        "user_id": "user_a",
+        "path": "dir_a",
+        "max_depth": 0,
+    }
+
+
+def test_desktop_workspace_route_passes_listing_depth_params(monkeypatch):
+    calls = {}
+
+    async def fake_get_desktop_file_workspace(agent_id, *, path=None, max_depth=None):
+        calls.update({"agent_id": agent_id, "path": path, "max_depth": max_depth})
+        return {"agent_id": agent_id, "files": [], "message": "ok"}
+
+    monkeypatch.setattr(
+        desktop_agent_router.agent_service,
+        "get_desktop_file_workspace",
+        fake_get_desktop_file_workspace,
+    )
+
+    response = asyncio.run(
+        desktop_agent_router.get_workspace(
+            "agent_demo",
+            _fake_request(),
+            path="dir_a",
+            max_depth=0,
+        )
+    )
+
+    assert response.message == "ok"
+    assert calls == {"agent_id": "agent_demo", "path": "dir_a", "max_depth": 0}


### PR DESCRIPTION
## Summary
- add optional path and max_depth controls for agent workspace listing
- keep default full recursive listing behavior for compatibility
- apply shared server/desktop routing and add coverage for depth, path safety, and parameter passthrough

## Tests
- .venv/bin/pytest tests/common/services/test_agent_service_workspace_listing.py tests/common/services/test_agent_service_workspace_delete.py
- git diff --check
- python -m compileall common/services/agent_service.py app/server/routers/agent.py app/desktop/core/routers/agent.py