### PR TITLE
fix: 修复流式断开取消链路导致 sage-server 100% CPU 空转

### DIFF
--- a/app/server/routers/chat.py
+++ b/app/server/routers/chat.py
@@ -193,36 +193,60 @@ async def _filter_stream_chunks(generator):
             await generator.aclose()
 
 
+# 流式清理动作的超时上限。
+# 历史实现把 interrupt_session / generator.aclose() 都无超时 await 在断开链路里，
+# 一旦下层 await 卡在 anyio 取消派发或锁等待，整个事件循环会被拖住。
+_DISCONNECT_INTERRUPT_TIMEOUT = 5.0
+_GENERATOR_ACLOSE_TIMEOUT = 5.0
+
+
 async def stream_api_with_disconnect_check(generator, request: Request, lock: asyncio.Lock, session_id: str):
     """
     Wrap the generator to monitor client disconnection.
     If client disconnects, stop the generator (which triggers its finally block).
+
+    断开检测策略：发现 ``request.is_disconnected()`` 后只 ``break``，不再人为抛 ``GeneratorExit``。
+    ``GeneratorExit`` 是 async generator 的关闭信号，规范上不应该在 ``except GeneratorExit`` 里
+    再 ``await`` 长协程（旧写法会在 generator 关闭临界态做远程持久化，叠加 anyio CancelScope
+    导致 sage-server 主线程 100% CPU 空转）。改为 ``break`` 后统一在 ``finally`` 里收尾。
     """
+    client_disconnected = False
     try:
         async for chunk in generator:
             if await request.is_disconnected():
                 logger.bind(session_id=session_id).info("Client disconnection detected")
-                # 抛出 GeneratorExit 模拟客户端断开，统一由异常处理逻辑处理
-                raise GeneratorExit
+                client_disconnected = True
+                break
             yield chunk
-    except (asyncio.CancelledError, GeneratorExit) as e:
-        # 标记会话中断，让内部逻辑有机会感知并处理
-        try:
-            await conversation_service.interrupt_session(session_id, "客户端断开连接")
-        except Exception as ex:
-            logger.bind(session_id=session_id).error(f"Error interrupting session: {ex}")
-
-        # 重新抛出异常，确保生成器正确关闭
-        raise e
+    except asyncio.CancelledError:
+        client_disconnected = True
+        raise
     except Exception as e:
         logger.bind(session_id=session_id).error(f"Stream generator error: {e}")
-        raise e
+        raise
     finally:
+        if client_disconnected:
+            try:
+                await asyncio.wait_for(
+                    conversation_service.interrupt_session(session_id, "客户端断开连接"),
+                    timeout=_DISCONNECT_INTERRUPT_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                logger.bind(session_id=session_id).warning(
+                    f"interrupt_session 超过 {_DISCONNECT_INTERRUPT_TIMEOUT}s 未返回，跳过强制等待"
+                )
+            except Exception as ex:
+                logger.bind(session_id=session_id).error(f"Error interrupting session: {ex}")
+
         # 确保 generator 关闭，触发内部清理逻辑 (sagents cleanup)
         # 这必须在释放锁之前执行，因为 sagents 清理逻辑需要获取锁
         try:
             if hasattr(generator, "aclose"):
-                await generator.aclose()
+                await asyncio.wait_for(generator.aclose(), timeout=_GENERATOR_ACLOSE_TIMEOUT)
+        except asyncio.TimeoutError:
+            logger.bind(session_id=session_id).warning(
+                f"generator.aclose 超过 {_GENERATOR_ACLOSE_TIMEOUT}s 未返回，跳过强制等待"
+            )
         except Exception as e:
             logger.bind(session_id=session_id).warning(f"Error closing generator: {e}")
 

--- a/common/services/chat_stream_manager.py
+++ b/common/services/chat_stream_manager.py
@@ -183,6 +183,10 @@ class StreamManager:
             return self._sessions[session_id].query
         return None
 
+    # 防御性兜底：即使下层 generator 的 aclose / 持久化路径仍可能偶发卡住，
+    # 这里也不应该让 stop_session 无限期 await，否则会顶住整条会话中断链路。
+    _STOP_SESSION_TIMEOUT = 5.0
+
     async def stop_session(self, session_id: Optional[str]) -> None:
         if not session_id:
             return
@@ -193,7 +197,12 @@ class StreamManager:
         if task and not task.done():
             task.cancel()
             try:
-                await task
+                # 用 shield 包一层只是为了让 wait_for 超时后不再额外 cancel 一次（task 已经被 cancel）。
+                await asyncio.wait_for(asyncio.shield(task), timeout=self._STOP_SESSION_TIMEOUT)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    f"stop_session: 等待 {session_id} 背景 task 取消超过 {self._STOP_SESSION_TIMEOUT}s，跳过等待"
+                )
             except asyncio.CancelledError:
                 pass
         session.status = "interrupted"

--- a/common/services/conversation_service.py
+++ b/common/services/conversation_service.py
@@ -13,7 +13,6 @@ from datetime import timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import anyio
 from loguru import logger
 from sagents.session_runtime import (
     build_conversation_messages_view,
@@ -263,20 +262,35 @@ async def persist_session_state(session_id: str) -> None:
         logger.bind(session_id=session_id).info("会话状态已刷新 conversation 时间戳")
 
 
+# 全局登记表：持有后台持久化 task 的强引用，避免被 GC，并便于进程退出时统一 await。
+_BACKGROUND_PERSISTENCE_TASKS: "set[asyncio.Task]" = set()
+
+
+def _spawn_background_persistence(session_id: str) -> asyncio.Task:
+    task = asyncio.create_task(
+        persist_session_state(session_id),
+        name=f"persist-session-{session_id}",
+    )
+    _BACKGROUND_PERSISTENCE_TASKS.add(task)
+
+    def _on_done(t: asyncio.Task) -> None:
+        _BACKGROUND_PERSISTENCE_TASKS.discard(t)
+        _log_background_persistence_result(session_id, t)
+
+    task.add_done_callback(_on_done)
+    return task
+
+
 async def persist_session_state_with_cancel_protection(session_id: str) -> None:
-    persistence_task = None
-    try:
-        with anyio.CancelScope(shield=True):
-            persistence_task = asyncio.create_task(persist_session_state(session_id))
-            await asyncio.shield(persistence_task)
-    except asyncio.CancelledError as cancel_exc:
-        if persistence_task is None:
-            raise cancel_exc
-        logger.bind(session_id=session_id).warning("会话持久化遇到取消，转入后台继续完成")
-        persistence_task.add_done_callback(
-            lambda task: _log_background_persistence_result(session_id, task)
-        )
-        raise cancel_exc
+    # 历史实现叠了 anyio.CancelScope(shield=True) + asyncio.shield()，在客户端断开/会话中断
+    # 的取消链路上会被同一函数连续调用两次（一次来自 interrupt_session，一次来自
+    # execute_chat_session 的 finally → _finalize_session_end），导致 anyio 的
+    # _deliver_cancellation 在事件循环里反复 call_soon 自己，sage-server 主线程出现
+    # 100% CPU 空转（py-spy 热点稳定停在 anyio/_backends/_asyncio.py:_deliver_cancellation）。
+    #
+    # 业务上这里只是一次会话快照写入，没有必要在取消路径上同步等待；改为登记到全局后台
+    # task 集合，立刻让取消传播收敛。即使后台持久化失败，影响也仅限于这一次快照丢失。
+    _spawn_background_persistence(session_id)
 
 
 def _log_background_persistence_result(session_id: str, task: asyncio.Task) -> None:

--- a/sagents/agent/simple_agent.py
+++ b/sagents/agent/simple_agent.py
@@ -558,11 +558,15 @@ class SimpleAgent(AgentBase):
             return True
 
         # 规则2：最后一条消息是工具调用错误结果（如参数解析失败等）
+        # 历史实现"工具失败必须继续"，与主循环按 error_category 的连续错误熔断方向相反：
+        # 当 LLM 措辞抖动让熔断 key 命不中时，规则 2 会一路放行到 max_loop_count 跑出大量 chunk。
+        # 改为让控制权回到主循环熔断（已按 TOOL_REJECTED=1 / 其他=2 的阈值生效），失败本身
+        # 不再强制再跑一轮。
         if last_message.matches_message_types([MessageType.DO_SUBTASK_RESULT.value]):
             content = last_message.content or ""
             if any(mark in content for mark in ["参数解析失败", "工具调用失败"]):
-                logger.debug("[SimpleAgent] must_continue 规则2命中：工具调用失败，必须继续")
-                return True
+                logger.debug("[SimpleAgent] must_continue 规则2命中：工具调用失败，交由主循环熔断按类别判断")
+                return False
 
         # 规则4：assistant 文本以继续标点结尾时强制继续；
         # 但若最后一条是真实 user 输入则不触发（避免反问用户被误判）
@@ -802,21 +806,26 @@ class SimpleAgent(AgentBase):
                 logger.info("SimpleAgent: 检测到停止条件，终止执行")
                 break
 
-            # 快速错误熔断：LLM 温度导致签名哈希不同，但错误内容固定可直接比对。
-            # 根据错误类型设置不同的容忍阈值：
-            #   TOOL_REJECTED（工具调用被拒绝）→ 1次即熔断，根本无法执行无需重试
-            #   其他错误（超时/参数错误/未知）→ 连续2次熔断，给一次重试机会
+            # 快速错误熔断：
+            # 历史实现用 error_content[:120] 作为比较 key，依赖错误文本逐字一致；一旦 LLM 措辞抖动
+            # 或错误信息里带时间戳/尾随空格，consecutive_error_hits 会反复重置为 1，再叠加
+            # _must_continue_by_rules 规则 2 的"工具失败必须继续"，可以一路撑到 max_loop_count
+            # 跑出大量 chunk，是这次 100% CPU 事故的放大器之一。
+            # 这里改为以 error_category 作为比较 key（5 个稳定类别，对措辞抖动免疫）；
+            # 同时按注释承诺的策略真的让 fuse_threshold 按类别走：
+            #   TOOL_REJECTED（工具调用被拒绝）→ 1 次即熔断，根本无法执行无需重试
+            #   其他错误（超时/参数错误/未知）→ 连续 2 次熔断，给一次重试机会
             error_chunks_this_turn = [
                 c for c in all_new_response_chunks
                 if is_execution_error_message_type(c.message_type) and (c.content or "").strip()
             ]
             if error_chunks_this_turn:
-                error_key = "|".join(
-                    (c.content or "").strip()[:120] for c in error_chunks_this_turn
-                )
-                # 识别错误类别
                 error_category = self._classify_error_category(error_chunks_this_turn)
-                fuse_threshold = 2
+                error_key = error_category
+                fuse_threshold = 1 if error_category == "TOOL_REJECTED" else 2
+                error_summary = " | ".join(
+                    (c.content or "").strip()[:80] for c in error_chunks_this_turn
+                )[:160]
 
                 if error_key == consecutive_error_key:
                     consecutive_error_hits += 1
@@ -826,13 +835,13 @@ class SimpleAgent(AgentBase):
 
                 if consecutive_error_hits >= fuse_threshold:
                     logger.warning(
-                        f"SimpleAgent: [{error_category}] 连续 {consecutive_error_hits} 轮出现相同错误，熔断停止。"
-                        f"错误摘要: {error_key[:80]}"
+                        f"SimpleAgent: [{error_category}] 连续 {consecutive_error_hits} 轮出现同类错误，熔断停止。"
+                        f"错误摘要: {error_summary}"
                     )
                     yield [MessageChunk(
                         role=MessageRole.ASSISTANT.value,
                         content=(
-                            f"检测到连续相同错误（类型：{error_category}，已出现 {consecutive_error_hits} 次），"
+                            f"检测到同类错误（类型：{error_category}，已出现 {consecutive_error_hits} 次），"
                             "已自动暂停以避免无效循环。请检查工具配置或提供新的指令。"
                         ),
                         type=MessageType.LOOP_BREAK.value,

--- a/tests/app/server/test_stream_api_disconnect.py
+++ b/tests/app/server/test_stream_api_disconnect.py
@@ -1,0 +1,151 @@
+"""stream_api_with_disconnect_check 行为测试。
+
+回归本次修复（commit 0bb54693）：
+- disconnect 检测后改为 break，不再人为 raise GeneratorExit
+  （旧实现会在 generator 关闭临界态做远程持久化，叠加 anyio CancelScope
+  造成 100% CPU 空转）。
+- interrupt_session / generator.aclose() 都加 5s 超时封顶，下层偶发卡死
+  不会拖死整个清理链路。
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.server.routers import chat as chat_module
+
+
+class _FakeRequest:
+    """模拟 FastAPI Request.is_disconnected()：按预设序列返回。"""
+
+    def __init__(self, disconnect_at: int):
+        self._disconnect_at = disconnect_at
+        self._calls = 0
+
+    async def is_disconnected(self) -> bool:
+        self._calls += 1
+        return self._calls > self._disconnect_at
+
+
+async def _normal_generator(num_chunks: int):
+    for i in range(num_chunks):
+        yield f"chunk-{i}\n"
+
+
+async def _generator_with_hanging_aclose():
+    """yield 一个 chunk 后 sleep；finally（被 aclose 触发）里卡死，模拟下层
+    清理被某个永远不返回的 await 挡住。"""
+    try:
+        yield "chunk-0\n"
+        await asyncio.sleep(10)
+    finally:
+        await asyncio.Future()
+
+
+@pytest.fixture
+def _patch_chat_module(monkeypatch):
+    """统一 patch chat router 模块里的副作用入口，返回一组 mock 供断言。"""
+    interrupt_mock = AsyncMock()
+    safe_release_mock = AsyncMock(return_value=True)
+    delete_lock_mock = monkeypatch.setattr(
+        chat_module, "delete_session_run_lock", lambda session_id: None
+    )
+
+    monkeypatch.setattr(
+        chat_module.conversation_service, "interrupt_session", interrupt_mock
+    )
+    monkeypatch.setattr(chat_module, "safe_release", safe_release_mock)
+
+    # 缩短超时，便于在 pytest 全局 2s timeout 内验证。
+    monkeypatch.setattr(chat_module, "_DISCONNECT_INTERRUPT_TIMEOUT", 0.1)
+    monkeypatch.setattr(chat_module, "_GENERATOR_ACLOSE_TIMEOUT", 0.1)
+
+    return SimpleNamespace(
+        interrupt=interrupt_mock,
+        safe_release=safe_release_mock,
+    )
+
+
+@pytest.mark.asyncio
+async def test_disconnect_breaks_loop_without_raising_generator_exit(_patch_chat_module):
+    """断开后正常 break；不应有 GeneratorExit 泄漏到调用方，
+    interrupt_session 应被调用一次，资源应被释放。"""
+    # 让 is_disconnected 第 1 次就返回 True（迭代第一个 chunk 后立即触发）
+    request = _FakeRequest(disconnect_at=0)
+    lock = asyncio.Lock()
+
+    chunks = []
+    gen = chat_module.stream_api_with_disconnect_check(
+        _normal_generator(5), request, lock, "session-disconnect-1"
+    )
+    # 直接消费完，不应抛任何异常
+    async for ch in gen:
+        chunks.append(ch)
+
+    # 第一个 chunk 还没 yield 就 break 了（因为先检查 is_disconnected）
+    assert chunks == []
+    _patch_chat_module.interrupt.assert_awaited_once()
+    _patch_chat_module.safe_release.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_yields_chunks_before_break(_patch_chat_module):
+    """前 N 次 is_disconnected 返回 False 时正常 yield，第 N+1 次返回 True 才 break。"""
+    request = _FakeRequest(disconnect_at=2)
+    lock = asyncio.Lock()
+
+    chunks = []
+    async for ch in chat_module.stream_api_with_disconnect_check(
+        _normal_generator(10), request, lock, "session-disconnect-2"
+    ):
+        chunks.append(ch)
+
+    assert chunks == ["chunk-0\n", "chunk-1\n"]
+    _patch_chat_module.interrupt.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_interrupt_session_timeout_does_not_block_cleanup(monkeypatch, _patch_chat_module):
+    """interrupt_session 卡死时应在超时后跳过，aclose / safe_release 仍要执行。"""
+
+    async def _hanging_interrupt(*args, **kwargs):
+        await asyncio.Future()
+
+    monkeypatch.setattr(
+        chat_module.conversation_service, "interrupt_session", _hanging_interrupt
+    )
+
+    request = _FakeRequest(disconnect_at=0)
+    lock = asyncio.Lock()
+
+    start = asyncio.get_event_loop().time()
+    async for _ in chat_module.stream_api_with_disconnect_check(
+        _normal_generator(5), request, lock, "session-interrupt-hang"
+    ):
+        pass
+    elapsed = asyncio.get_event_loop().time() - start
+
+    # 应在 interrupt 超时（100ms）附近完成，远小于 pytest 2s timeout。
+    assert elapsed < 1.0, f"interrupt_session 卡死时清理未及时返回，elapsed={elapsed:.3f}s"
+    # 资源释放路径仍要被走到。
+    _patch_chat_module.safe_release.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_generator_aclose_timeout_does_not_block_cleanup(_patch_chat_module):
+    """generator.aclose() 卡死时应在超时后跳过，safe_release 仍要执行。"""
+    request = _FakeRequest(disconnect_at=0)
+    lock = asyncio.Lock()
+
+    start = asyncio.get_event_loop().time()
+    async for _ in chat_module.stream_api_with_disconnect_check(
+        _generator_with_hanging_aclose(), request, lock, "session-aclose-hang"
+    ):
+        pass
+    elapsed = asyncio.get_event_loop().time() - start
+
+    # 两个超时窗口都 100ms，且 interrupt mock 立即返回，总耗时应在 ~100ms 附近。
+    assert elapsed < 1.0, f"aclose 卡死时清理未及时返回，elapsed={elapsed:.3f}s"
+    _patch_chat_module.safe_release.assert_awaited_once()

--- a/tests/common/services/test_chat_stream_token_persistence.py
+++ b/tests/common/services/test_chat_stream_token_persistence.py
@@ -154,3 +154,41 @@ def test_stream_manager_stop_session_closes_background_generator():
     asyncio.run(_run())
 
     assert closed is True
+
+
+def test_stream_manager_stop_session_times_out_when_background_task_hangs(monkeypatch):
+    """回归 commit 8dfad2fb：stop_session 给 await task 加了 5s 超时封顶。
+
+    构造一个 generator，其 finally 里 await 一个永远不返回的 future，模拟
+    aclose / 锁等待卡死场景；原实现的无超时 await task 会在这里挂住整条
+    中断链路，新实现应在短时间内放弃等待并继续后续清理。
+    """
+    manager = StreamManager.get_instance()
+    # 把 5s 阈值压到 100ms，便于在 pytest 全局 2s timeout 内验证。
+    monkeypatch.setattr(manager, "_STOP_SESSION_TIMEOUT", 0.1)
+
+    async def _hanging_generator():
+        try:
+            yield '{"type":"assistant_text"}\n'
+            await asyncio.sleep(10)
+        finally:
+            # 模拟 generator 的清理逻辑被某个永远不返回的 await 挡住，
+            # 让 task 在被 cancel 之后依然无法终止。
+            await asyncio.Future()
+
+    async def _run() -> float:
+        session_id = "session-stop-hang"
+        lock = asyncio.Lock()
+        await lock.acquire()
+        await manager.start_session(session_id, "query", _hanging_generator(), lock)
+        await asyncio.sleep(0.01)
+
+        start = asyncio.get_event_loop().time()
+        await manager.stop_session(session_id)
+        elapsed = asyncio.get_event_loop().time() - start
+        return elapsed
+
+    elapsed = asyncio.run(_run())
+
+    # 应在 timeout (100ms) 附近返回，给充分余量避免 CI 抖动误报。
+    assert elapsed < 1.0, f"stop_session 在背景 task 卡死时未及时返回，elapsed={elapsed:.3f}s"

--- a/tests/common/services/test_conversation_persistence_background.py
+++ b/tests/common/services/test_conversation_persistence_background.py
@@ -1,0 +1,115 @@
+"""持久化背景任务行为测试。
+
+回归本次修复（commit 0bb54693）：persist_session_state_with_cancel_protection
+不再用 anyio.CancelScope(shield=True) + asyncio.shield() 双 shield，改为
+立刻派发后台 task，避免取消链路里同一上下文连续两次撞 shield 导致 anyio
+_deliver_cancellation 反复 call_soon 自己造成 100% CPU 空转。
+"""
+
+import asyncio
+
+import pytest
+
+from common.services import conversation_service
+
+
+@pytest.fixture(autouse=True)
+def _clear_background_tasks():
+    """每个用例前后清空全局后台 task 集合，避免互相串扰。"""
+    conversation_service._BACKGROUND_PERSISTENCE_TASKS.clear()
+    yield
+    conversation_service._BACKGROUND_PERSISTENCE_TASKS.clear()
+
+
+def _install_fake_persist(monkeypatch, *, duration: float = 0.0, raise_exc: Exception | None = None):
+    """把模块级 persist_session_state 替换成可控 fake，返回观测列表。"""
+    calls: list[str] = []
+
+    async def _fake(session_id: str) -> None:
+        calls.append(session_id)
+        if duration > 0:
+            await asyncio.sleep(duration)
+        if raise_exc is not None:
+            raise raise_exc
+
+    monkeypatch.setattr(conversation_service, "persist_session_state", _fake)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_persist_with_cancel_protection_returns_immediately_without_waiting(monkeypatch):
+    """调用后立即返回，不等持久化跑完。"""
+    # 把持久化设成 100ms 才结束，但 wait_for(协程, timeout=10ms) 应该仍能完成。
+    _install_fake_persist(monkeypatch, duration=0.1)
+
+    await asyncio.wait_for(
+        conversation_service.persist_session_state_with_cancel_protection("s1"),
+        timeout=0.01,
+    )
+
+
+@pytest.mark.asyncio
+async def test_persist_with_cancel_protection_registers_and_unregisters_task(monkeypatch):
+    """后台 task 应登记到全局集合，跑完后自动移除。"""
+    _install_fake_persist(monkeypatch, duration=0.05)
+
+    await conversation_service.persist_session_state_with_cancel_protection("s1")
+    assert len(conversation_service._BACKGROUND_PERSISTENCE_TASKS) == 1
+    [task] = list(conversation_service._BACKGROUND_PERSISTENCE_TASKS)
+    assert task.get_name() == "persist-session-s1"
+
+    await task
+    # done_callback 是在 task 完成后被事件循环调度的，需要让出一次让 callback 跑完。
+    await asyncio.sleep(0)
+    assert conversation_service._BACKGROUND_PERSISTENCE_TASKS == set()
+
+
+@pytest.mark.asyncio
+async def test_persist_with_cancel_protection_two_calls_in_same_context_dont_deadlock(monkeypatch):
+    """事故重现 case：取消链路里 interrupt_session 与 _finalize_session_end 会连续
+    调用同一个函数两次。原实现的双 shield 在这个场景里会让取消传播卡住，
+    新实现两次都应立即返回。"""
+    _install_fake_persist(monkeypatch, duration=0.05)
+
+    await asyncio.wait_for(
+        asyncio.gather(
+            conversation_service.persist_session_state_with_cancel_protection("s1"),
+            conversation_service.persist_session_state_with_cancel_protection("s1"),
+        ),
+        timeout=0.1,
+    )
+
+    assert len(conversation_service._BACKGROUND_PERSISTENCE_TASKS) == 2
+
+
+@pytest.mark.asyncio
+async def test_persist_with_cancel_protection_does_not_block_caller_cancellation(monkeypatch):
+    """调用方被取消时立即收敛，不再被持久化 shield 顶住。"""
+    _install_fake_persist(monkeypatch, duration=10.0)
+
+    async def _caller():
+        await conversation_service.persist_session_state_with_cancel_protection("s1")
+        # 模拟调用方在持久化后做"真正的耗时工作"被 cancel
+        await asyncio.sleep(10.0)
+
+    task = asyncio.create_task(_caller())
+    await asyncio.sleep(0.01)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_persist_with_cancel_protection_swallows_background_exception(monkeypatch):
+    """后台持久化抛异常时调用方不感知，异常只会被 logger.warning 吞掉。"""
+    _install_fake_persist(monkeypatch, raise_exc=RuntimeError("boom"))
+
+    await conversation_service.persist_session_state_with_cancel_protection("s1")
+
+    [task] = list(conversation_service._BACKGROUND_PERSISTENCE_TASKS)
+    with pytest.raises(RuntimeError, match="boom"):
+        await task
+    # 让 done_callback 跑完，集合清空。
+    await asyncio.sleep(0)
+    assert conversation_service._BACKGROUND_PERSISTENCE_TASKS == set()

--- a/tests/sagents/agent/test_simple_agent_task_complete.py
+++ b/tests/sagents/agent/test_simple_agent_task_complete.py
@@ -91,3 +91,75 @@ async def test_user_question_with_punctuation_does_not_force_continue():
         ),
     ]
     assert await agent._must_continue_by_rules(messages) is False
+
+
+# ---- 规则 2 行为变更：工具失败不再强制继续，由主循环按 error_category 熔断 ----
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "content",
+    [
+        "工具调用失败：未提供的工具",
+        "参数解析失败：JSON 解码错误",
+        "调用 customer_send_message 时工具调用失败，原因：xxx",
+    ],
+)
+async def test_tool_failure_no_longer_forces_continue(content):
+    """回归 commit b0b70322：规则 2 历史实现"工具失败必须继续"，
+    与主循环按 error_category 的连续错误熔断方向相反，会让单次会话撑到
+    max_loop_count 跑出大量 chunk。现已改为 return False，把决策权交回
+    主循环熔断（TOOL_REJECTED 1 次熔断、其他 2 次熔断）。
+
+    此处断言失败标记本身不再强制继续，而不是熔断的最终行为（熔断在主循环里）。
+    """
+    agent = SimpleAgent(model=DummyModel(), model_config={})
+    messages = [
+        MessageChunk(
+            role=MessageRole.ASSISTANT.value,
+            content=content,
+            message_type=MessageType.DO_SUBTASK_RESULT.value,
+        ),
+    ]
+    assert await agent._must_continue_by_rules(messages) is False
+
+
+@pytest.mark.asyncio
+async def test_tool_failure_marker_in_unrelated_message_type_does_not_continue():
+    """规则 2 仅检查 DO_SUBTASK_RESULT 类型；其它类型即使包含失败关键词也不应触发。"""
+    agent = SimpleAgent(model=DummyModel(), model_config={})
+    messages = [
+        MessageChunk(
+            role=MessageRole.ASSISTANT.value,
+            content='工具调用失败，但其实是正常文本',
+            message_type=MessageType.ASSISTANT_TEXT.value,
+        ),
+    ]
+    assert await agent._must_continue_by_rules(messages) is False
+
+
+# ---- _classify_error_category：保护本次熔断 key 改造的 5 类映射 ----
+
+@pytest.mark.parametrize(
+    "content, expected",
+    [
+        ("模型调用了未提供的工具，已拒绝", "TOOL_REJECTED"),
+        ("tool not provided in this turn", "TOOL_REJECTED"),
+        ("违规工具：foo_tool", "TOOL_REJECTED"),
+        ("turn_status 工具未调用", "TURN_STATUS"),
+        ("execution timeout exceeded", "TIMEOUT"),
+        ("工具执行超时", "TIMEOUT"),
+        ("invalid arguments for tool", "INVALID_ARGS"),
+        ("参数解析失败", "INVALID_ARGS"),
+        ("some unknown error occurred", "OTHER"),
+    ],
+)
+def test_classify_error_category_covers_known_kinds(content, expected):
+    """主循环熔断现在以 error_category 作为比较 key（对 LLM 措辞抖动免疫），
+    分类映射稳定性直接决定熔断是否能命中，需要专门保护。"""
+    agent = SimpleAgent(model=DummyModel(), model_config={})
+    chunk = MessageChunk(
+        role=MessageRole.ASSISTANT.value,
+        content=content,
+        message_type=MessageType.AGENT_EXECUTION_ERROR.value,
+    )
+    assert agent._classify_error_category([chunk]) == expected


### PR DESCRIPTION
## 背景与现象

`sage-server` 在容器里出现持续 99%+ CPU 占用，但同时所有可观测信号都正常：

- 进程没有活跃业务请求
- `/api/stream/active_sessions` 返回 `[]`
- `sage-es` 健康检查 `green`
- 没有持续新请求日志

也就是说**不是 ES、不是 MySQL、不是外部请求压垮服务**，是 `sage-server` 进程内部事件循环空转。

用 `py-spy` 抓栈，主线程热点稳定停在：

```
anyio/_backends/_asyncio.py:_deliver_cancellation
```

这条栈强烈指向「取消逻辑没收敛」，而不是业务计算占用 CPU。

复现链路：

```
工具调用失败（如 customer_send_message 持续失败）
→ SimpleAgent 多轮循环，单次会话产生大量流式 chunk
→ 客户端/前端断开
→ 后端进入 stream 清理逻辑
→ generator.aclose / interrupt_session / 会话状态持久化
→ AnyIO CancelScope 反复 deliver cancellation
→ 主事件循环持续空转
→ sage-server 100% CPU（即便 active_sessions 已空也不恢复）
```

## 触发场景

事故的核心触发动作 = **流式响应被取消**。在 sage-server 上能让流式响应被取消的来源有三类，对应日常用户行为：

| 触发源 | 用户行为 |
|---|---|
| A. Starlette 自动取消（客户端 TCP 断开） | 关浏览器 / 切 Tab、前端 `AbortController.abort()`、Ctrl-C curl、网络断、反向代理读超时 |
| B. 显式中断接口（`POST /api/sessions/{session_id}/interrupt`） | 点"停止输出"按钮 |
| C. 服务端 self-cancel（`chat.py:81-88`，同 session 检测到旧会话先 interrupt 再起新的） | 在同一对话里直接追问下一条 |

> 这 3 种行为每天大量发生，每次都会进入这次修复涉及的取消链路。平时没每次都爆 CPU，是因为还要叠加「agent 多轮循环 + 大量流式 chunk + 同一上下文连续两次撞 shield」才会让 anyio `_deliver_cancellation` 落入死循环。本次修复后这些日常行为都不再有踩雷的风险。

## 根因分析

### 1. 主放大器：`persist_session_state_with_cancel_protection` 的双 shield + 同一取消上下文里被调用两次

文件：`common/services/conversation_service.py`

历史实现同时叠了 `anyio.CancelScope(shield=True)` 和 `asyncio.shield()`：

```python
async def persist_session_state_with_cancel_protection(session_id: str) -> None:
    persistence_task = None
    try:
        with anyio.CancelScope(shield=True):
            persistence_task = asyncio.create_task(persist_session_state(session_id))
            await asyncio.shield(persistence_task)
    except asyncio.CancelledError as cancel_exc:
        ...
        raise cancel_exc
```

更致命的是，**同一个取消上下文里这个函数会被连续调用两次**：

```
client disconnect
→ stream_api_with_disconnect_check raise GeneratorExit
→ await interrupt_session(...)
     └─ await persist_session_state_with_cancel_protection()   # 第 1 次撞 shield
→ finally: await generator.aclose()
     └─ 触发 execute_chat_session() 的 finally
        └─ _finalize_session_end()
           └─ await persist_session_state_with_cancel_protection()   # 第 2 次撞 shield
```

机制层面：anyio 的 `_deliver_cancellation` 在派发取消时，如果发现 scope 内还有 task 没收敛，会 `loop.call_soon(self._deliver_cancellation)` 把自己重新挂回 ready queue。内层 task 被 `asyncio.shield` 屏蔽掉取消后，**派发 → 检查 → 未生效 → 重新 call_soon** 就变成一个 ready-queue 级别的死循环，事件循环看上去 100% busy。

### 2. 触发器：`stream_api_with_disconnect_check` 主动 `raise GeneratorExit`，并在 except 里 await 长协程

文件：`app/server/routers/chat.py`

```python
async def stream_api_with_disconnect_check(generator, request: Request, lock: asyncio.Lock, session_id: str):
    try:
        async for chunk in generator:
            if await request.is_disconnected():
                raise GeneratorExit                       # ← 反模式
    except (asyncio.CancelledError, GeneratorExit) as e:
        await conversation_service.interrupt_session(...) # ← 在 GeneratorExit 临界态做远程持久化
        raise e
    finally:
        await generator.aclose()                          # ← 无超时保护
```

`GeneratorExit` 是 Python 给 async generator 的关闭信号，规范上不应在 `except GeneratorExit:` 内再 `await` 长协程。配合第 1 项的双 shield，这里就是真正点燃事故的导火索。`generator.aclose()` 也没有超时封顶，下层一旦卡住整个清理链路被顶死。

### 3. 防御缺口：`StreamManager.stop_session` 取消后 `await task` 无超时

文件：`common/services/chat_stream_manager.py`

```python
if task and not task.done():
    task.cancel()
    try:
        await task          # ← 无超时
    except asyncio.CancelledError:
        pass
```

`stop_session` 是会话中断链路上唯一的"刹车"。如果下层 `generator.aclose()` 在被取消时仍能卡住，这里会跟着一起卡，让中断永远不返回。

### 4. 放大源：SimpleAgent 工具失败循环的两类设计问题

文件：`sagents/agent/simple_agent.py`

**(a) 注释和代码不一致的实现 bug**：注释承诺 `TOOL_REJECTED` 类错误 1 次熔断、其他错误 2 次熔断，但代码硬编码 `fuse_threshold = 2`，`error_category` 算了但没用上。

```python
error_category = self._classify_error_category(error_chunks_this_turn)
fuse_threshold = 2     # ← 与上面注释承诺的策略不一致
```

**(b) 熔断比较 key 对 LLM 措辞抖动不稳定**：原实现用 `error_content[:120]` 作为比较 key，依赖错误文本逐字一致。LLM 温度抖一下、错误信息带时间戳、带尾随空格，`consecutive_error_hits` 就会反复重置为 1，熔断永远不触发。

**(c) `_must_continue_by_rules` 规则 2 和熔断方向相反**：

```python
if any(mark in content for mark in ["参数解析失败", "工具调用失败"]):
    return True   # ← 工具失败必须继续
```

规则 2 一直踩油门、熔断踩刹车。一旦比较 key miss，规则 2 会一路放行到 `max_loop_count`，单次会话跑出大量 chunk，让上面的取消链路有更多机会触发死循环。

## 解决方案

3 个 commit，按 P0 → P1-1 → P1-2 顺序：

- `0bb54693` **P0**：拆 shield + disconnect 走 `break` + 清理动作加超时（治本）
- `8dfad2fb` **P1-1**：`StreamManager.stop_session` 加 5s 超时（防御性兜底）
- `b0b70322` **P1-2**：SimpleAgent 熔断按 `error_category` 收敛，消除规则 2 与熔断对冲（治放大源）

## 改动详情

### 改动 1：`common/services/conversation_service.py`

- 删除 `import anyio`（不再使用）。
- 新增 `_BACKGROUND_PERSISTENCE_TASKS` 全局 task 集合，持强引用防 GC。
- 新增 `_spawn_background_persistence(session_id)`：创建后台 task、登记、`add_done_callback` 收尾。
- 重写 `persist_session_state_with_cancel_protection`：不再 shield、不再 `await`，直接调用 `_spawn_background_persistence(session_id)` 后立即返回。

效果：取消链路里两次调用都不再撞 shield，anyio `_deliver_cancellation` 没有理由反复 `call_soon` 自己。

### 改动 2：`app/server/routers/chat.py` (`stream_api_with_disconnect_check`)

- 检测断开后改为 `break`，**不再人为 `raise GeneratorExit`**。
- `except` 列表去掉 `GeneratorExit`，只保留 `asyncio.CancelledError`（仍然 re-raise）。
- 用 `client_disconnected` 标记把 `interrupt_session(...)` 移到 `finally`，并用 `asyncio.wait_for(..., timeout=5)` 封顶。
- `generator.aclose()` 同样用 `asyncio.wait_for(..., timeout=5)` 封顶。

效果：避免在 generator 关闭临界态做远程持久化；即便下层偶发慢，最多卡 10s 即强制继续清理，事件循环不会被拖死。

### 改动 3：`common/services/chat_stream_manager.py` (`stop_session`)

- `await task` → `await asyncio.wait_for(asyncio.shield(task), timeout=5)`。
- 超时打 warning 并继续后续清理，不抛异常。
- `shield` 包是为了 `wait_for` 超时后不再额外 `cancel` 一次（task 已经被 cancel）。

效果：防御性兜底，未来若有人写出新的卡死路径，这里不会顶住整条中断链路。

### 改动 4：`sagents/agent/simple_agent.py`

主循环熔断块：

- 比较 key 从 `error_content[:120]` 改为 `error_category`（5 个稳定类别：`TOOL_REJECTED` / `TURN_STATUS` / `TIMEOUT` / `INVALID_ARGS` / `OTHER`），对 LLM 措辞抖动免疫。
- `fuse_threshold` 真按注释承诺走：`TOOL_REJECTED → 1`，其他 → `2`。
- 日志和用户提示文案同步更新。

`_must_continue_by_rules` 规则 2：

- "工具失败必须继续" 改为 `return False`，决策权交回主循环熔断。
- 避免规则 2（油门）和熔断（刹车）相互拉扯。

## 行为变化要点（部署前需要知道的）

> 三项行为变化都是预期的收敛行为，但请 reviewer 重点确认。

### 1. 持久化变成后台异步

原本调用方 `await persist_session_state_with_cancel_protection(...)` 会**等持久化写完才返回**。改完后该函数立即返回，持久化在后台 task 里跑。

排查影响：仓库内只有 `interrupt_session` 和 `_finalize_session_end` 两个调用方，都不依赖"返回时已写完"。如果其他地方有同步语义依赖（例如"中断后立即读取最新快照"），请告知，需要单独处理。

### 2. 进程退出时后台持久化可能未跑完

新版后台 task 登记在模块级 `_BACKGROUND_PERSISTENCE_TASKS`，进程被 `SIGTERM` 时 task 可能没跑完。短期不影响（持久化失败影响仅限单次快照），但**如果未来要加 graceful shutdown**，建议在退出钩子里加：

```python
await asyncio.gather(*_BACKGROUND_PERSISTENCE_TASKS, return_exceptions=True)
```

### 3. SimpleAgent 失败收敛速度变快

工具第一次失败后不再无脑继续：

- `TOOL_REJECTED` 类（模型调用了未提供的工具）→ **1 次就停**。
- 其他类错误（`TIMEOUT` / `INVALID_ARGS` / `TURN_STATUS` / `OTHER`）→ **连续 2 次就停**。

原来在 LLM 措辞抖动时可以撑到 `max_loop_count` 的场景，现在最多 2 轮就熔断。这是预期的收敛行为，但**建议跑一次回归测试**确认不会误伤正常的"工具瞬时失败 → 重试成功"场景。

## 验证方法

复现 + 验收步骤：

1. 构造一次工具持续失败的会话（例如让 `customer_send_message` 一直报 `task ... does not belong to ...`）。
2. 客户端中途断开（关闭浏览器 / Ctrl-C 终止 curl）。
3. 等待 30s，观察：
   - `curl http://127.0.0.1:30050/api/stream/active_sessions` 应返回 `[]`。
   - `docker stats sage-server` 的 CPU 应回落到正常水位（< 10%）。
   - `py-spy dump --pid <sage-server pid>` 主线程栈**不应**再停在 `anyio/_backends/_asyncio.py:_deliver_cancellation`。
4. 正常会话回归：跑若干轮多工具调用，确认 SimpleAgent 在正常重试场景（瞬时失败 + 第二轮成功）下不会被误熔断。

## 回滚策略

3 个 commit 按粒度独立，可单独 revert：

- 只想保留根因修复，回退熔断行为变化：`git revert b0b70322`
- 同时回退防御性超时：`git revert 8dfad2fb b0b70322`
- 全部回滚：`git revert 0bb54693 8dfad2fb b0b70322`

## 总结

不是 ES、不是机器负载、也不是还有请求没结束，而是**流式请求取消/清理阶段的 AnyIO CancelScope 在同一上下文里连续两次撞 shield，导致 `_deliver_cancellation` 在事件循环里反复 `call_soon` 自己**；SimpleAgent 失败循环和文本 hash 熔断的脆弱设计是放大源。本次 PR 切断根因（拆 shield + 改 break）、加上防御性超时、修正熔断比较 key 与 `must_continue` 规则 2，问题闭环。