### PR TITLE
Feat/mcp tool i18n

### DIFF
--- a/app/server/routers/kdb.py
+++ b/app/server/routers/kdb.py
@@ -349,7 +349,31 @@ async def kdb_doc_task_redo(req: KdbDocTaskRedoRequest, http_request: Request):
     return await Response.succ(data=SuccessResponse(success=True, user_id=kdb.user_id))
 
 
-@sage_mcp_tool(server_name="knowledge_base")
+@sage_mcp_tool(
+    server_name="knowledge_base",
+    description_i18n={
+        "zh": "在 ZavixAI 知识库中检索文档，并返回与查询最相关的结果。",
+        "en": "Search documents in the ZavixAI knowledge database and return the most relevant results for the query.",
+        "pt": "Pesquisa documentos na base de conhecimento ZavixAI e retorna os resultados mais relevantes para a consulta.",
+    },
+    param_description_i18n={
+        "index_name": {
+            "zh": "要检索的知识库索引名称，必填。",
+            "en": "Name of the knowledge base index to search. Required.",
+            "pt": "Nome do índice da base de conhecimento a pesquisar. Obrigatório.",
+        },
+        "query": {
+            "zh": "检索查询内容，必填。",
+            "en": "Search query. Required.",
+            "pt": "Consulta de pesquisa. Obrigatória.",
+        },
+        "top_k": {
+            "zh": "返回结果数量，范围 1 到 50，默认 5。",
+            "en": "Number of results to return, from 1 to 50. Defaults to 5.",
+            "pt": "Número de resultados a retornar, de 1 a 50. O padrão é 5.",
+        },
+    },
+)
 async def retrieve_on_zavixai_db(index_name: str, query: str, top_k: int = 5):
     """
     Search documents on ZavixAI knowledge database.

--- a/app/server/web/src/views/AgentList.vue
+++ b/app/server/web/src/views/AgentList.vue
@@ -402,7 +402,7 @@ const agentToExport = ref(null)
 const showAuthModal = ref(false)
 const authAgentId = ref('')
 
-const { t, isZhCN } = useLanguage()
+const { t, isZhCN, language } = useLanguage()
 const route = useRoute()
 const currentUser = ref(getCurrentUser())
 const agentEditStore = useAgentEditStore()
@@ -412,6 +412,10 @@ watch(() => route.query.refresh, () => {
   if (currentView.value !== 'list') {
     handleBackToList()
   }
+})
+
+watch(language, () => {
+  loadAvailableTools()
 })
 
 const canEdit = (agent) => {
@@ -432,6 +436,10 @@ const handleToolsUpdated = () => {
   loadAvailableTools()
 }
 
+const getToolListLanguage = () => {
+  return language.value === 'enUS' ? 'en' : 'zh'
+}
+
 onMounted(async () => {
   await loadAgents()
   await loadModelProviders()
@@ -448,7 +456,7 @@ onUnmounted(() => {
 const loadAvailableTools = async () => {
   try {
     loading.value = true
-    const response = await toolAPI.getTools()
+    const response = await toolAPI.getTools({ language: getToolListLanguage() })
     if (response.tools) {
       tools.value = response.tools
     }

--- a/mcp_servers/im_server/im_server.py
+++ b/mcp_servers/im_server/im_server.py
@@ -265,7 +265,36 @@ async def _send_file_via_provider(
 
 
 @mcp.tool()
-@sage_mcp_tool(server_name="IM Service")
+@sage_mcp_tool(
+    server_name="IM Service",
+    description_i18n={
+        "zh": "发送本地文件给 IM 用户或群聊。支持企业微信、钉钉、飞书。重要：agent_id 必填，必须使用当前对话关联的 Agent ID。",
+        "en": "Send a local file to an IM user or group chat. Supports WeChat Work, DingTalk and Feishu. Important: agent_id is required and must be the agent ID bound to the current conversation.",
+        "pt": "Envia um arquivo local para um usuário ou grupo de IM. Suporta WeChat Work, DingTalk e Feishu. Importante: agent_id é obrigatório e deve ser o ID do agente vinculado à conversa atual.",
+    },
+    param_description_i18n={
+        "file_path": {
+            "zh": "本地文件路径，例如 '/path/to/document.pdf'。",
+            "en": "Local file path, e.g. '/path/to/document.pdf'.",
+            "pt": "Caminho do arquivo local, por exemplo '/path/to/document.pdf'.",
+        },
+        "provider": {
+            "zh": "IM 平台名称，可选值：wechat_work（企业微信）、feishu（飞书）、dingtalk（钉钉）。",
+            "en": "IM platform name. Values: wechat_work, feishu, dingtalk.",
+            "pt": "Nome da plataforma de IM. Valores: wechat_work, feishu, dingtalk.",
+        },
+        "agent_id": {
+            "zh": "必填。Agent 标识，必须使用系统提示中提供的当前 Agent ID，不要省略或自行编造。",
+            "en": "Required. Agent identifier; must be the current agent ID provided in the system prompt. Do not omit or fabricate it.",
+            "pt": "Obrigatório. Identificador do agente; deve ser o ID do agente atual fornecido no prompt do sistema. Não omita nem invente.",
+        },
+        "chat_id": {
+            "zh": "群聊 ID。需要发送到群聊时填写；chat_id 与私聊接收方至少提供一个。",
+            "en": "Group chat ID. Provide this when sending to a group chat; provide at least one group chat ID or private recipient.",
+            "pt": "ID do chat em grupo. Use ao enviar para um grupo; forneça pelo menos um ID de grupo ou destinatário privado.",
+        },
+    },
+)
 async def send_file_through_im(
     file_path: str,
     provider: str,
@@ -335,7 +364,36 @@ async def send_file_through_im(
 
 
 @mcp.tool()
-@sage_mcp_tool(server_name="IM Service")
+@sage_mcp_tool(
+    server_name="IM Service",
+    description_i18n={
+        "zh": "发送本地图片给 IM 用户或群聊，图片会以图片消息形式显示。支持企业微信、钉钉、飞书。重要：agent_id 必填，必须使用当前对话关联的 Agent ID。",
+        "en": "Send a local image to an IM user or group chat as an image message. Supports WeChat Work, DingTalk and Feishu. Important: agent_id is required and must be the agent ID bound to the current conversation.",
+        "pt": "Envia uma imagem local para um usuário ou grupo de IM como mensagem de imagem. Suporta WeChat Work, DingTalk e Feishu. Importante: agent_id é obrigatório e deve ser o ID do agente vinculado à conversa atual.",
+    },
+    param_description_i18n={
+        "file_path": {
+            "zh": "本地图片路径，例如 '/path/to/image.png'。支持 JPG、PNG、GIF、BMP、WebP。",
+            "en": "Local image path, e.g. '/path/to/image.png'. Supports JPG, PNG, GIF, BMP and WebP.",
+            "pt": "Caminho da imagem local, por exemplo '/path/to/image.png'. Suporta JPG, PNG, GIF, BMP e WebP.",
+        },
+        "provider": {
+            "zh": "IM 平台名称，可选值：wechat_work（企业微信）、dingtalk（钉钉）、feishu（飞书）。",
+            "en": "IM platform name. Values: wechat_work, dingtalk, feishu.",
+            "pt": "Nome da plataforma de IM. Valores: wechat_work, dingtalk, feishu.",
+        },
+        "agent_id": {
+            "zh": "必填。Agent 标识，必须使用系统提示中提供的当前 Agent ID，不要省略或自行编造。",
+            "en": "Required. Agent identifier; must be the current agent ID provided in the system prompt. Do not omit or fabricate it.",
+            "pt": "Obrigatório. Identificador do agente; deve ser o ID do agente atual fornecido no prompt do sistema. Não omita nem invente.",
+        },
+        "chat_id": {
+            "zh": "群聊 ID。需要发送到群聊时填写；chat_id 与私聊接收方至少提供一个。",
+            "en": "Group chat ID. Provide this when sending to a group chat; provide at least one group chat ID or private recipient.",
+            "pt": "ID do chat em grupo. Use ao enviar para um grupo; forneça pelo menos um ID de grupo ou destinatário privado.",
+        },
+    },
+)
 async def send_image_through_im(
     file_path: str,
     provider: str,
@@ -475,7 +533,36 @@ async def _send_message_to_agent(
 
 
 @mcp.tool()
-@sage_mcp_tool(server_name="IM Service")
+@sage_mcp_tool(
+    server_name="IM Service",
+    description_i18n={
+        "zh": "向 IM 用户或群聊发送文本消息。支持飞书、钉钉、企业微信、iMessage。重要：agent_id 必填，必须使用当前对话关联的 Agent ID。多条消息会自动按顺序发送。",
+        "en": "Send a text message to an IM user or group chat. Supports Feishu, DingTalk, WeChat Work and iMessage. Important: agent_id is required and must be the agent ID bound to the current conversation. Multiple messages are sent in order automatically.",
+        "pt": "Envia uma mensagem de texto para um usuário ou grupo de IM. Suporta Feishu, DingTalk, WeChat Work e iMessage. Importante: agent_id é obrigatório e deve ser o ID do agente vinculado à conversa atual. Várias mensagens são enviadas em ordem automaticamente.",
+    },
+    param_description_i18n={
+        "content": {
+            "zh": "要发送的消息内容。",
+            "en": "Message content to send.",
+            "pt": "Conteúdo da mensagem a enviar.",
+        },
+        "provider": {
+            "zh": "IM 平台名称，可选值：feishu（飞书）、dingtalk（钉钉）、wechat_work（企业微信）、imessage。",
+            "en": "IM platform name. Values: feishu, dingtalk, wechat_work, imessage.",
+            "pt": "Nome da plataforma de IM. Valores: feishu, dingtalk, wechat_work, imessage.",
+        },
+        "agent_id": {
+            "zh": "必填。Agent 标识，必须使用系统提示中提供的当前 Agent ID，不要省略或自行编造。",
+            "en": "Required. Agent identifier; must be the current agent ID provided in the system prompt. Do not omit or fabricate it.",
+            "pt": "Obrigatório. Identificador do agente; deve ser o ID do agente atual fornecido no prompt do sistema. Não omita nem invente.",
+        },
+        "chat_id": {
+            "zh": "群聊 ID。需要发送到群聊时填写；chat_id 与私聊接收方至少提供一个。",
+            "en": "Group chat ID. Provide this when sending to a group chat; provide at least one group chat ID or private recipient.",
+            "pt": "ID do chat em grupo. Use ao enviar para um grupo; forneça pelo menos um ID de grupo ou destinatário privado.",
+        },
+    },
+)
 async def send_message_through_im(
     content: str,
     provider: str,

--- a/mcp_servers/image_generation/unified_image_generation_server.py
+++ b/mcp_servers/image_generation/unified_image_generation_server.py
@@ -268,7 +268,36 @@ async def generate_image_impl(
     name="generate_image",
     description="根据文本描述生成图片。支持参考图生成（保持人物一致性）。自动选择可用的提供商。"
 )
-@sage_mcp_tool(server_name="unified_image_generation_server")
+@sage_mcp_tool(
+    server_name="unified_image_generation_server",
+    description_i18n={
+        "zh": "根据文本描述生成图片。支持使用参考图生成风格一致或人物一致的图片，并会自动选择当前可用的图片生成提供商。",
+        "en": "Generate an image from a text prompt. Supports reference images for style or character consistency and automatically selects an available image generation provider.",
+        "pt": "Gera uma imagem a partir de um prompt de texto. Suporta imagens de referência para consistência de estilo ou personagem e seleciona automaticamente um provedor de geração de imagens disponível.",
+    },
+    param_description_i18n={
+        "prompt": {
+            "zh": "图片描述提示词，必填。建议详细描述场景、风格、人物、光线、构图等。",
+            "en": "Image prompt. Required. Describe the scene, style, characters, lighting, composition and other details.",
+            "pt": "Prompt da imagem. Obrigatório. Descreva a cena, estilo, personagens, iluminação, composição e outros detalhes.",
+        },
+        "aspect_ratio": {
+            "zh": "图片宽高比，默认 1:1。可选值：1:1、16:9、4:3、3:2、2:3、9:16。",
+            "en": "Image aspect ratio. Defaults to 1:1. Values: 1:1, 16:9, 4:3, 3:2, 2:3, 9:16.",
+            "pt": "Proporção da imagem. O padrão é 1:1. Valores: 1:1, 16:9, 4:3, 3:2, 2:3, 9:16.",
+        },
+        "reference_image": {
+            "zh": "参考图 URL，可选。提供后可用于生成风格一致或人物一致的图片。",
+            "en": "Optional reference image URL. Use it to generate images with consistent style or character identity.",
+            "pt": "URL opcional da imagem de referência. Use para gerar imagens com estilo ou identidade de personagem consistentes.",
+        },
+        "output_path": {
+            "zh": "图片保存路径，可选。提供后图片会保存到该路径；否则返回 base64 编码的图片数据。",
+            "en": "Optional output path. If provided, the image is saved there; otherwise base64-encoded image data is returned.",
+            "pt": "Caminho de saída opcional. Se informado, a imagem será salva nesse caminho; caso contrário, os dados da imagem em base64 serão retornados.",
+        },
+    },
+)
 async def generate_image(
     prompt: str,
     aspect_ratio: str = "1:1",

--- a/mcp_servers/search/unified_search_server.py
+++ b/mcp_servers/search/unified_search_server.py
@@ -222,7 +222,31 @@ async def search_images(
     name="search_web_page",
     description="搜索网页内容。支持多个搜索引擎，自动选择可用的引擎。"
 )
-@sage_mcp_tool(server_name="unified_search_server")
+@sage_mcp_tool(
+    server_name="unified_search_server",
+    description_i18n={
+        "zh": "搜索网页内容。支持多个搜索引擎，并会自动选择当前可用的搜索引擎。",
+        "en": "Search web pages. Supports multiple search engines and automatically selects an available provider.",
+        "pt": "Pesquise páginas da web. Suporta vários mecanismos de busca e seleciona automaticamente um provedor disponível.",
+    },
+    param_description_i18n={
+        "query": {
+            "zh": "搜索查询词，必填。",
+            "en": "Search query. Required.",
+            "pt": "Consulta de pesquisa. Obrigatória.",
+        },
+        "count": {
+            "zh": "返回结果数量，默认 10，最大 100。",
+            "en": "Number of results to return. Defaults to 10, maximum 100.",
+            "pt": "Número de resultados a retornar. O padrão é 10, máximo 100.",
+        },
+        "time_range": {
+            "zh": "时间范围筛选，可选值：day、week、month、year；空字符串表示不限时间。",
+            "en": "Optional time range filter. Values: day, week, month, year. Empty string means no time limit.",
+            "pt": "Filtro opcional de intervalo de tempo. Valores: day, week, month, year. String vazia significa sem limite de tempo.",
+        },
+    },
+)
 async def search_web_page(
     query: str,
     count: int = 10,
@@ -271,7 +295,31 @@ async def search_web_page(
     name="search_image_from_web",
     description="搜索网络图片。支持多个搜索引擎，自动选择可用的引擎。"
 )
-@sage_mcp_tool(server_name="unified_search_server")
+@sage_mcp_tool(
+    server_name="unified_search_server",
+    description_i18n={
+        "zh": "搜索网络图片。支持多个图片搜索引擎，并会自动选择当前可用的搜索引擎。",
+        "en": "Search images on the web. Supports multiple image search engines and automatically selects an available provider.",
+        "pt": "Pesquise imagens na web. Suporta vários mecanismos de busca de imagens e seleciona automaticamente um provedor disponível.",
+    },
+    param_description_i18n={
+        "query": {
+            "zh": "图片搜索查询词，必填。",
+            "en": "Image search query. Required.",
+            "pt": "Consulta de pesquisa de imagens. Obrigatória.",
+        },
+        "count": {
+            "zh": "返回图片结果数量，默认 10，最大 100。",
+            "en": "Number of image results to return. Defaults to 10, maximum 100.",
+            "pt": "Número de resultados de imagem a retornar. O padrão é 10, máximo 100.",
+        },
+        "time_range": {
+            "zh": "时间范围筛选，可选值：day、week、month、year；空字符串表示不限时间。",
+            "en": "Optional time range filter. Values: day, week, month, year. Empty string means no time limit.",
+            "pt": "Filtro opcional de intervalo de tempo. Valores: day, week, month, year. String vazia significa sem limite de tempo.",
+        },
+    },
+)
 async def search_image_from_web(
     query: str,
     count: int = 10,

--- a/mcp_servers/task_scheduler/task_scheduler_server.py
+++ b/mcp_servers/task_scheduler/task_scheduler_server.py
@@ -507,7 +507,41 @@ def ensure_scheduler_started() -> bool:
 # --- MCP Tools ---
 
 @mcp.tool()
-@sage_mcp_tool(server_name="task_scheduler")
+@sage_mcp_tool(
+    server_name="task_scheduler",
+    description_i18n={
+        "zh": "从任务调度器中列出任务，支持按任务类型、状态、计划时间范围和数量限制筛选。",
+        "en": "List tasks from the task scheduler with filters for task type, status, scheduled time range and result limit.",
+        "pt": "Lista tarefas do agendador com filtros por tipo de tarefa, status, intervalo de horário agendado e limite de resultados.",
+    },
+    param_description_i18n={
+        "task_type": {
+            "zh": "要列出的任务类型。可选值：once（一次性任务，支持状态和时间筛选）、recurring（循环任务模板）、all（两者都包含）。默认 once。",
+            "en": "Task type to list. Values: once (one-time tasks, supports status and time filters), recurring (recurring templates), all (both). Defaults to once.",
+            "pt": "Tipo de tarefa a listar. Valores: once (tarefas únicas, com filtros de status e tempo), recurring (modelos recorrentes), all (ambos). O padrão é once.",
+        },
+        "status": {
+            "zh": "按状态筛选一次性任务。可选值：pending、processing、completed、failed。仅对一次性任务生效。",
+            "en": "Filter one-time tasks by status. Values: pending, processing, completed, failed. Applies only to one-time tasks.",
+            "pt": "Filtra tarefas únicas por status. Valores: pending, processing, completed, failed. Aplica-se apenas a tarefas únicas.",
+        },
+        "scheduled_after": {
+            "zh": "筛选计划时间晚于此时间的一次性任务。优先使用带时区偏移的 ISO 8601，例如 '2026-04-13T18:37:42+08:00'；未带偏移时按当前会话本地时区解释。",
+            "en": "Filter one-time tasks scheduled after this time. Prefer ISO 8601 with timezone offset, e.g. '2026-04-13T18:37:42+08:00'. If no offset is provided, it is interpreted in the current session's local timezone.",
+            "pt": "Filtra tarefas únicas agendadas após este horário. Prefira ISO 8601 com fuso horário, por exemplo '2026-04-13T18:37:42+08:00'. Sem deslocamento, será interpretado no fuso local da sessão atual.",
+        },
+        "scheduled_before": {
+            "zh": "筛选计划时间早于此时间的一次性任务。优先使用带时区偏移的 ISO 8601，例如 '2026-04-13T18:37:42+08:00'；未带偏移时按当前会话本地时区解释。",
+            "en": "Filter one-time tasks scheduled before this time. Prefer ISO 8601 with timezone offset, e.g. '2026-04-13T18:37:42+08:00'. If no offset is provided, it is interpreted in the current session's local timezone.",
+            "pt": "Filtra tarefas únicas agendadas antes deste horário. Prefira ISO 8601 com fuso horário, por exemplo '2026-04-13T18:37:42+08:00'. Sem deslocamento, será interpretado no fuso local da sessão atual.",
+        },
+        "limit": {
+            "zh": "最多返回的任务数量，默认 50。",
+            "en": "Maximum number of tasks to return. Defaults to 50.",
+            "pt": "Número máximo de tarefas a retornar. O padrão é 50.",
+        },
+    },
+)
 async def list_tasks(
     task_type: str = "once",
     status: Optional[str] = None,
@@ -628,7 +662,41 @@ async def list_tasks(
 
 
 @mcp.tool()
-@sage_mcp_tool(server_name="task_scheduler")
+@sage_mcp_tool(
+    server_name="task_scheduler",
+    description_i18n={
+        "zh": "添加新任务到调度器。可创建一次性任务或循环任务；时间必须按当前会话本地时区理解，不要主动改写为 UTC。",
+        "en": "Add a new task to the scheduler. Creates either a one-time task or a recurring task; time values must be interpreted in the current session's local timezone and should not be rewritten to UTC.",
+        "pt": "Adiciona uma nova tarefa ao agendador. Cria uma tarefa única ou recorrente; horários devem ser interpretados no fuso local da sessão atual e não devem ser reescritos para UTC.",
+    },
+    param_description_i18n={
+        "name": {
+            "zh": "任务名称或标题。",
+            "en": "Task name or title.",
+            "pt": "Nome ou título da tarefa.",
+        },
+        "description": {
+            "zh": "单次执行的具体任务描述，说明这次要做什么。循环任务也应写单次执行内容，不要写“每天执行”这类循环信息。",
+            "en": "Concrete description of one execution: what should be done this time. For recurring tasks, describe one run, not recurrence text such as 'run every day'.",
+            "pt": "Descrição concreta de uma execução: o que deve ser feito desta vez. Para tarefas recorrentes, descreva uma execução, não textos de recorrência como 'executar todos os dias'.",
+        },
+        "agent_id": {
+            "zh": "执行此任务的 Agent ID。",
+            "en": "Agent ID that will execute this task.",
+            "pt": "ID do agente que executará esta tarefa.",
+        },
+        "schedule": {
+            "zh": "任务计划。一次性任务：执行时间，优先使用带时区偏移的 ISO 8601，例如 '2026-04-13T18:37:42+08:00'；未带偏移时按当前会话本地时区解释。循环任务：cron 表达式，例如 '0 9 * * *'。",
+            "en": "Task schedule. For one-time tasks: execution time, preferably ISO 8601 with timezone offset, e.g. '2026-04-13T18:37:42+08:00'; without an offset, interpret it in the current session's local timezone. For recurring tasks: cron expression, e.g. '0 9 * * *'.",
+            "pt": "Agendamento da tarefa. Para tarefas únicas: horário de execução, de preferência ISO 8601 com fuso horário, por exemplo '2026-04-13T18:37:42+08:00'; sem deslocamento, interprete no fuso local da sessão atual. Para tarefas recorrentes: expressão cron, por exemplo '0 9 * * *'.",
+        },
+        "is_recurring": {
+            "zh": "是否创建循环任务。False 表示一次性任务，True 表示循环任务。默认 False。",
+            "en": "Whether to create a recurring task. False means one-time task, True means recurring task. Defaults to False.",
+            "pt": "Se deve criar uma tarefa recorrente. False significa tarefa única, True significa tarefa recorrente. O padrão é False.",
+        },
+    },
+)
 async def add_task(
     name: str,
     description: str,
@@ -734,7 +802,21 @@ async def add_task(
 
 
 @mcp.tool()
-@sage_mcp_tool(server_name="task_scheduler")
+@sage_mcp_tool(
+    server_name="task_scheduler",
+    description_i18n={
+        "zh": "从调度器中删除任务。一次性任务会连同执行历史一起删除；循环任务会删除模板和所有待执行实例。此操作不可撤销。",
+        "en": "Delete a task from the scheduler. One-time tasks are removed with their execution history; recurring tasks remove the template and all pending instances. This action cannot be undone.",
+        "pt": "Remove uma tarefa do agendador. Tarefas únicas são removidas com o histórico de execução; tarefas recorrentes removem o modelo e todas as instâncias pendentes. Esta ação não pode ser desfeita.",
+    },
+    param_description_i18n={
+        "task_id": {
+            "zh": "要删除的任务 ID，例如 'once_123' 或 'rec_456'。",
+            "en": "ID of the task to delete, e.g. 'once_123' or 'rec_456'.",
+            "pt": "ID da tarefa a excluir, por exemplo 'once_123' ou 'rec_456'.",
+        },
+    },
+)
 async def delete_task(task_id: str, user_id: Optional[str] = None) -> str:
     """
     Delete a task from the scheduler.
@@ -789,7 +871,21 @@ async def delete_task(task_id: str, user_id: Optional[str] = None) -> str:
 
 
 @mcp.tool()
-@sage_mcp_tool(server_name="task_scheduler")
+@sage_mcp_tool(
+    server_name="task_scheduler",
+    description_i18n={
+        "zh": "手动将任务标记为完成。一次性任务会更新为 completed；循环任务会更新最近执行时间。",
+        "en": "Manually mark a task as completed. One-time tasks are updated to completed; recurring tasks update their last executed time.",
+        "pt": "Marca manualmente uma tarefa como concluída. Tarefas únicas são atualizadas para completed; tarefas recorrentes atualizam o último horário de execução.",
+    },
+    param_description_i18n={
+        "task_id": {
+            "zh": "要标记完成的任务 ID，例如 'once_123' 或 'rec_456'。",
+            "en": "ID of the task to mark as completed, e.g. 'once_123' or 'rec_456'.",
+            "pt": "ID da tarefa a marcar como concluída, por exemplo 'once_123' ou 'rec_456'.",
+        },
+    },
+)
 async def complete_task(task_id: str, user_id: Optional[str] = None) -> str:
     """
     Mark a task as completed manually.
@@ -852,7 +948,26 @@ async def complete_task(task_id: str, user_id: Optional[str] = None) -> str:
 
 
 @mcp.tool()
-@sage_mcp_tool(server_name="task_scheduler")
+@sage_mcp_tool(
+    server_name="task_scheduler",
+    description_i18n={
+        "zh": "启用或禁用循环任务。仅适用于 rec_* 循环任务；禁用后不会再生成新的待执行实例。",
+        "en": "Enable or disable a recurring task. Applies only to rec_* tasks; disabled recurring tasks will not spawn new pending instances.",
+        "pt": "Ativa ou desativa uma tarefa recorrente. Aplica-se apenas a tarefas rec_*; tarefas recorrentes desativadas não criarão novas instâncias pendentes.",
+    },
+    param_description_i18n={
+        "task_id": {
+            "zh": "循环任务 ID，例如 'rec_456'。",
+            "en": "Recurring task ID, e.g. 'rec_456'.",
+            "pt": "ID da tarefa recorrente, por exemplo 'rec_456'.",
+        },
+        "enabled": {
+            "zh": "True 表示启用循环任务，False 表示禁用循环任务。默认 True。",
+            "en": "True enables the recurring task; False disables it. Defaults to True.",
+            "pt": "True ativa a tarefa recorrente; False a desativa. O padrão é True.",
+        },
+    },
+)
 async def enable_task(task_id: str, enabled: bool = True, user_id: Optional[str] = None) -> str:
     """
     Enable or disable a recurring task.
@@ -906,7 +1021,21 @@ async def enable_task(task_id: str, enabled: bool = True, user_id: Optional[str]
 
 
 @mcp.tool()
-@sage_mcp_tool(server_name="task_scheduler")
+@sage_mcp_tool(
+    server_name="task_scheduler",
+    description_i18n={
+        "zh": "获取指定任务的详细信息。一次性任务会返回任务详情和执行历史；循环任务会返回循环任务模板详情。",
+        "en": "Get detailed information for a specific task. One-time tasks return task details and execution history; recurring tasks return template details.",
+        "pt": "Obtém informações detalhadas de uma tarefa específica. Tarefas únicas retornam detalhes e histórico de execução; tarefas recorrentes retornam detalhes do modelo.",
+    },
+    param_description_i18n={
+        "task_id": {
+            "zh": "要查询的任务 ID，例如 'once_123' 或 'rec_456'。",
+            "en": "ID of the task to retrieve, e.g. 'once_123' or 'rec_456'.",
+            "pt": "ID da tarefa a recuperar, por exemplo 'once_123' ou 'rec_456'.",
+        },
+    },
+)
 async def get_task_details(task_id: str, user_id: Optional[str] = None) -> str:
     """
     Get detailed information about a specific task.
@@ -988,7 +1117,51 @@ async def get_task_details(task_id: str, user_id: Optional[str] = None) -> str:
 
 
 @mcp.tool()
-@sage_mcp_tool(server_name="task_scheduler")
+@sage_mcp_tool(
+    server_name="task_scheduler",
+    description_i18n={
+        "zh": "更新调度器中的已有任务。一次性任务可更新名称、描述、执行 Agent、执行时间或最大重试次数；循环任务可更新名称、描述、执行 Agent、cron 表达式或启用状态。只会更新提供的字段。",
+        "en": "Update an existing scheduler task. One-time tasks can update name, description, agent, execution time or max retries; recurring tasks can update name, description, agent, cron expression or enabled state. Only provided fields are changed.",
+        "pt": "Atualiza uma tarefa existente no agendador. Tarefas únicas podem atualizar nome, descrição, agente, horário de execução ou máximo de tentativas; tarefas recorrentes podem atualizar nome, descrição, agente, expressão cron ou estado ativo. Somente campos fornecidos são alterados.",
+    },
+    param_description_i18n={
+        "task_id": {
+            "zh": "要更新的任务 ID，例如 'once_123' 或 'rec_456'。",
+            "en": "ID of the task to update, e.g. 'once_123' or 'rec_456'.",
+            "pt": "ID da tarefa a atualizar, por exemplo 'once_123' ou 'rec_456'.",
+        },
+        "name": {
+            "zh": "新的任务名称或标题，可选。",
+            "en": "New task name or title. Optional.",
+            "pt": "Novo nome ou título da tarefa. Opcional.",
+        },
+        "description": {
+            "zh": "新的任务描述，可选。对于循环任务，仍应描述单次执行内容。",
+            "en": "New task description. Optional. For recurring tasks, still describe one execution.",
+            "pt": "Nova descrição da tarefa. Opcional. Para tarefas recorrentes, ainda descreva uma execução.",
+        },
+        "agent_id": {
+            "zh": "新的执行 Agent ID，可选。",
+            "en": "New agent ID to execute the task. Optional.",
+            "pt": "Novo ID do agente que executará a tarefa. Opcional.",
+        },
+        "schedule": {
+            "zh": "新的计划时间，可选。一次性任务优先使用带时区偏移的 ISO 8601，例如 '2026-04-13T18:37:42+08:00'；未带偏移时按当前会话本地时区解释。循环任务使用 cron 表达式。",
+            "en": "New schedule. Optional. For one-time tasks, prefer ISO 8601 with timezone offset, e.g. '2026-04-13T18:37:42+08:00'; without an offset, interpret it in the current session's local timezone. For recurring tasks, use a cron expression.",
+            "pt": "Novo agendamento. Opcional. Para tarefas únicas, prefira ISO 8601 com fuso horário, por exemplo '2026-04-13T18:37:42+08:00'; sem deslocamento, interprete no fuso local da sessão atual. Para tarefas recorrentes, use uma expressão cron.",
+        },
+        "enabled": {
+            "zh": "是否启用循环任务，可选。仅适用于循环任务。",
+            "en": "Whether the recurring task is enabled. Optional. Applies only to recurring tasks.",
+            "pt": "Se a tarefa recorrente está ativa. Opcional. Aplica-se apenas a tarefas recorrentes.",
+        },
+        "max_retries": {
+            "zh": "新的最大重试次数，可选。仅适用于一次性任务。",
+            "en": "New maximum retry count. Optional. Applies only to one-time tasks.",
+            "pt": "Novo número máximo de tentativas. Opcional. Aplica-se apenas a tarefas únicas.",
+        },
+    },
+)
 async def update_task(
     task_id: str,
     name: Optional[str] = None,

--- a/tests/sagents/tool/impl/test_execute_shell_integration.py
+++ b/tests/sagents/tool/impl/test_execute_shell_integration.py
@@ -17,6 +17,10 @@ from sagents.utils.sandbox.config import VolumeMount
 from sagents.utils.sandbox.providers.passthrough.passthrough import PassthroughSandboxProvider
 
 
+def _same_real_path(left: str, right: str) -> bool:
+    return os.path.realpath(left) == os.path.realpath(right)
+
+
 pytestmark = [
     pytest.mark.skipif(
         shutil.which("bash") is None,
@@ -148,7 +152,7 @@ async def test_await_shell_reads_running_task_tail_from_agent_workspace_bg_log(s
     task_id = started["task_id"]
     expected_output_file = os.path.join(tmpdir, "bg", f"{task_id}.log")
     assert started["status"] == "running"
-    assert started["output_file"] == expected_output_file
+    assert _same_real_path(started["output_file"], expected_output_file)
     assert os.path.exists(expected_output_file)
 
     monitored = await tool.await_shell(
@@ -158,7 +162,7 @@ async def test_await_shell_reads_running_task_tail_from_agent_workspace_bg_log(s
         session_id="s1",
     )
     assert monitored["status"] == "running"
-    assert monitored["output_file"] == expected_output_file
+    assert _same_real_path(monitored["output_file"], expected_output_file)
     assert "phase1" in monitored["tail_output"]
     assert "phase2" not in monitored["tail_output"]
 
@@ -176,7 +180,7 @@ async def test_await_shell_reads_completed_stdout_from_agent_workspace_bg_log(sh
     task_id = started["task_id"]
     expected_output_file = os.path.join(tmpdir, "bg", f"{task_id}.log")
     assert started["status"] == "running"
-    assert started["output_file"] == expected_output_file
+    assert _same_real_path(started["output_file"], expected_output_file)
 
     completed = await tool.await_shell(
         task_id=task_id,
@@ -186,9 +190,9 @@ async def test_await_shell_reads_completed_stdout_from_agent_workspace_bg_log(sh
     final_output_file = completed["output_file"]
     assert completed["status"] == "completed"
     assert completed["exit_code"] == 0
-    assert final_output_file == expected_output_file
+    assert _same_real_path(final_output_file, expected_output_file)
     assert os.path.isabs(final_output_file)
-    assert os.path.dirname(final_output_file) == os.path.join(tmpdir, "bg")
+    assert _same_real_path(os.path.dirname(final_output_file), os.path.join(tmpdir, "bg"))
     assert os.path.basename(final_output_file) == f"{task_id}.log"
     assert "phase1" in completed["stdout"]
     assert "phase2" in completed["stdout"]
@@ -219,8 +223,8 @@ async def test_background_log_dir_virtual_workspace_is_restored_to_host_path(mon
         task_id = started["task_id"]
         expected_host_output_file = os.path.join(host_tmpdir, "bg", f"{task_id}.log")
 
-        assert started["output_file"] == expected_host_output_file
-        assert os.path.dirname(started["output_file"]) == os.path.join(host_tmpdir, "bg")
+        assert _same_real_path(started["output_file"], expected_host_output_file)
+        assert _same_real_path(os.path.dirname(started["output_file"]), os.path.join(host_tmpdir, "bg"))
         assert not started["output_file"].startswith(sandbox_workspace)
 
         completed = await tool.await_shell(
@@ -229,7 +233,7 @@ async def test_background_log_dir_virtual_workspace_is_restored_to_host_path(mon
             session_id="s1",
         )
         assert completed["status"] == "completed"
-        assert completed["output_file"] == expected_host_output_file
+        assert _same_real_path(completed["output_file"], expected_host_output_file)
         with open(completed["output_file"], encoding="utf-8") as log_file:
             assert "mapped-log" in log_file.read()
     finally:

--- a/tests/sagents/tool/test_mcp_tool_schema_display.py
+++ b/tests/sagents/tool/test_mcp_tool_schema_display.py
@@ -1,7 +1,7 @@
 import unittest
 
 from sagents.tool.tool_manager import ToolManager
-from sagents.tool.tool_schema import McpToolSpec, StreamableHttpServerParameters
+from sagents.tool.tool_schema import McpToolSpec, SageMcpToolSpec, StreamableHttpServerParameters
 
 
 class TestMcpToolSchemaDisplay(unittest.TestCase):
@@ -120,6 +120,57 @@ class TestMcpToolSchemaDisplay(unittest.TestCase):
         self.assertEqual(display_tool["parameters"]["query"]["description"], "搜索关键词。")
         self.assertEqual(display_tool["input_schema"]["properties"]["query"]["description"], "搜索关键词。")
         self.assertEqual(display_tool["input_schema"]["required"], ["query"])
+
+    def test_sage_mcp_tool_i18n_reaches_openai_schema(self):
+        tm = ToolManager(is_auto_discover=False, isolated=True)
+        tm.tools = {}
+
+        tool = SageMcpToolSpec(
+            name="send_message_through_im",
+            description="Send message fallback.",
+            description_i18n={
+                "zh": "发送 IM 消息。",
+                "en": "Send an IM message.",
+                "pt": "Envia uma mensagem de IM.",
+            },
+            func=None,
+            parameters={
+                "content": {"type": "string", "description": "Message content."},
+                "provider": {"type": "string", "description": "Provider name."},
+                "session_id": {"type": "string", "description": "Session ID."},
+                "user_id": {"type": "string", "description": "User ID."},
+            },
+            required=["content", "provider", "session_id", "user_id"],
+            param_description_i18n={
+                "content": {
+                    "zh": "要发送的消息内容。",
+                    "en": "Message content to send.",
+                    "pt": "Conteúdo da mensagem a enviar.",
+                },
+                "provider": {
+                    "zh": "IM 平台名称。",
+                    "en": "IM platform name.",
+                    "pt": "Nome da plataforma de IM.",
+                },
+            },
+            server_name="IM Service",
+        )
+        tm.tools[tool.name] = tool
+
+        fn = tm.get_openai_tools(lang="pt", fallback_chain=["en"])[0]["function"]
+        params = fn["parameters"]
+
+        self.assertEqual(fn["description"], "Envia uma mensagem de IM.")
+        self.assertEqual(
+            params["properties"]["content"]["description"],
+            "Conteúdo da mensagem a enviar.",
+        )
+        self.assertEqual(
+            params["properties"]["provider"]["description"],
+            "Nome da plataforma de IM.",
+        )
+        self.assertEqual(set(params["properties"].keys()), {"content", "provider"})
+        self.assertEqual(set(params["required"]), {"content", "provider"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 总结
- 为内置 MCP 工具补充 `zh/en/pt` 多语言描述元数据，覆盖 IM、搜索、图片生成、任务调度和知识库工具。
- 新增 Sage MCP 工具 schema 测试，验证多语言描述会进入模型使用的 OpenAI tools schema，并确保 `session_id/user_id` 仍不暴露给模型。
- 修复 Web 端 Agent 配置页语言切换后工具描述不刷新的问题，切换语言时会重新拉取工具列表。
- 修复 macOS 上 `/var` 与 `/private/var` 路径别名导致的 shell 集成测试误失败。