### PR TITLE
Align tool detail language with page settings

### DIFF
--- a/app/desktop/core/routers/tool.py
+++ b/app/desktop/core/routers/tool.py
@@ -21,6 +21,26 @@ class ExecToolRequest(BaseModel):
     arguments: Dict[str, Any] = {}
 
 
+def _resolve_request_language(http_request: Request, language: Optional[str] = None, default: str = "zh") -> str:
+    candidate = (language or "").strip()
+    if not candidate:
+        headers = http_request.headers
+        candidate = (
+            headers.get("x-accept-language")
+            or headers.get("accept-language")
+            or ""
+        ).strip()
+
+    normalized = candidate.lower().replace("_", "-")
+    if normalized.startswith("zh"):
+        return "zh"
+    if normalized.startswith("pt"):
+        return "pt"
+    if normalized.startswith("en"):
+        return "en"
+    return default
+
+
 @tool_router.post("/exec")
 async def exec_tool(request: ExecToolRequest, http_request: Request):
     """执行工具"""
@@ -35,7 +55,7 @@ async def exec_tool(request: ExecToolRequest, http_request: Request):
 
 
 @tool_router.get("")
-async def get_tools(http_request: Request, type: Optional[str] = None):
+async def get_tools(http_request: Request, type: Optional[str] = None, language: Optional[str] = None):
     """
     获取可用工具列表
 
@@ -47,6 +67,7 @@ async def get_tools(http_request: Request, type: Optional[str] = None):
         user_id=get_desktop_user_id(http_request),
         role=get_desktop_user_role(http_request),
         tool_type=type,
+        language=_resolve_request_language(http_request, language, default="zh"),
     )
 
     return await Response.succ(message="获取工具列表成功", data={"tools": tools})

--- a/app/desktop/ui/src/api/tool.js
+++ b/app/desktop/ui/src/api/tool.js
@@ -11,7 +11,7 @@ export const toolAPI = {
    * @returns {Promise<Array>}
    */
   getTools: async (params = {}) => {
-    return await request.get('/api/tools')
+    return await request.get('/api/tools', params)
   },
 
   getBrowserExtensionStatus: async () => {

--- a/app/desktop/ui/src/components/ToolDetail.vue
+++ b/app/desktop/ui/src/components/ToolDetail.vue
@@ -517,7 +517,7 @@ const getToolTypeBadgeVariant = (type) => {
   }
 }
 
-const getSchemaVariant = (schema) => {
+function getSchemaVariant(schema) {
   if (!schema || typeof schema !== 'object') {
     return {}
   }
@@ -530,7 +530,7 @@ const getSchemaVariant = (schema) => {
   return variants.find((item) => item && typeof item === 'object' && item.type !== 'null') || schema
 }
 
-const normalizeSchema = (schema) => {
+function normalizeSchema(schema) {
   const variant = getSchemaVariant(schema)
   return {
     ...(variant && typeof variant === 'object' ? variant : {}),
@@ -540,7 +540,7 @@ const normalizeSchema = (schema) => {
   }
 }
 
-const getSchemaType = (schema) => {
+function getSchemaType(schema) {
   const variant = getSchemaVariant(schema)
   if (Array.isArray(variant.type)) {
     return variant.type.filter((item) => item !== 'null').join(' | ') || 'unknown'
@@ -548,7 +548,7 @@ const getSchemaType = (schema) => {
   return variant.type || 'unknown'
 }
 
-const formatParameters = (parameters, requiredNames = []) => {
+function formatParameters(parameters, requiredNames = []) {
   if (!parameters || typeof parameters !== 'object') {
     return []
   }

--- a/app/server/routers/tool.py
+++ b/app/server/routers/tool.py
@@ -21,6 +21,26 @@ class ExecToolRequest(BaseModel):
     arguments: Dict[str, Any] = {}
 
 
+def _resolve_request_language(http_request: Request, language: Optional[str] = None, default: str = "en") -> str:
+    candidate = (language or "").strip()
+    if not candidate:
+        headers = http_request.headers
+        candidate = (
+            headers.get("x-accept-language")
+            or headers.get("accept-language")
+            or ""
+        ).strip()
+
+    normalized = candidate.lower().replace("_", "-")
+    if normalized.startswith("zh"):
+        return "zh"
+    if normalized.startswith("pt"):
+        return "pt"
+    if normalized.startswith("en"):
+        return "en"
+    return default
+
+
 @tool_router.post("/exec")
 async def exec_tool(request: ExecToolRequest, http_request: Request):
     """执行工具"""
@@ -35,7 +55,7 @@ async def exec_tool(request: ExecToolRequest, http_request: Request):
 
 
 @tool_router.get("")
-async def get_tools(http_request: Request, type: Optional[str] = None):
+async def get_tools(http_request: Request, type: Optional[str] = None, language: Optional[str] = None):
     """
     获取可用工具列表
 
@@ -47,6 +67,7 @@ async def get_tools(http_request: Request, type: Optional[str] = None):
         user_id=get_request_user_id(http_request),
         role=get_request_role(http_request),
         tool_type=type,
+        language=_resolve_request_language(http_request, language, default="en"),
     )
 
     return await Response.succ(message="获取工具列表成功", data={"tools": tools})

--- a/app/server/web/src/api/tool.js
+++ b/app/server/web/src/api/tool.js
@@ -11,7 +11,7 @@ export const toolAPI = {
    * @returns {Promise<Array>}
    */
   getTools: async (params = {}) => {
-    return await request.get('/api/tools')
+    return await request.get('/api/tools', params)
   },
 
 

--- a/common/services/tool_service.py
+++ b/common/services/tool_service.py
@@ -155,6 +155,7 @@ async def list_tools(
     user_id: str = "",
     role: str = "user",
     tool_type: Optional[str] = None,
+    language: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     try:
         await ensure_default_anytool_server()
@@ -164,7 +165,10 @@ async def list_tools(
     if not tool_manager:
         return []
 
-    available_tools = tool_manager.list_tools_with_type()
+    available_tools = tool_manager.list_tools_with_type(
+        lang=language,
+        fallback_chain=["en"] if language != "en" else None,
+    )
     # 隐藏工具：
     # - turn_status：协议性内置工具，由 SimpleAgent 强制注入，不让用户单独勾选；
     # - await_shell / kill_shell：与 execute_shell_command 共享后台任务注册表，作为捆绑工具

--- a/sagents/tool/tool_manager.py
+++ b/sagents/tool/tool_manager.py
@@ -64,6 +64,30 @@ def _get_display_input_schema(tool: Union[ToolSpec, McpToolSpec, SageMcpToolSpec
     }
 
 
+def _apply_localized_schema_descriptions(display_schema: Dict[str, Any], localized_schema: Dict[str, Any]) -> Dict[str, Any]:
+    """Overlay localized descriptions without changing the display schema shape."""
+    if not isinstance(display_schema, dict) or not isinstance(localized_schema, dict):
+        return display_schema
+
+    if isinstance(localized_schema.get("description"), str):
+        display_schema["description"] = localized_schema["description"]
+
+    display_properties = display_schema.get("properties")
+    localized_properties = localized_schema.get("properties")
+    if isinstance(display_properties, dict) and isinstance(localized_properties, dict):
+        for name, display_property in display_properties.items():
+            localized_property = localized_properties.get(name)
+            if isinstance(display_property, dict) and isinstance(localized_property, dict):
+                _apply_localized_schema_descriptions(display_property, localized_property)
+
+    display_items = display_schema.get("items")
+    localized_items = localized_schema.get("items")
+    if isinstance(display_items, dict) and isinstance(localized_items, dict):
+        _apply_localized_schema_descriptions(display_items, localized_items)
+
+    return display_schema
+
+
 def _truncate_result(result: str, max_tokens: int = MAX_TOOL_RESULT_TOKENS) -> str:
     """截断工具返回结果，限制在最大 token 数内
     
@@ -884,6 +908,9 @@ class ToolManager:
             spec = convert_spec_to_openai_format(tool, lang=lang, fallback_chain=fallback_chain)
             fn = spec.get("function", {})
             input_schema = _get_display_input_schema(tool)
+            localized_parameters = fn.get("parameters", {})
+            if isinstance(localized_parameters, dict):
+                _apply_localized_schema_descriptions(input_schema, localized_parameters)
             params = input_schema.get("properties", {})
             tools_list.append({
                 "name": fn.get("name", getattr(tool, "name", "")),
@@ -942,6 +969,9 @@ class ToolManager:
             spec = convert_spec_to_openai_format(tool, lang=lang, fallback_chain=fallback_chain)
             fn = spec.get("function", {})
             input_schema = _get_display_input_schema(tool)
+            localized_parameters = fn.get("parameters", {})
+            if isinstance(localized_parameters, dict):
+                _apply_localized_schema_descriptions(input_schema, localized_parameters)
             params = input_schema.get("properties", {})
 
             tools_with_type.append({

--- a/tests/sagents/tool/test_mcp_tool_schema_display.py
+++ b/tests/sagents/tool/test_mcp_tool_schema_display.py
@@ -80,6 +80,47 @@ class TestMcpToolSchemaDisplay(unittest.TestCase):
         self.assertNotIn("anyOf", params["properties"]["count"])
         self.assertFalse(tm.get_openai_tools()[0]["function"]["strict"])
 
+    def test_display_schema_uses_requested_language_for_descriptions(self):
+        tm = ToolManager(is_auto_discover=False, isolated=True)
+        tm.tools = {}
+
+        input_schema = {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query.",
+                    "description_i18n": {
+                        "zh": "搜索关键词。",
+                        "en": "Search query.",
+                    },
+                },
+            },
+            "required": ["query"],
+        }
+        tool = McpToolSpec(
+            name="web_search",
+            description="Search the web",
+            description_i18n={
+                "zh": "搜索网页",
+                "en": "Search the web",
+            },
+            func=None,
+            parameters=input_schema["properties"],
+            required=input_schema["required"],
+            server_name="search",
+            server_params=StreamableHttpServerParameters(url="http://example.invalid/mcp"),
+            input_schema=input_schema,
+        )
+        tm.tools[tool.name] = tool
+
+        display_tool = tm.list_tools_with_type(lang="zh", fallback_chain=["en"])[0]
+
+        self.assertEqual(display_tool["description"], "搜索网页")
+        self.assertEqual(display_tool["parameters"]["query"]["description"], "搜索关键词。")
+        self.assertEqual(display_tool["input_schema"]["properties"]["query"]["description"], "搜索关键词。")
+        self.assertEqual(display_tool["input_schema"]["required"], ["query"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- pass page/request language through desktop and server tool list routes
- localize tool detail parameter descriptions while preserving display schema shape
- fix desktop ToolDetail schema helper initialization order

## Verification
- .venv/bin/pytest tests/sagents/tool/test_mcp_tool_schema_display.py
- npm run build in app/desktop/ui
- npm run build in app/server/web
- git diff --check