### PR TITLE
Fix original token accounting for tool_calls during context compression

### DIFF
--- a/sagents/tool/impl/compress_history_tool.py
+++ b/sagents/tool/impl/compress_history_tool.py
@@ -306,13 +306,14 @@ class CompressHistoryTool:
                 f"共 {len(to_compress)} 条消息"
             )
 
-            # 3. 计算原始 token 数
-            original_tokens = sum(
-                self._calculate_tokens(msg.get_content() or "") for msg in to_compress
-            )
-
-            # 4. 格式化消息并调用 LLM 压缩
+            # 3. 格式化消息，并按实际送入压缩 prompt 的文本统计原始 token
             messages_text = self._format_messages_for_compression(to_compress)
+
+            # 不能只统计 MessageChunk.content，因为 assistant 的 tool_calls
+            # 可能没有 content，但会被 convert_messages_to_str 写入压缩输入。
+            original_tokens = self._calculate_tokens(messages_text)
+
+            # 4. 调用 LLM 压缩
             summary = await self._call_llm_for_compression(messages_text, session_id)
 
             # 5. 计算压缩后的 token 数

--- a/tests/sagents/messages/test_compress_history_tool.py
+++ b/tests/sagents/messages/test_compress_history_tool.py
@@ -5,6 +5,7 @@ Test CompressHistoryTool
 """
 
 import asyncio
+import re
 import sys
 from datetime import datetime
 from typing import List, Dict, Optional
@@ -180,6 +181,49 @@ class TestCompressHistoryTool:
         )
         print("OK: compress_conversation_history no compression needed")
 
+    def test_compress_conversation_history_counts_tool_calls_in_original_tokens(self):
+        """Test: original token stats include tool_calls sent to compression."""
+        large_args = "X" * 4000
+        messages = [
+            self.create_message(MessageRole.SYSTEM.value, "System"),
+            self.create_message(MessageRole.USER.value, "User 1"),
+            self.create_message(
+                MessageRole.ASSISTANT.value,
+                "",
+                msg_type=MessageType.TOOL_CALL.value,
+                tool_calls=[
+                    {
+                        "id": "call_large",
+                        "type": "function",
+                        "function": {
+                            "name": "large_tool",
+                            "arguments": large_args,
+                        },
+                    }
+                ],
+            ),
+            self.create_message(MessageRole.USER.value, "User 2"),
+        ]
+
+        async def fake_call_llm(messages_text, session_id):
+            del messages_text, session_id
+            return "short summary"
+
+        self.tool._call_llm_for_compression = fake_call_llm  # type: ignore[method-assign]
+        result = asyncio.run(
+            self.tool.compress_conversation_history(messages, "test_session")
+        )
+
+        assert result["status"] == "success"
+        match = re.search(r"(\d+)\s*tokens\s*→", result["message"])
+        assert match is not None
+        original_tokens = int(match.group(1))
+        content_only_tokens = sum(
+            self.tool._calculate_tokens(msg.get_content() or "") for msg in messages[1:3]
+        )
+        assert original_tokens > content_only_tokens + 500
+        print("OK: compress_conversation_history counts tool_calls")
+
     def test_compression_levels_config(self):
         """Test: compression levels configuration"""
         assert "light" in self.tool.compression_levels
@@ -281,6 +325,10 @@ def run_tests():
         (
             "test_compress_conversation_history_no_compress_needed",
             test_class.test_compress_conversation_history_no_compress_needed,
+        ),
+        (
+            "test_compress_conversation_history_counts_tool_calls_in_original_tokens",
+            test_class.test_compress_conversation_history_counts_tool_calls_in_original_tokens,
         ),
         ("test_compression_levels_config", test_class.test_compression_levels_config),
         # Integration tests


### PR DESCRIPTION
## Summary

Fix original token accounting in `compress_conversation_history` so assistant `tool_calls` are included in the pre-compression token count.

Previously, the original token count was calculated only from each message's `content`. However, the actual compression input is produced by `MessageManager.convert_messages_to_str(...)`, which includes assistant `tool_calls` when `content` is empty. This could undercount the original context size when tool call arguments were large.

## Changes

- Compute `original_tokens` from the formatted compression input (`messages_text`)
- Keep token accounting aligned with the actual text sent to the compression prompt
- Add a regression test for assistant messages with empty `content` and large `tool_calls.function.arguments`
- Include the new regression test in the manual `run_tests()` list

## Scope

This PR only fixes the original token accounting issue for `tool_calls`.

It does not change:

- LLM summary length budgeting
- Oversized summary truncation
- Compressed token accounting for the full tool result wrapper

## Tests

```bash
python3 -m pytest tests/sagents/messages/test_compress_history_tool.py::TestCompressHistoryTool::test_compress_conversation_history_counts_tool_calls_in_original_tokens -q