### PR TITLE
Unify tool argument context overrides

### DIFF
--- a/common/services/tool_service.py
+++ b/common/services/tool_service.py
@@ -136,11 +136,15 @@ async def execute_tool(
                     error_detail="Permission denied",
                 )
 
+    safe_tool_params = dict(tool_params)
+    safe_tool_params.pop("session_id", None)
+    safe_tool_params.pop("user_id", None)
+
     tool_response = await tool_manager.run_tool_async(
         tool_name=tool_name,
         session_id="",
         user_id=user_id,
-        **tool_params,
+        **safe_tool_params,
     )
     if tool_response is not None:
         logger.info(f"执行工具成功: {tool_name}")

--- a/sagents/agent/agent_base.py
+++ b/sagents/agent/agent_base.py
@@ -1555,8 +1555,9 @@ class AgentBase(ABC):
 
             # 构造调用参数，确保 session_id 正确传递且不重复
             call_kwargs = arguments.copy()
-            # 如果 arguments 中有 session_id，移除它（因为会作为显式参数传递）
+            # 如果 arguments 中有保留身份字段，移除它们（因为会作为可信上下文传递）
             call_kwargs.pop("session_id", None)
+            call_kwargs.pop("user_id", None)
 
             with _bind_tool_progress_context(session_id, tool_call["id"]):
                 try:

--- a/sagents/tool/mcp_proxy.py
+++ b/sagents/tool/mcp_proxy.py
@@ -81,25 +81,11 @@ class McpProxy:
     async def run_mcp_tool(
         self,
         tool: McpToolSpec,
-        session_id: Optional[str] = None,
-        user_id: Optional[str] = None,
+        runtime_session_id: Optional[str] = None,
+        runtime_user_id: Optional[str] = None,
         **kwargs,
     ) -> Any:
         """Run an MCP tool asynchronously"""
-        if not session_id:
-            session_id = "default"
-        # 只有当工具参数定义中包含 session_id / user_id 时才传递
-        tool_params = getattr(tool, "parameters", {}) or {}
-        is_anytool_server = getattr(tool, "server_name", "") == "AnyTool"
-        if is_anytool_server:
-            if session_id and "session_id" not in kwargs:
-                kwargs["session_id"] = session_id
-            if user_id and "user_id" not in kwargs:
-                kwargs["user_id"] = user_id
-        if "session_id" in tool_params:
-            kwargs["session_id"] = session_id
-        if user_id and "user_id" in tool_params and "user_id" not in kwargs:
-            kwargs["user_id"] = user_id
         try:
             if isinstance(tool.server_params, SseServerParameters):
                 return await self._execute_sse_mcp_tool(tool, **kwargs)

--- a/sagents/tool/tool_manager.py
+++ b/sagents/tool/tool_manager.py
@@ -1119,6 +1119,87 @@ class ToolManager:
             tools_json.sort(key=lambda t: (t.get("function") or {}).get("name") or "")
         return tools_json
 
+    def _get_declared_tool_param_names(
+        self, tool: Union[ToolSpec, McpToolSpec, SageMcpToolSpec]
+    ) -> set[str]:
+        """Collect top-level parameters that the tool declares."""
+        declared: set[str] = set()
+
+        parameters = getattr(tool, "parameters", None)
+        if isinstance(parameters, dict):
+            declared.update(str(name) for name in parameters.keys())
+
+        required = getattr(tool, "required", None)
+        if isinstance(required, list):
+            declared.update(str(name) for name in required)
+
+        func = getattr(tool, "func", None)
+        if func is not None:
+            try:
+                import inspect
+
+                sig = inspect.signature(func)
+                for name, param in sig.parameters.items():
+                    if name == "self":
+                        continue
+                    if param.kind in (
+                        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                        inspect.Parameter.KEYWORD_ONLY,
+                    ):
+                        declared.add(name)
+            except (ValueError, TypeError):
+                pass
+
+        return declared
+
+    def _build_trusted_tool_context(
+        self,
+        session_context: Optional[SessionContext],
+    ) -> Dict[str, Any]:
+        """Build trusted context used to override model-generated tool args."""
+        trusted_context: Dict[str, Any] = {}
+        system_context = getattr(session_context, "system_context", None)
+        if isinstance(system_context, dict):
+            trusted_context.update(system_context)
+
+        return trusted_context
+
+    def _apply_system_context_overrides(
+        self,
+        tool: Union[ToolSpec, McpToolSpec, SageMcpToolSpec],
+        kwargs: Dict[str, Any],
+        trusted_context: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Apply trusted context to declared tool parameters only."""
+        declared_params = self._get_declared_tool_param_names(tool)
+        if not declared_params or not trusted_context:
+            return dict(kwargs)
+
+        merged = dict(kwargs)
+        for name in declared_params:
+            if name in trusted_context and trusted_context[name] is not None:
+                merged[name] = trusted_context[name]
+
+        return merged
+
+    def _prepare_tool_kwargs(
+        self,
+        tool: Union[ToolSpec, McpToolSpec, SageMcpToolSpec],
+        tool_name: str,
+        kwargs: Dict[str, Any],
+        trusted_context: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Normalize model args, remove reserved identity fields, and overlay context."""
+        normalized = self._normalize_kwargs_by_schema(tool, tool_name, kwargs)
+        normalized = {k: v for k, v in normalized.items() if v is not None}
+
+        # The model must never supply identity fields directly. If system_context
+        # declares the same keys, they are reintroduced by the generic overlay.
+        normalized.pop("session_id", None)
+        normalized.pop("user_id", None)
+
+        return self._apply_system_context_overrides(tool, normalized, trusted_context)
+
     async def run_tool_async(
         self,
         tool_name: str,
@@ -1148,69 +1229,31 @@ class ToolManager:
 
         logger.debug(f"Found tool: {tool_name} (type: {type(tool).__name__})")
 
-        # Normalize arguments by tool parameter schema.
-        # Some models may emit nested JSON objects as escaped strings
-        # (e.g. updates="{\"start_at\":\"...\"}") which breaks MCP validation.
-        kwargs = self._normalize_kwargs_by_schema(tool, tool_name, kwargs)
-
-        # In strict mode the LLM passes null for optional parameters; strip them out
-        # so tools receive their Python default values instead of None.
-        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        trusted_context = self._build_trusted_tool_context(session_context)
+        kwargs = self._prepare_tool_kwargs(tool, tool_name, kwargs, trusted_context)
 
         # Step 2: Execute based on tool type (self-call prevention handled at agent level)
 
         try:
             # Step 3: Execute tool
             if isinstance(tool, McpToolSpec):
-                # For MCP tools, session_id is passed explicitly, so remove from kwargs
-                kwargs.pop("session_id", None)
                 final_result = await self._execute_mcp_tool(
                     tool,
-                    session_id,
-                    user_id=resolved_user_id,
+                    runtime_session_id=session_id,
+                    runtime_user_id=resolved_user_id,
                     **kwargs,
                 )
             elif isinstance(tool, SageMcpToolSpec):
-                # Ensure session_id is not in kwargs
-                kwargs.pop("session_id", None)
-                if resolved_user_id and "user_id" not in kwargs:
-                    import inspect
-
-                    func_to_inspect = tool.func
-                    has_user_id_param = False
-                    try:
-                        sig = inspect.signature(func_to_inspect)
-                        has_user_id_param = "user_id" in sig.parameters
-                    except (ValueError, TypeError):
-                        pass
-                    if (
-                        not has_user_id_param
-                        and hasattr(tool, "parameters")
-                        and tool.parameters
-                    ):
-                        has_user_id_param = "user_id" in tool.parameters
-                    if (
-                        not has_user_id_param
-                        and hasattr(tool, "required")
-                        and tool.required
-                    ):
-                        has_user_id_param = "user_id" in tool.required
-                    if has_user_id_param:
-                        kwargs["user_id"] = resolved_user_id
-                        logger.debug(
-                            f"[Tool Execution] Injected user_id for {tool.name}"
-                        )
                 final_result = await self._execute_standard_tool_async(
-                    tool, session_id=session_id, **kwargs
+                    tool, runtime_session_id=session_id, **kwargs
                 )
             elif isinstance(tool, ToolSpec):
                 # 检查必填参数
                 required_params = getattr(tool, "required", []) or []
-                # session_id 是系统注入的参数，如果不在 kwargs 中但工具需要，不算 missing
                 missing_params = [
                     p
                     for p in required_params
-                    if p != "session_id" and (p not in kwargs or kwargs.get(p) is None)
+                    if p not in kwargs or kwargs.get(p) is None
                 ]
                 if missing_params:
                     # 返回错误信息而不是 raise
@@ -1227,74 +1270,9 @@ class ToolManager:
 
                 # Tools run directly, they use sandbox internally if needed
                 try:
-                    # Inject session_id if the tool function expects it
-                    import inspect
-
-                    func_to_inspect = tool.func
-
-                    has_session_id_param = False
-
-                    # For bound methods, check the bound method's signature directly
-                    try:
-                        sig = inspect.signature(func_to_inspect)
-                        has_session_id_param = "session_id" in sig.parameters
-                        logger.debug(
-                            f"[Tool] Checking {tool.name} signature: {list(sig.parameters.keys())}, has_session_id: {has_session_id_param}"
-                        )
-                    except (ValueError, TypeError) as e:
-                        logger.debug(
-                            f"[Tool] Failed to get signature for {tool.name}: {e}"
-                        )
-                        pass
-
-                    # Also check from tool spec as fallback
-                    if (
-                        not has_session_id_param
-                        and hasattr(tool, "parameters")
-                        and tool.parameters
-                    ):
-                        has_session_id_param = "session_id" in tool.parameters
-                        logger.debug(
-                            f"[Tool] Checked tool.parameters for {tool.name}: has_session_id={has_session_id_param}"
-                        )
-                    if (
-                        not has_session_id_param
-                        and hasattr(tool, "required")
-                        and tool.required
-                    ):
-                        has_session_id_param = "session_id" in tool.required
-                        logger.debug(
-                            f"[Tool] Checked tool.required for {tool.name}: has_session_id={has_session_id_param}"
-                        )
-
-                    if has_session_id_param:
-                        kwargs["session_id"] = session_id
-                        logger.debug(f"[Tool] Injected session_id for {tool.name}")
-
-                    if resolved_user_id and "user_id" not in kwargs:
-                        has_user_id_param = False
-                        try:
-                            has_user_id_param = "user_id" in sig.parameters
-                        except Exception:
-                            has_user_id_param = False
-                        if (
-                            not has_user_id_param
-                            and hasattr(tool, "parameters")
-                            and tool.parameters
-                        ):
-                            has_user_id_param = "user_id" in tool.parameters
-                        if (
-                            not has_user_id_param
-                            and hasattr(tool, "required")
-                            and tool.required
-                        ):
-                            has_user_id_param = "user_id" in tool.required
-                        if has_user_id_param:
-                            kwargs["user_id"] = resolved_user_id
-                            logger.debug(f"[Tool] Injected user_id for {tool.name}")
-
-                    # Execute tool directly (tools use sandbox internally if needed)
-                    result = await self._execute_standard_tool_async(tool, **kwargs)
+                    result = await self._execute_standard_tool_async(
+                        tool, runtime_session_id=session_id, **kwargs
+                    )
                     # _execute_standard_tool_async 已经返回 JSON 字符串，直接使用
                     final_result = result
 
@@ -1447,8 +1425,8 @@ class ToolManager:
     async def _execute_mcp_tool(
         self,
         tool: McpToolSpec,
-        session_id: str,
-        user_id: Optional[str] = None,
+        runtime_session_id: str,
+        runtime_user_id: Optional[str] = None,
         **kwargs,
     ) -> str:
         """Execute MCP tool and format result"""
@@ -1456,8 +1434,8 @@ class ToolManager:
         try:
             result = await self._mcp_proxy.run_mcp_tool(
                 tool,
-                session_id,
-                user_id=user_id,
+                runtime_session_id=runtime_session_id,
+                runtime_user_id=runtime_user_id,
                 **kwargs,
             )
             logger.info(f"MCP tool {tool.name} execution completed successfully")
@@ -1490,61 +1468,15 @@ class ToolManager:
             raise
 
     async def _execute_standard_tool_async(
-        self, tool: ToolSpec, session_id: str = "", **kwargs
+        self, tool: ToolSpec, runtime_session_id: str = "", **kwargs
     ) -> str:
         """Execute standard tool and format result (async version)"""
         logger.debug(
-            f"[_execute_standard_tool_async] START | tool={tool.name} | session={session_id or 'NO_SESSION'}"
+            f"[_execute_standard_tool_async] START | tool={tool.name} | session={runtime_session_id or 'NO_SESSION'}"
         )
         execute_start = time.perf_counter()
 
         try:
-            # Inject session_id if the tool function expects it
-            import inspect
-
-            func_to_inspect = tool.func
-
-            has_session_id_param = False
-
-            # For bound methods, check the bound method's signature directly
-            # Don't unwrap __wrapped__ because we need to see the actual signature
-            # that will be used when calling the method
-            try:
-                sig = inspect.signature(func_to_inspect)
-                has_session_id_param = "session_id" in sig.parameters
-                logger.debug(
-                    f"[_execute_standard_tool_async] Checking {tool.name} signature: {list(sig.parameters.keys())}, has_session_id: {has_session_id_param}"
-                )
-            except (ValueError, TypeError) as e:
-                logger.debug(
-                    f"[_execute_standard_tool_async] Failed to get signature for {tool.name}: {e}"
-                )
-                pass
-
-            # Also check from tool spec parameters (as fallback)
-            if (
-                not has_session_id_param
-                and hasattr(tool, "parameters")
-                and tool.parameters
-            ):
-                has_session_id_param = "session_id" in tool.parameters
-                logger.debug(
-                    f"[_execute_standard_tool_async] Checked tool.parameters for {tool.name}: has_session_id={has_session_id_param}"
-                )
-
-            # Also check from tool spec required params (as fallback)
-            if not has_session_id_param and hasattr(tool, "required") and tool.required:
-                has_session_id_param = "session_id" in tool.required
-                logger.debug(
-                    f"[_execute_standard_tool_async] Checked tool.required for {tool.name}: has_session_id={has_session_id_param}"
-                )
-
-            if has_session_id_param:
-                kwargs["session_id"] = session_id
-                logger.debug(
-                    f"[_execute_standard_tool_async] Injected session_id for tool: {tool.name}"
-                )
-
             # Execute the tool function
             logger.debug(
                 f"[_execute_standard_tool_async] Executing | tool={tool.name} | is_async={asyncio.iscoroutinefunction(tool.func)}"

--- a/tests/sagents/tool/impl/test_memory_tool.py
+++ b/tests/sagents/tool/impl/test_memory_tool.py
@@ -386,7 +386,9 @@ class TestMemoryTool(unittest.TestCase):
         self.assertEqual(len(result["long_term_memory"]), 1)
         self.assertEqual(len(result["session_history"]), 1)
 
-    def test_tool_manager_run_tool_async_injects_session_id_for_search_memory(self):
+    def test_tool_manager_run_tool_async_uses_system_context_session_id_for_search_memory(
+        self,
+    ):
         tool = self.MemoryTool()
         manager = self.ToolManager(is_auto_discover=False, isolated=True)
         manager.register_tools_from_object(tool)
@@ -404,6 +406,13 @@ class TestMemoryTool(unittest.TestCase):
         with (
             patch.object(tool, "_search_file_memory", fake_file_search),
             patch.object(tool, "_search_session_history", fake_history_search),
+            patch(
+                "sagents.tool.tool_manager._resolve_session_context",
+                return_value=types.SimpleNamespace(
+                    system_context={"session_id": "session-tool"},
+                    user_id=None,
+                ),
+            ),
         ):
             raw = asyncio.run(
                 manager.run_tool_async(

--- a/tests/sagents/tool/test_tool_context_injection.py
+++ b/tests/sagents/tool/test_tool_context_injection.py
@@ -1,11 +1,14 @@
 import json
 import unittest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 from common.services import tool_service
 from common.services.tool_service import execute_tool
+from sagents.agent.agent_base import AgentBase
 from sagents.tool.mcp_proxy import McpProxy
 from sagents.tool.tool_manager import ToolManager
+from sagents.tool.tool_proxy import ToolProxy
 from sagents.tool.tool_schema import (
     McpToolSpec,
     SageMcpToolSpec,
@@ -19,12 +22,22 @@ async def echo_kwargs(**kwargs):
     return kwargs
 
 
+async def echo_no_args():
+    return {"called": True}
+
+
+class _TestAgent(AgentBase):
+    async def run_stream(self, session_context):
+        if False:
+            yield []
+
+
 class TestToolContextInjection(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.tool_manager = ToolManager(is_auto_discover=False, isolated=True)
         self.tool_manager.tools = {}
 
-    async def test_standard_tool_injects_session_and_user_id(self):
+    async def test_standard_tool_uses_session_and_user_id_from_system_context(self):
         tool = ToolSpec(
             name="echo_tool",
             description="echo",
@@ -38,13 +51,21 @@ class TestToolContextInjection(unittest.IsolatedAsyncioTestCase):
             required=["foo"],
         )
         self.tool_manager.tools[tool.name] = tool
-
-        result = await self.tool_manager.run_tool_async(
-            tool_name="echo_tool",
-            session_id="session-1",
+        session_context = SimpleNamespace(
+            system_context={"session_id": "session-1", "user_id": "user-1"},
             user_id="user-1",
-            foo="bar",
         )
+
+        with patch(
+            "sagents.tool.tool_manager._resolve_session_context",
+            return_value=session_context,
+        ):
+            result = await self.tool_manager.run_tool_async(
+                tool_name="echo_tool",
+                session_id="runtime-session",
+                user_id="runtime-user",
+                foo="bar",
+            )
 
         payload = json.loads(result)
         self.assertEqual(
@@ -56,7 +77,9 @@ class TestToolContextInjection(unittest.IsolatedAsyncioTestCase):
             },
         )
 
-    async def test_built_in_mcp_tool_injects_session_and_user_id(self):
+    async def test_built_in_mcp_tool_uses_session_and_user_id_from_system_context(
+        self,
+    ):
         tool = SageMcpToolSpec(
             name="builtin_echo",
             description="echo",
@@ -71,13 +94,21 @@ class TestToolContextInjection(unittest.IsolatedAsyncioTestCase):
             server_name="builtin",
         )
         self.tool_manager.tools[tool.name] = tool
-
-        result = await self.tool_manager.run_tool_async(
-            tool_name="builtin_echo",
-            session_id="session-2",
+        session_context = SimpleNamespace(
+            system_context={"session_id": "session-2", "user_id": "user-2"},
             user_id="user-2",
-            foo="bar",
         )
+
+        with patch(
+            "sagents.tool.tool_manager._resolve_session_context",
+            return_value=session_context,
+        ):
+            result = await self.tool_manager.run_tool_async(
+                tool_name="builtin_echo",
+                session_id="runtime-session",
+                user_id="runtime-user",
+                foo="bar",
+            )
 
         payload = json.loads(result)
         self.assertEqual(
@@ -89,7 +120,459 @@ class TestToolContextInjection(unittest.IsolatedAsyncioTestCase):
             },
         )
 
-    async def test_mcp_tool_manager_passes_user_id_to_proxy(self):
+    async def test_standard_tool_uses_system_context_identity_when_present(self):
+        tool = ToolSpec(
+            name="echo_tool",
+            description="echo",
+            description_i18n={},
+            func=echo_kwargs,
+            parameters={
+                "foo": {"type": "string"},
+                "session_id": {"type": "string"},
+                "user_id": {"type": "string"},
+            },
+            required=["foo"],
+        )
+        self.tool_manager.tools[tool.name] = tool
+        session_context = SimpleNamespace(
+            system_context={
+                "session_id": "context-session",
+                "user_id": "context-user",
+            },
+            user_id="context-user",
+        )
+
+        with patch(
+            "sagents.tool.tool_manager._resolve_session_context",
+            return_value=session_context,
+        ):
+            result = await self.tool_manager.run_tool_async(
+                tool_name="echo_tool",
+                session_id="real-session",
+                user_id="real-user",
+                foo="bar",
+            )
+
+        payload = json.loads(result)
+        self.assertEqual(
+            payload["content"],
+            {
+                "foo": "bar",
+                "session_id": "context-session",
+                "user_id": "context-user",
+            },
+        )
+
+    async def test_standard_tool_system_context_overrides_model_argument(self):
+        tool = ToolSpec(
+            name="echo_tool",
+            description="echo",
+            description_i18n={},
+            func=echo_kwargs,
+            parameters={"foo": {"type": "string"}},
+            required=["foo"],
+        )
+        self.tool_manager.tools[tool.name] = tool
+        session_context = SimpleNamespace(
+            system_context={
+                "foo": "context-value",
+                "session_id": "context-session",
+                "user_id": "context-user",
+            },
+            user_id="context-user",
+        )
+
+        with patch(
+            "sagents.tool.tool_manager._resolve_session_context",
+            return_value=session_context,
+        ):
+            result = await self.tool_manager.run_tool_async(
+                tool_name="echo_tool",
+                session_id="session-ctx",
+                foo="model-value",
+            )
+
+        payload = json.loads(result)
+        self.assertEqual(payload["content"], {"foo": "context-value"})
+
+    async def test_standard_tool_system_context_can_fill_required_argument(self):
+        tool = ToolSpec(
+            name="echo_tool",
+            description="echo",
+            description_i18n={},
+            func=echo_kwargs,
+            parameters={"foo": {"type": "string"}},
+            required=["foo"],
+        )
+        self.tool_manager.tools[tool.name] = tool
+        session_context = SimpleNamespace(
+            system_context={"foo": "context-value"}, user_id=None
+        )
+
+        with patch(
+            "sagents.tool.tool_manager._resolve_session_context",
+            return_value=session_context,
+        ):
+            result = await self.tool_manager.run_tool_async(
+                tool_name="echo_tool",
+                session_id="session-ctx",
+            )
+
+        payload = json.loads(result)
+        self.assertEqual(payload["content"], {"foo": "context-value"})
+
+    async def test_standard_tool_system_context_none_does_not_override_model_argument(
+        self,
+    ):
+        tool = ToolSpec(
+            name="echo_tool",
+            description="echo",
+            description_i18n={},
+            func=echo_kwargs,
+            parameters={"foo": {"type": "string"}},
+            required=["foo"],
+        )
+        self.tool_manager.tools[tool.name] = tool
+        session_context = SimpleNamespace(system_context={"foo": None}, user_id=None)
+
+        with patch(
+            "sagents.tool.tool_manager._resolve_session_context",
+            return_value=session_context,
+        ):
+            result = await self.tool_manager.run_tool_async(
+                tool_name="echo_tool",
+                session_id="session-ctx",
+                foo="model-value",
+            )
+
+        payload = json.loads(result)
+        self.assertEqual(payload["content"], {"foo": "model-value"})
+
+    async def test_standard_tool_does_not_leak_undeclared_system_context_keys(self):
+        tool = ToolSpec(
+            name="echo_tool",
+            description="echo",
+            description_i18n={},
+            func=echo_kwargs,
+            parameters={"foo": {"type": "string"}},
+            required=["foo"],
+        )
+        self.tool_manager.tools[tool.name] = tool
+        session_context = SimpleNamespace(
+            system_context={
+                "foo": "context-value",
+                "secret": "must-not-leak",
+                "session_id": "context-session",
+            },
+            user_id=None,
+        )
+
+        with patch(
+            "sagents.tool.tool_manager._resolve_session_context",
+            return_value=session_context,
+        ):
+            result = await self.tool_manager.run_tool_async(
+                tool_name="echo_tool",
+                session_id="runtime-session",
+                foo="model-value",
+            )
+
+        payload = json.loads(result)
+        self.assertEqual(payload["content"], {"foo": "context-value"})
+
+    async def test_standard_tool_without_parameters_ignores_all_context(self):
+        tool = ToolSpec(
+            name="no_arg_tool",
+            description="echo",
+            description_i18n={},
+            func=echo_no_args,
+            parameters={},
+            required=[],
+        )
+        self.tool_manager.tools[tool.name] = tool
+        session_context = SimpleNamespace(
+            system_context={
+                "foo": "context-value",
+                "session_id": "context-session",
+                "user_id": "context-user",
+            },
+            user_id="context-user",
+        )
+
+        with patch(
+            "sagents.tool.tool_manager._resolve_session_context",
+            return_value=session_context,
+        ):
+            result = await self.tool_manager.run_tool_async(
+                tool_name="no_arg_tool",
+                session_id="runtime-session",
+            )
+
+        payload = json.loads(result)
+        self.assertEqual(payload["content"], {"called": True})
+
+    async def test_declared_session_id_is_missing_without_system_context(self):
+        tool = ToolSpec(
+            name="echo_tool",
+            description="echo",
+            description_i18n={},
+            func=echo_kwargs,
+            parameters={
+                "foo": {"type": "string"},
+                "session_id": {"type": "string"},
+            },
+            required=["foo", "session_id"],
+        )
+        self.tool_manager.tools[tool.name] = tool
+        session_context = SimpleNamespace(system_context={}, user_id=None)
+
+        with patch(
+            "sagents.tool.tool_manager._resolve_session_context",
+            return_value=session_context,
+        ):
+            result = await self.tool_manager.run_tool_async(
+                tool_name="echo_tool",
+                session_id="runtime-session",
+                foo="bar",
+            )
+
+        payload = json.loads(result)
+        self.assertFalse(payload["success"])
+        self.assertIn("session_id", payload["error"])
+
+    async def test_agent_tool_call_drops_model_forged_identity_and_uses_system_context(
+        self,
+    ):
+        tool = ToolSpec(
+            name="echo_tool",
+            description="echo",
+            description_i18n={},
+            func=echo_kwargs,
+            parameters={
+                "foo": {"type": "string"},
+                "session_id": {"type": "string"},
+                "user_id": {"type": "string"},
+            },
+            required=["foo"],
+        )
+        self.tool_manager.tools[tool.name] = tool
+        session_context = SimpleNamespace(
+            system_context={
+                "session_id": "context-session",
+                "user_id": "context-user",
+            },
+            user_id="context-user",
+        )
+
+        with patch(
+            "sagents.tool.tool_manager._resolve_session_context",
+            return_value=session_context,
+        ):
+            chunks = []
+            async for chunk in _TestAgent()._execute_tool(
+                tool_call={
+                    "id": "tool-call-1",
+                    "function": {
+                        "name": "echo_tool",
+                        "arguments": json.dumps(
+                            {
+                                "foo": "bar",
+                                "session_id": "forged-session",
+                                "user_id": "forged-user",
+                            }
+                        ),
+                    },
+                },
+                tool_manager=self.tool_manager,
+                messages_input=[],
+                session_id="runtime-session",
+                session_context=session_context,  # pyright: ignore[reportArgumentType]
+            ):
+                chunks.extend(chunk)
+
+        content = json.loads(chunks[-1].content)  # pyright: ignore[arg-type]
+        self.assertEqual(
+            content,
+            {
+                "foo": "bar",
+                "session_id": "context-session",
+                "user_id": "context-user",
+            },
+        )
+
+    async def test_built_in_mcp_tool_system_context_overrides_and_identity_is_trusted(
+        self,
+    ):
+        tool = SageMcpToolSpec(
+            name="builtin_echo",
+            description="echo",
+            description_i18n={},
+            func=echo_kwargs,
+            parameters={
+                "foo": {"type": "string"},
+                "session_id": {"type": "string"},
+                "user_id": {"type": "string"},
+            },
+            required=["foo"],
+            server_name="builtin",
+        )
+        self.tool_manager.tools[tool.name] = tool
+        session_context = SimpleNamespace(
+            system_context={
+                "foo": "context-value",
+                "session_id": "context-session",
+                "user_id": "context-user",
+            },
+            user_id="context-user",
+        )
+
+        with patch(
+            "sagents.tool.tool_manager._resolve_session_context",
+            return_value=session_context,
+        ):
+            result = await self.tool_manager.run_tool_async(
+                tool_name="builtin_echo",
+                session_id="real-session",
+                user_id="real-user",
+                foo="model-value",
+            )
+
+        payload = json.loads(result)
+        self.assertEqual(
+            payload["content"],
+            {
+                "foo": "context-value",
+                "session_id": "context-session",
+                "user_id": "context-user",
+            },
+        )
+
+    async def test_remote_mcp_tool_system_context_overrides_model_argument(self):
+        tool = McpToolSpec(
+            name="remote_echo",
+            description="echo",
+            description_i18n={},
+            func=None,
+            parameters={
+                "foo": {"type": "string"},
+                "session_id": {"type": "string"},
+                "user_id": {"type": "string"},
+            },
+            required=["foo"],
+            server_name="remote",
+            server_params=StreamableHttpServerParameters(url="http://example.invalid"),
+        )
+        self.tool_manager.tools[tool.name] = tool
+        session_context = SimpleNamespace(
+            system_context={
+                "foo": "context-value",
+                "session_id": "context-session",
+                "user_id": "context-user",
+            },
+            user_id="context-user",
+        )
+
+        with (
+            patch(
+                "sagents.tool.tool_manager._resolve_session_context",
+                return_value=session_context,
+            ),
+            patch.object(
+                McpProxy,
+                "_execute_streamable_http_mcp_tool",
+                new_callable=AsyncMock,
+                return_value={"content": [{"text": "ok"}]},
+            ) as mock_execute,
+        ):
+            result = await self.tool_manager.run_tool_async(
+                tool_name="remote_echo",
+                session_id="real-session",
+                user_id="real-user",
+                foo="model-value",
+            )
+
+        payload = json.loads(result)
+        self.assertEqual(payload["content"], "ok")
+        call_kwargs = mock_execute.await_args.kwargs  # pyright: ignore[reportOptionalMemberAccess]
+        self.assertEqual(call_kwargs["foo"], "context-value")
+        self.assertEqual(call_kwargs["session_id"], "context-session")
+        self.assertEqual(call_kwargs["user_id"], "context-user")
+
+    async def test_tool_proxy_applies_system_context_overrides(self):
+        tool = ToolSpec(
+            name="echo_tool",
+            description="echo",
+            description_i18n={},
+            func=echo_kwargs,
+            parameters={"foo": {"type": "string"}},
+            required=["foo"],
+        )
+        self.tool_manager.tools[tool.name] = tool
+        proxy = ToolProxy(self.tool_manager)
+        session_context = SimpleNamespace(
+            system_context={"foo": "context-value"}, user_id=None
+        )
+
+        with patch(
+            "sagents.tool.tool_manager._resolve_session_context",
+            return_value=session_context,
+        ):
+            result = await proxy.run_tool_async(
+                tool_name="echo_tool",
+                session_id="session-ctx",
+                foo="model-value",
+            )
+
+        payload = json.loads(result)
+        self.assertEqual(payload["content"], {"foo": "context-value"})
+
+    async def test_remote_mcp_does_not_leak_undeclared_system_context_keys(self):
+        tool = McpToolSpec(
+            name="remote_echo",
+            description="echo",
+            description_i18n={},
+            func=None,
+            parameters={"foo": {"type": "string"}},
+            required=["foo"],
+            server_name="remote",
+            server_params=StreamableHttpServerParameters(url="http://example.invalid"),
+        )
+        self.tool_manager.tools[tool.name] = tool
+        session_context = SimpleNamespace(
+            system_context={
+                "foo": "context-value",
+                "secret": "must-not-leak",
+                "session_id": "context-session",
+            },
+            user_id=None,
+        )
+
+        with (
+            patch(
+                "sagents.tool.tool_manager._resolve_session_context",
+                return_value=session_context,
+            ),
+            patch.object(
+                McpProxy,
+                "_execute_streamable_http_mcp_tool",
+                new_callable=AsyncMock,
+                return_value={"content": [{"text": "ok"}]},
+            ) as mock_execute,
+        ):
+            result = await self.tool_manager.run_tool_async(
+                tool_name="remote_echo",
+                session_id="runtime-session",
+                foo="model-value",
+            )
+
+        payload = json.loads(result)
+        self.assertEqual(payload["content"], "ok")
+        call_kwargs = mock_execute.await_args.kwargs  # pyright: ignore[reportOptionalMemberAccess]
+        self.assertEqual(call_kwargs["foo"], "context-value")
+        self.assertNotIn("secret", call_kwargs)
+        self.assertNotIn("session_id", call_kwargs)
+
+    async def test_mcp_tool_manager_does_not_use_runtime_identity_as_tool_args(self):
         tool = McpToolSpec(
             name="remote_echo",
             description="echo",
@@ -123,10 +606,12 @@ class TestToolContextInjection(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["content"], "ok")
         mock_run_mcp_tool.assert_awaited_once()
         call_kwargs = mock_run_mcp_tool.await_args.kwargs  # pyright: ignore[reportOptionalMemberAccess]
-        self.assertEqual(call_kwargs["user_id"], "user-3")
+        self.assertEqual(call_kwargs["runtime_user_id"], "user-3")
         self.assertEqual(call_kwargs["foo"], "bar")
+        self.assertNotIn("session_id", call_kwargs)
+        self.assertNotIn("user_id", call_kwargs)
 
-    async def test_mcp_proxy_injects_session_and_user_id_when_declared(self):
+    async def test_mcp_proxy_preserves_session_and_user_id_from_kwargs(self):
         tool = McpToolSpec(
             name="remote_echo",
             description="echo",
@@ -240,7 +725,7 @@ class TestToolContextInjection(unittest.IsolatedAsyncioTestCase):
         with patch.object(tool_service, "get_tool_manager", return_value=fake_manager):
             result = await execute_tool(
                 "basic_tool",
-                {"foo": "bar"},
+                {"foo": "bar", "session_id": "fake-session", "user_id": "fake-user"},
                 user_id="user-5",
                 role="user",
             )
@@ -252,6 +737,7 @@ class TestToolContextInjection(unittest.IsolatedAsyncioTestCase):
         call_kwargs = fake_manager.run_tool_async.await_args.kwargs  # pyright: ignore[reportAttributeAccessIssue,reportOptionalMemberAccess]
         self.assertEqual(call_kwargs["user_id"], "user-5")
         self.assertEqual(call_kwargs["foo"], "bar")
+        self.assertEqual(call_kwargs["session_id"], "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- route declared tool parameters through a single system_context overlay path
- stop injecting session_id/user_id as special tool args; model-provided identity fields are stripped at call boundaries
- update local, built-in MCP, remote MCP, ToolProxy, Agent, and HTTP tool paths with expanded coverage

## Tests
- python3 -m pytest tests/sagents/tool/test_tool_context_injection.py
- python3 -m pytest tests/sagents/tool