### PR TITLE
fix: 客户端断开后清理路径加超时与改用 break，避免事件循环空转

### DIFF
--- a/app/server/routers/chat.py
+++ b/app/server/routers/chat.py
@@ -193,36 +193,60 @@ async def _filter_stream_chunks(generator):
             await generator.aclose()
 
 
+# 流式清理动作的超时上限。
+# 历史实现把 interrupt_session / generator.aclose() 都无超时 await 在断开链路里，
+# 一旦下层 await 卡在 anyio 取消派发或锁等待，整个事件循环会被拖住。
+_DISCONNECT_INTERRUPT_TIMEOUT = 5.0
+_GENERATOR_ACLOSE_TIMEOUT = 5.0
+
+
 async def stream_api_with_disconnect_check(generator, request: Request, lock: asyncio.Lock, session_id: str):
     """
     Wrap the generator to monitor client disconnection.
     If client disconnects, stop the generator (which triggers its finally block).
+
+    断开检测策略：发现 ``request.is_disconnected()`` 后只 ``break``，不再人为抛 ``GeneratorExit``。
+    ``GeneratorExit`` 是 async generator 的关闭信号，规范上不应该在 ``except GeneratorExit`` 里
+    再 ``await`` 长协程（旧写法会在 generator 关闭临界态做远程持久化，叠加 anyio CancelScope
+    导致 sage-server 主线程 100% CPU 空转）。改为 ``break`` 后统一在 ``finally`` 里收尾。
     """
+    client_disconnected = False
     try:
         async for chunk in generator:
             if await request.is_disconnected():
                 logger.bind(session_id=session_id).info("Client disconnection detected")
-                # 抛出 GeneratorExit 模拟客户端断开，统一由异常处理逻辑处理
-                raise GeneratorExit
+                client_disconnected = True
+                break
             yield chunk
-    except (asyncio.CancelledError, GeneratorExit) as e:
-        # 标记会话中断，让内部逻辑有机会感知并处理
-        try:
-            await conversation_service.interrupt_session(session_id, "客户端断开连接")
-        except Exception as ex:
-            logger.bind(session_id=session_id).error(f"Error interrupting session: {ex}")
-
-        # 重新抛出异常，确保生成器正确关闭
-        raise e
+    except asyncio.CancelledError:
+        client_disconnected = True
+        raise
     except Exception as e:
         logger.bind(session_id=session_id).error(f"Stream generator error: {e}")
-        raise e
+        raise
     finally:
+        if client_disconnected:
+            try:
+                await asyncio.wait_for(
+                    conversation_service.interrupt_session(session_id, "客户端断开连接"),
+                    timeout=_DISCONNECT_INTERRUPT_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                logger.bind(session_id=session_id).warning(
+                    f"interrupt_session 超过 {_DISCONNECT_INTERRUPT_TIMEOUT}s 未返回，跳过强制等待"
+                )
+            except Exception as ex:
+                logger.bind(session_id=session_id).error(f"Error interrupting session: {ex}")
+
         # 确保 generator 关闭，触发内部清理逻辑 (sagents cleanup)
         # 这必须在释放锁之前执行，因为 sagents 清理逻辑需要获取锁
         try:
             if hasattr(generator, "aclose"):
-                await generator.aclose()
+                await asyncio.wait_for(generator.aclose(), timeout=_GENERATOR_ACLOSE_TIMEOUT)
+        except asyncio.TimeoutError:
+            logger.bind(session_id=session_id).warning(
+                f"generator.aclose 超过 {_GENERATOR_ACLOSE_TIMEOUT}s 未返回，跳过强制等待"
+            )
         except Exception as e:
             logger.bind(session_id=session_id).warning(f"Error closing generator: {e}")
 

--- a/common/services/chat_stream_manager.py
+++ b/common/services/chat_stream_manager.py
@@ -183,6 +183,10 @@ class StreamManager:
             return self._sessions[session_id].query
         return None
 
+    # 防御性兜底：即使下层 generator 的 aclose / 持久化路径仍可能偶发卡住，
+    # 这里也不应该让 stop_session 无限期 await，否则会顶住整条会话中断链路。
+    _STOP_SESSION_TIMEOUT = 5.0
+
     async def stop_session(self, session_id: Optional[str]) -> None:
         if not session_id:
             return
@@ -193,7 +197,12 @@ class StreamManager:
         if task and not task.done():
             task.cancel()
             try:
-                await task
+                # 用 shield 包一层只是为了让 wait_for 超时后不再额外 cancel 一次（task 已经被 cancel）。
+                await asyncio.wait_for(asyncio.shield(task), timeout=self._STOP_SESSION_TIMEOUT)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    f"stop_session: 等待 {session_id} 背景 task 取消超过 {self._STOP_SESSION_TIMEOUT}s，跳过等待"
+                )
             except asyncio.CancelledError:
                 pass
         session.status = "interrupted"

--- a/tests/app/server/test_stream_api_disconnect.py
+++ b/tests/app/server/test_stream_api_disconnect.py
@@ -1,0 +1,151 @@
+"""stream_api_with_disconnect_check 行为测试。
+
+回归本次修复（commit 0bb54693）：
+- disconnect 检测后改为 break，不再人为 raise GeneratorExit
+  （旧实现会在 generator 关闭临界态做远程持久化，叠加 anyio CancelScope
+  造成 100% CPU 空转）。
+- interrupt_session / generator.aclose() 都加 5s 超时封顶，下层偶发卡死
+  不会拖死整个清理链路。
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.server.routers import chat as chat_module
+
+
+class _FakeRequest:
+    """模拟 FastAPI Request.is_disconnected()：按预设序列返回。"""
+
+    def __init__(self, disconnect_at: int):
+        self._disconnect_at = disconnect_at
+        self._calls = 0
+
+    async def is_disconnected(self) -> bool:
+        self._calls += 1
+        return self._calls > self._disconnect_at
+
+
+async def _normal_generator(num_chunks: int):
+    for i in range(num_chunks):
+        yield f"chunk-{i}\n"
+
+
+async def _generator_with_hanging_aclose():
+    """yield 一个 chunk 后 sleep；finally（被 aclose 触发）里卡死，模拟下层
+    清理被某个永远不返回的 await 挡住。"""
+    try:
+        yield "chunk-0\n"
+        await asyncio.sleep(10)
+    finally:
+        await asyncio.Future()
+
+
+@pytest.fixture
+def _patch_chat_module(monkeypatch):
+    """统一 patch chat router 模块里的副作用入口，返回一组 mock 供断言。"""
+    interrupt_mock = AsyncMock()
+    safe_release_mock = AsyncMock(return_value=True)
+    delete_lock_mock = monkeypatch.setattr(
+        chat_module, "delete_session_run_lock", lambda session_id: None
+    )
+
+    monkeypatch.setattr(
+        chat_module.conversation_service, "interrupt_session", interrupt_mock
+    )
+    monkeypatch.setattr(chat_module, "safe_release", safe_release_mock)
+
+    # 缩短超时，便于在 pytest 全局 2s timeout 内验证。
+    monkeypatch.setattr(chat_module, "_DISCONNECT_INTERRUPT_TIMEOUT", 0.1)
+    monkeypatch.setattr(chat_module, "_GENERATOR_ACLOSE_TIMEOUT", 0.1)
+
+    return SimpleNamespace(
+        interrupt=interrupt_mock,
+        safe_release=safe_release_mock,
+    )
+
+
+@pytest.mark.asyncio
+async def test_disconnect_breaks_loop_without_raising_generator_exit(_patch_chat_module):
+    """断开后正常 break；不应有 GeneratorExit 泄漏到调用方，
+    interrupt_session 应被调用一次，资源应被释放。"""
+    # 让 is_disconnected 第 1 次就返回 True（迭代第一个 chunk 后立即触发）
+    request = _FakeRequest(disconnect_at=0)
+    lock = asyncio.Lock()
+
+    chunks = []
+    gen = chat_module.stream_api_with_disconnect_check(
+        _normal_generator(5), request, lock, "session-disconnect-1"
+    )
+    # 直接消费完，不应抛任何异常
+    async for ch in gen:
+        chunks.append(ch)
+
+    # 第一个 chunk 还没 yield 就 break 了（因为先检查 is_disconnected）
+    assert chunks == []
+    _patch_chat_module.interrupt.assert_awaited_once()
+    _patch_chat_module.safe_release.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_yields_chunks_before_break(_patch_chat_module):
+    """前 N 次 is_disconnected 返回 False 时正常 yield，第 N+1 次返回 True 才 break。"""
+    request = _FakeRequest(disconnect_at=2)
+    lock = asyncio.Lock()
+
+    chunks = []
+    async for ch in chat_module.stream_api_with_disconnect_check(
+        _normal_generator(10), request, lock, "session-disconnect-2"
+    ):
+        chunks.append(ch)
+
+    assert chunks == ["chunk-0\n", "chunk-1\n"]
+    _patch_chat_module.interrupt.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_interrupt_session_timeout_does_not_block_cleanup(monkeypatch, _patch_chat_module):
+    """interrupt_session 卡死时应在超时后跳过，aclose / safe_release 仍要执行。"""
+
+    async def _hanging_interrupt(*args, **kwargs):
+        await asyncio.Future()
+
+    monkeypatch.setattr(
+        chat_module.conversation_service, "interrupt_session", _hanging_interrupt
+    )
+
+    request = _FakeRequest(disconnect_at=0)
+    lock = asyncio.Lock()
+
+    start = asyncio.get_event_loop().time()
+    async for _ in chat_module.stream_api_with_disconnect_check(
+        _normal_generator(5), request, lock, "session-interrupt-hang"
+    ):
+        pass
+    elapsed = asyncio.get_event_loop().time() - start
+
+    # 应在 interrupt 超时（100ms）附近完成，远小于 pytest 2s timeout。
+    assert elapsed < 1.0, f"interrupt_session 卡死时清理未及时返回，elapsed={elapsed:.3f}s"
+    # 资源释放路径仍要被走到。
+    _patch_chat_module.safe_release.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_generator_aclose_timeout_does_not_block_cleanup(_patch_chat_module):
+    """generator.aclose() 卡死时应在超时后跳过，safe_release 仍要执行。"""
+    request = _FakeRequest(disconnect_at=0)
+    lock = asyncio.Lock()
+
+    start = asyncio.get_event_loop().time()
+    async for _ in chat_module.stream_api_with_disconnect_check(
+        _generator_with_hanging_aclose(), request, lock, "session-aclose-hang"
+    ):
+        pass
+    elapsed = asyncio.get_event_loop().time() - start
+
+    # 两个超时窗口都 100ms，且 interrupt mock 立即返回，总耗时应在 ~100ms 附近。
+    assert elapsed < 1.0, f"aclose 卡死时清理未及时返回，elapsed={elapsed:.3f}s"
+    _patch_chat_module.safe_release.assert_awaited_once()

--- a/tests/common/services/test_chat_stream_token_persistence.py
+++ b/tests/common/services/test_chat_stream_token_persistence.py
@@ -154,3 +154,41 @@ def test_stream_manager_stop_session_closes_background_generator():
     asyncio.run(_run())
 
     assert closed is True
+
+
+def test_stream_manager_stop_session_times_out_when_background_task_hangs(monkeypatch):
+    """回归 commit 8dfad2fb：stop_session 给 await task 加了 5s 超时封顶。
+
+    构造一个 generator，其 finally 里 await 一个永远不返回的 future，模拟
+    aclose / 锁等待卡死场景；原实现的无超时 await task 会在这里挂住整条
+    中断链路，新实现应在短时间内放弃等待并继续后续清理。
+    """
+    manager = StreamManager.get_instance()
+    # 把 5s 阈值压到 100ms，便于在 pytest 全局 2s timeout 内验证。
+    monkeypatch.setattr(manager, "_STOP_SESSION_TIMEOUT", 0.1)
+
+    async def _hanging_generator():
+        try:
+            yield '{"type":"assistant_text"}\n'
+            await asyncio.sleep(10)
+        finally:
+            # 模拟 generator 的清理逻辑被某个永远不返回的 await 挡住，
+            # 让 task 在被 cancel 之后依然无法终止。
+            await asyncio.Future()
+
+    async def _run() -> float:
+        session_id = "session-stop-hang"
+        lock = asyncio.Lock()
+        await lock.acquire()
+        await manager.start_session(session_id, "query", _hanging_generator(), lock)
+        await asyncio.sleep(0.01)
+
+        start = asyncio.get_event_loop().time()
+        await manager.stop_session(session_id)
+        elapsed = asyncio.get_event_loop().time() - start
+        return elapsed
+
+    elapsed = asyncio.run(_run())
+
+    # 应在 timeout (100ms) 附近返回，给充分余量避免 CI 抖动误报。
+    assert elapsed < 1.0, f"stop_session 在背景 task 卡死时未及时返回，elapsed={elapsed:.3f}s"


### PR DESCRIPTION
## 原因

客户端断开后，`stream_api_with_disconnect_check` 的清理路径存在两个问题：

1. 检测到 disconnect 后 `raise GeneratorExit`，再在 `except GeneratorExit:` 里
   `await interrupt_session` / `aclose` —— 在 generator 关闭信号的异常分支里再
   `await` 长协程是反模式，会把"已被取消"语义重复叠加进 cleanup。
2. 清理路径上的 `interrupt_session` / `generator.aclose()` /
   `StreamManager.stop_session` 全是裸 `await`，下层在取消上下文里偶发卡住时
   会无限阻塞，事件循环被一次断开事件长时间拖住。

叠加效果：`py-spy` 看到主线程死死停在
`anyio/_backends/_asyncio.py:_deliver_cancellation`，
`active_sessions` 已空但 CPU 仍维持 99%+。

## 解决什么问题

- `stream_api_with_disconnect_check` 改为 `break` 退出循环，统一在 `finally` 收尾，
  不再在 `GeneratorExit` 异常分支里 `await` 长协程。
- `interrupt_session` / `generator.aclose()` / `StreamManager.stop_session`
  各加 5s 超时封顶，下层卡住时被超时丢弃并打 warning，不再拖死事件循环。

效果：CPU 从"无限烧"变成"最多烧 5s 后回落"，断开后 sage-server 能正常恢复。

## 范围说明

本 PR 只做"超时止血"，正常请求路径完全不动。
真正的根因在 `persist_session_state_with_cancel_protection` 的
`anyio.CancelScope(shield=True)` + `asyncio.shield()` 双 shield 实现，
那部分会改变持久化语义，**单独 PR 评审**。