### PR TITLE
Fix/cadvisor api compatibility

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -44,6 +44,8 @@ deploy/compose.sh --observability up -d
 deploy/compose.sh dev --observability up -d
 ```
 
+`deploy/docker-compose.observability.yml` 中的 `sage-cadvisor` 当前默认使用 `ghcr.io/google/cadvisor:v0.57.0`，兼容 Docker Engine API `v1.40+`（按 Docker 官方 API version matrix，对应 Docker 19.03 及以上）。
+
 也可以直接指定对应 compose 文件：
 
 ```bash

--- a/deploy/docker-compose.observability.yml
+++ b/deploy/docker-compose.observability.yml
@@ -50,7 +50,6 @@ services:
       - shared
 
   sage-cadvisor:
-    # cAdvisor v0.57.0 restores Docker Engine API compatibility for v1.40+.
     image: ghcr.io/google/cadvisor:v0.57.0
     container_name: sage-cadvisor
     restart: always

--- a/deploy/docker-compose.observability.yml
+++ b/deploy/docker-compose.observability.yml
@@ -50,7 +50,8 @@ services:
       - shared
 
   sage-cadvisor:
-    image: ghcr.io/google/cadvisor:0.56.2
+    # cAdvisor v0.57.0 restores Docker Engine API compatibility for v1.40+.
+    image: ghcr.io/google/cadvisor:v0.57.0
     container_name: sage-cadvisor
     restart: always
     privileged: true


### PR DESCRIPTION
## Summary
- upgrade `sage-cadvisor` from `ghcr.io/google/cadvisor:0.56.2` to `ghcr.io/google/cadvisor:v0.57.0`
- document why `v0.57.0` is required in our observability deployment
- clarify that `v0.57.0` restores Docker Engine API compatibility for `v1.40+`

## Why
`cAdvisor 0.56.2` can fail against some local Docker / Docker Desktop setups due to a Docker API compatibility mismatch, which prevents Docker factory registration and causes missing Compose labels/metadata in metrics.

`cAdvisor v0.57.0` includes the upstream fix that restores compatibility with Docker Engine API `v1.40+`, making it suitable for environments where the Docker server API is below `1.44` but still at least `1.40`.