### PR TITLE
Fix self-check retry context handling

### DIFF
--- a/sagents/context/messages/message_manager.py
+++ b/sagents/context/messages/message_manager.py
@@ -1040,6 +1040,7 @@ class MessageManager:
                 MessageType.TASK_ANALYSIS.value,
                 MessageType.TOOL_CALL_RESULT.value,
                 MessageType.SKILL_OBSERVATION.value,
+                MessageType.AGENT_EXECUTION_ERROR.value,
             ]
 
         # 全量消息进入；后续靠 recent_turns + 上层压缩链路控制长度

--- a/sagents/sagents.py
+++ b/sagents/sagents.py
@@ -503,14 +503,14 @@ class SAgent:
         )
 
         # 预定义简单模式
+        simple_agent_prelude = ParallelNode(
+            branches=[
+                AgentNode(agent_key="tool_suggestion"),
+                AgentNode(agent_key="memory_recall"),
+            ]
+        )
         simple_agent_core = SequenceNode(
             steps=[
-                ParallelNode(
-                    branches=[
-                        AgentNode(agent_key="tool_suggestion"),
-                        AgentNode(agent_key="memory_recall"),
-                    ]
-                ),
                 IfNode(
                     condition="enable_plan",
                     true_body=SequenceNode(
@@ -530,25 +530,30 @@ class SAgent:
                 ),
             ]
         )
-        simple_agent_body = LoopNode(
-            condition="self_check_should_retry",
-            max_loops=3,
-            body=SequenceNode(
-                steps=[
-                    simple_agent_core,
-                    AgentNode(agent_key="self_check"),
-                ]
-            ),
+        simple_agent_body = SequenceNode(
+            steps=[
+                simple_agent_prelude,
+                LoopNode(
+                    condition="self_check_should_retry",
+                    max_loops=3,
+                    body=SequenceNode(
+                        steps=[
+                            simple_agent_core,
+                            AgentNode(agent_key="self_check"),
+                        ]
+                    ),
+                ),
+            ]
         )
 
+        fib_agent_prelude = ParallelNode(
+            branches=[
+                AgentNode(agent_key="tool_suggestion"),
+                AgentNode(agent_key="memory_recall"),
+            ]
+        )
         fib_agent_core = SequenceNode(
             steps=[
-                ParallelNode(
-                    branches=[
-                        AgentNode(agent_key="tool_suggestion"),
-                        AgentNode(agent_key="memory_recall"),
-                    ]
-                ),
                 IfNode(
                     condition="enable_plan",
                     true_body=SequenceNode(
@@ -565,15 +570,20 @@ class SAgent:
             ]
         )
 
-        fib_agent_body = LoopNode(
-            condition="self_check_should_retry",
-            max_loops=3,
-            body=SequenceNode(
-                steps=[
-                    fib_agent_core,
-                    AgentNode(agent_key="self_check"),
-                ]
-            ),
+        fib_agent_body = SequenceNode(
+            steps=[
+                fib_agent_prelude,
+                LoopNode(
+                    condition="self_check_should_retry",
+                    max_loops=3,
+                    body=SequenceNode(
+                        steps=[
+                            fib_agent_core,
+                            AgentNode(agent_key="self_check"),
+                        ]
+                    ),
+                ),
+            ]
         )
 
         steps.append(

--- a/tests/sagents/flow/test_default_self_check_flow.py
+++ b/tests/sagents/flow/test_default_self_check_flow.py
@@ -1,0 +1,49 @@
+from sagents.flow.schema import AgentNode, IfNode, LoopNode, ParallelNode, SequenceNode
+from sagents.sagents import SAgent
+
+
+def _agent_keys(node):
+    keys = []
+    if isinstance(node, AgentNode):
+        return [node.agent_key]
+    if isinstance(node, SequenceNode):
+        for step in node.steps:
+            keys.extend(_agent_keys(step))
+    elif isinstance(node, ParallelNode):
+        for branch in node.branches:
+            keys.extend(_agent_keys(branch))
+    elif isinstance(node, LoopNode):
+        keys.extend(_agent_keys(node.body))
+    elif isinstance(node, IfNode):
+        keys.extend(_agent_keys(node.true_body))
+        if node.false_body is not None:
+            keys.extend(_agent_keys(node.false_body))
+    return keys
+
+
+def test_simple_and_fibre_memory_recall_run_outside_self_check_retry_loop(tmp_path):
+    flow = SAgent(str(tmp_path), enable_obs=False)._build_default_flow(
+        agent_mode="simple",
+        max_loop_count=5,
+    )
+    switch = flow.root.steps[1]
+
+    for mode, executor_key in [("simple", "simple"), ("fibre", "fibre")]:
+        body = switch.cases[mode]
+
+        assert isinstance(body, SequenceNode)
+        assert isinstance(body.steps[0], ParallelNode)
+        assert sorted(_agent_keys(body.steps[0])) == [
+            "memory_recall",
+            "tool_suggestion",
+        ]
+
+        retry_loop = body.steps[1]
+        assert isinstance(retry_loop, LoopNode)
+        assert retry_loop.condition == "self_check_should_retry"
+
+        loop_keys = _agent_keys(retry_loop.body)
+        assert executor_key in loop_keys
+        assert "self_check" in loop_keys
+        assert "memory_recall" not in loop_keys
+        assert "tool_suggestion" not in loop_keys

--- a/tests/sagents/messages/test_history_anchor.py
+++ b/tests/sagents/messages/test_history_anchor.py
@@ -274,6 +274,26 @@ class TestExtractIgnoresActiveStartIndex:
         assert "u2" in contents
         assert "a2" in contents
 
+    def test_agent_execution_error_stays_in_default_context(self):
+        """自检/执行错误必须进入下一轮 LLM 上下文，否则 agent 会看不到修复反馈。"""
+        mm = MessageManager()
+        mm.messages = [
+            _make(MessageRole.USER.value, "生成结果"),
+            _make(MessageRole.ASSISTANT.value, "结果: [missing](/tmp/missing.md)"),
+            _make(
+                MessageRole.ASSISTANT.value,
+                "自检发现以下问题，需要先修复后再继续",
+                msg_type=MessageType.AGENT_EXECUTION_ERROR.value,
+            ),
+        ]
+
+        result = mm.extract_all_context_messages(
+            recent_turns=0, last_turn_user_only=False
+        )
+        contents = [m.content for m in result]
+
+        assert "自检发现以下问题，需要先修复后再继续" in contents
+
     def test_compress_anchor_still_filters(self):
         """有压缩调用时仍然只保留 user + 最新压缩 + 之后"""
         mm = MessageManager()


### PR DESCRIPTION
## Summary
- keep self-check execution errors in default LLM context so retry turns can see the failure feedback
- move simple/fibre memory recall and tool suggestion outside the self-check retry loop
- add regression coverage for retry flow structure and execution-error context retention

## Tests
- python -m pytest tests/sagents/flow/test_default_self_check_flow.py tests/sagents/messages/test_history_anchor.py tests/sagents/test_self_check_agent_paths.py
- python -m py_compile sagents/sagents.py sagents/context/messages/message_manager.py tests/sagents/flow/test_default_self_check_flow.py tests/sagents/messages/test_history_anchor.py