### PR TITLE
fix(agent): 持久压缩超长原始上下文

### DIFF
--- a/sagents/agent/agent_base.py
+++ b/sagents/agent/agent_base.py
@@ -92,7 +92,17 @@ class AgentBase(ABC):
         # 实际的上下文长度由 SessionContext 中的 context_budget_manager 动态管理
         # 这里只是作为兜底的安全阈值
 
-        self.max_model_input_len = 1000000
+        configured_max_input = None
+        configured_max_model = None
+        if isinstance(model_config, dict):
+            configured_max_input = model_config.get("max_model_input_len")
+            configured_max_model = model_config.get("max_model_len")
+        env_max_input = os.getenv("SAGE_MAX_MODEL_INPUT_LEN")
+        max_model_len = int(configured_max_model or 64000)
+        requested_max_input = int(
+            configured_max_input or env_max_input or max_model_len
+        )
+        self.max_model_input_len = min(requested_max_input, max_model_len)
 
         logger.debug(
             f"AgentBase: 初始化 {self.__class__.__name__}，模型配置: {model_config}, 最大输入长度（安全阈值）: {self.max_model_input_len}"

--- a/sagents/agent/simple_agent.py
+++ b/sagents/agent/simple_agent.py
@@ -736,6 +736,81 @@ class SimpleAgent(AgentBase):
             )
             return False
 
+    def _resolve_raw_context_limit(self, session_context: SessionContext) -> int:
+        configured = None
+        if getattr(session_context, "agent_config", None):
+            configured = session_context.agent_config.get("max_model_input_len")
+        max_model_len = int(self.model_config.get("max_model_len", 64000))
+        requested_limit = int(configured or self.max_model_input_len)
+        return min(requested_limit, max_model_len)
+
+    def _resolve_persistent_compression_threshold(
+        self, session_context: SessionContext, raw_context_limit: int
+    ) -> int:
+        configured = None
+        if getattr(session_context, "agent_config", None):
+            configured = session_context.agent_config.get(
+                "persistent_compression_threshold"
+            )
+        if configured is None and isinstance(self.model_config, dict):
+            configured = self.model_config.get("persistent_compression_threshold")
+        if configured is None:
+            configured = os.getenv("SAGE_PERSISTENT_COMPRESSION_THRESHOLD")
+        max_model_len = int(self.model_config.get("max_model_len", 64000))
+        upper_limit = min(raw_context_limit, max_model_len)
+        if configured:
+            return min(int(configured), upper_limit)
+        return max(1, int(upper_limit * 0.75))
+
+    async def _persistently_compress_raw_messages_if_needed(
+        self,
+        messages_input: List[MessageChunk],
+        session_id: str,
+        limit: int,
+        *,
+        force: bool = False,
+        message_manager: Optional[MessageManager] = None,
+    ) -> tuple[List[MessageChunk], List[MessageChunk], bool]:
+        current_tokens = MessageManager.calculate_messages_token_length(
+            cast(List[Union[MessageChunk, Dict[str, Any]]], messages_input)
+        )
+        if not force and current_tokens <= limit:
+            return messages_input, [], False
+
+        logger.info(
+            "SimpleAgent: 开始持久压缩raw消息上下文。"
+            f"当前: {current_tokens}, limit: {limit}, force: {force}"
+        )
+        emitted_chunks: List[MessageChunk] = []
+        async for messages_chunk in self._compress_messages_with_tool(
+            messages_input, session_id
+        ):
+            emitted_chunks.extend(messages_chunk)
+
+        if not emitted_chunks:
+            logger.warning("SimpleAgent: 持久压缩未产生任何工具消息")
+            return messages_input, [], current_tokens > limit
+
+        if message_manager is not None:
+            message_manager.add_messages(emitted_chunks)
+
+        messages_with_compression = MessageManager.merge_new_messages_to_old_messages(
+            cast(List[Union[MessageChunk, Dict[str, Any]]], emitted_chunks),
+            cast(List[Union[MessageChunk, Dict[str, Any]]], messages_input),
+        )
+        compacted_messages = MessageManager.extract_messages_for_inference(
+            messages_with_compression
+        )
+        compacted_tokens = MessageManager.calculate_messages_token_length(
+            compacted_messages
+        )
+        logger.info(
+            "SimpleAgent: raw消息持久压缩完成。"
+            f"{current_tokens} -> {compacted_tokens} tokens, "
+            f"消息数 {len(messages_input)} -> {len(compacted_messages)}"
+        )
+        return compacted_messages, emitted_chunks, compacted_tokens > limit
+
     async def _execute_loop(
         self,
         messages_input: List[MessageChunk],
@@ -780,6 +855,12 @@ class SimpleAgent(AgentBase):
         logger.debug(f"SimpleAgent: 加载历史签名 {len(recent_signatures)} 个")
         force_tool_choice_auto_next = False
         turn_status_only_next = False
+        raw_context_limit = self._resolve_raw_context_limit(session_context)
+        persistent_compression_threshold = (
+            self._resolve_persistent_compression_threshold(
+                session_context, raw_context_limit
+            )
+        )
         while True:
             if self._should_abort_due_to_session(session_context):
                 break
@@ -861,6 +942,38 @@ class SimpleAgent(AgentBase):
                     "SimpleAgent: 工具扩展后已刷新本轮工具列表: "
                     f"{[tool['function']['name'] for tool in tools_json]}"
                 )
+
+            current_raw_tokens = MessageManager.calculate_messages_token_length(
+                cast(List[Union[MessageChunk, Dict[str, Any]]], messages_input)
+            )
+            if current_raw_tokens > persistent_compression_threshold:
+                logger.info(
+                    "SimpleAgent: raw上下文达到持久压缩阈值，尝试压缩。"
+                    f"当前: {current_raw_tokens}, 阈值: {persistent_compression_threshold}, "
+                    f"硬上限: {raw_context_limit}"
+                )
+                (
+                    messages_input,
+                    compression_chunks,
+                    still_over_limit,
+                ) = await self._persistently_compress_raw_messages_if_needed(
+                    messages_input,
+                    session_id,
+                    raw_context_limit,
+                    force=True,
+                    message_manager=message_manager,
+                )
+                if compression_chunks:
+                    yield compression_chunks
+                if still_over_limit and current_raw_tokens > raw_context_limit:
+                    yield [
+                        MessageChunk(
+                            role=MessageRole.ASSISTANT.value,
+                            content=f"消息长度超过最大长度：{raw_context_limit},是否需要继续执行？",
+                            type=MessageType.AGENT_EXECUTION_ERROR.value,
+                        )
+                    ]
+                    break
 
             # 调用LLM
             should_break = False
@@ -1024,16 +1137,35 @@ class SimpleAgent(AgentBase):
                 MessageManager.calculate_messages_token_length(
                     cast(List[Union[MessageChunk, Dict[str, Any]]], messages_input)
                 )
-                > self.max_model_input_len
+                > raw_context_limit
             ):
                 logger.warning(
-                    f"SimpleAgent: 消息长度超过 {self.max_model_input_len}，截断消息"
+                    f"SimpleAgent: 消息长度超过 {raw_context_limit}，先尝试持久压缩"
+                )
+                (
+                    messages_input,
+                    compression_chunks,
+                    still_over_limit,
+                ) = await self._persistently_compress_raw_messages_if_needed(
+                    messages_input,
+                    session_id,
+                    raw_context_limit,
+                    force=True,
+                    message_manager=message_manager,
+                )
+                if compression_chunks:
+                    yield compression_chunks
+                if not still_over_limit:
+                    continue
+
+                logger.warning(
+                    f"SimpleAgent: 持久压缩后消息长度仍超过 {raw_context_limit}，暂停执行"
                 )
                 # 任务暂停，返回一个超长的错误消息块
                 yield [
                     MessageChunk(
                         role=MessageRole.ASSISTANT.value,
-                        content=f"消息长度超过最大长度：{self.max_model_input_len},是否需要继续执行？",
+                        content=f"消息长度超过最大长度：{raw_context_limit},是否需要继续执行？",
                         type=MessageType.AGENT_EXECUTION_ERROR.value,
                     )
                 ]

--- a/tests/sagents/agent/test_simple_agent_raw_context_compression.py
+++ b/tests/sagents/agent/test_simple_agent_raw_context_compression.py
@@ -1,0 +1,407 @@
+from types import SimpleNamespace
+
+import pytest
+
+from sagents.agent.simple_agent import SimpleAgent
+from sagents.context.messages.message import MessageChunk, MessageRole, MessageType
+from sagents.context.messages.message_manager import MessageManager
+
+
+def _msg(
+    role: str,
+    content: str,
+    message_type: str,
+    tool_call_id: str | None = None,
+) -> MessageChunk:
+    return MessageChunk(
+        role=role,
+        content=content,
+        message_type=message_type,
+        tool_call_id=tool_call_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_persistent_raw_context_compression_yields_tool_messages(monkeypatch):
+    agent = SimpleAgent(model=None, model_config={})
+    raw_messages = [
+        _msg(MessageRole.SYSTEM.value, "system", MessageType.SYSTEM.value),
+        _msg(MessageRole.USER.value, "please continue", MessageType.USER_INPUT.value),
+        _msg(
+            MessageRole.ASSISTANT.value,
+            "old output",
+            MessageType.ASSISTANT_TEXT.value,
+        ),
+    ]
+    tool_call = _msg(MessageRole.ASSISTANT.value, "", MessageType.TOOL_CALL.value)
+    tool_call.tool_calls = [
+        {
+            "id": "auto_compress_test",
+            "type": "function",
+            "function": {
+                "name": "compress_conversation_history",
+                "arguments": '{"session_id": "sess-test"}',
+            },
+        }
+    ]
+    tool_result = _msg(
+        MessageRole.TOOL.value,
+        "历史已压缩",
+        MessageType.TOOL_CALL_RESULT.value,
+        tool_call_id="auto_compress_test",
+    )
+    tool_result.metadata = {
+        "tool_name": "compress_conversation_history",
+        "auto_generated": True,
+        "status": "success",
+    }
+    compacted_messages = [raw_messages[1], tool_call, tool_result]
+
+    async def fake_compress(messages, session_id):
+        assert messages == raw_messages
+        assert session_id == "sess-test"
+        yield [tool_call]
+        yield [tool_result]
+
+    monkeypatch.setattr(agent, "_compress_messages_with_tool", fake_compress)
+    monkeypatch.setattr(
+        "sagents.agent.simple_agent.MessageManager.extract_messages_for_inference",
+        lambda messages: compacted_messages,
+    )
+    token_lengths = iter([1_000_001, 500])
+    monkeypatch.setattr(
+        "sagents.agent.simple_agent.MessageManager.calculate_messages_token_length",
+        lambda messages: next(token_lengths),
+    )
+
+    (
+        result_messages,
+        emitted_chunks,
+        still_over_limit,
+    ) = await agent._persistently_compress_raw_messages_if_needed(
+        raw_messages,
+        session_id="sess-test",
+        limit=1_000_000,
+        force=True,
+    )
+
+    assert result_messages == compacted_messages
+    assert emitted_chunks == [tool_call, tool_result]
+    assert still_over_limit is False
+
+
+@pytest.mark.asyncio
+async def test_persistent_raw_context_compression_writes_anchor_to_message_manager(
+    monkeypatch,
+):
+    agent = SimpleAgent(model=None, model_config={})
+    message_manager = MessageManager()
+    raw_messages = [
+        _msg(MessageRole.USER.value, "please continue", MessageType.USER_INPUT.value),
+        _msg(
+            MessageRole.ASSISTANT.value,
+            "old output",
+            MessageType.ASSISTANT_TEXT.value,
+        ),
+    ]
+    message_manager.add_messages(raw_messages)
+
+    tool_call = _msg(MessageRole.ASSISTANT.value, "", MessageType.TOOL_CALL.value)
+    tool_call.tool_calls = [
+        {
+            "id": "auto_compress_test",
+            "type": "function",
+            "function": {
+                "name": "compress_conversation_history",
+                "arguments": '{"session_id": "sess-test"}',
+            },
+        }
+    ]
+    tool_result = _msg(
+        MessageRole.TOOL.value,
+        "历史已压缩",
+        MessageType.TOOL_CALL_RESULT.value,
+        tool_call_id="auto_compress_test",
+    )
+    tool_result.metadata = {
+        "tool_name": "compress_conversation_history",
+        "auto_generated": True,
+        "status": "success",
+    }
+
+    async def fake_compress(messages, session_id):
+        yield [tool_call]
+        yield [tool_result]
+
+    monkeypatch.setattr(agent, "_compress_messages_with_tool", fake_compress)
+    monkeypatch.setattr(
+        "sagents.agent.simple_agent.MessageManager.extract_messages_for_inference",
+        lambda messages: [raw_messages[0], tool_call, tool_result],
+    )
+    token_lengths = iter([1_000_001, 500])
+    monkeypatch.setattr(
+        "sagents.agent.simple_agent.MessageManager.calculate_messages_token_length",
+        lambda messages: next(token_lengths),
+    )
+
+    await agent._persistently_compress_raw_messages_if_needed(
+        raw_messages,
+        session_id="sess-test",
+        limit=1_000_000,
+        force=True,
+        message_manager=message_manager,
+    )
+
+    assert message_manager.messages[-2:] == [tool_call, tool_result]
+    assert message_manager.active_start_index == len(message_manager.messages) - 2
+
+
+@pytest.mark.asyncio
+async def test_persistent_raw_context_compression_handles_real_100k_plus_context(
+    monkeypatch,
+):
+    configured_limit = 100_000
+    agent = SimpleAgent(model=None, model_config={})
+    message_manager = MessageManager()
+    raw_messages = [
+        _msg(MessageRole.USER.value, "continue the task", MessageType.USER_INPUT.value),
+        _msg(
+            MessageRole.ASSISTANT.value,
+            "A" * 600_000,
+            MessageType.ASSISTANT_TEXT.value,
+        ),
+    ]
+    message_manager.add_messages(raw_messages)
+    raw_tokens = MessageManager.calculate_messages_token_length(raw_messages)
+    assert raw_tokens > configured_limit
+
+    tool_call = _msg(MessageRole.ASSISTANT.value, "", MessageType.TOOL_CALL.value)
+    tool_call.tool_calls = [
+        {
+            "id": "auto_compress_100k",
+            "type": "function",
+            "function": {
+                "name": "compress_conversation_history",
+                "arguments": '{"session_id": "sess-100k"}',
+            },
+        }
+    ]
+    tool_result = _msg(
+        MessageRole.TOOL.value,
+        "压缩摘要：旧的大段 assistant 历史已经被总结。",
+        MessageType.TOOL_CALL_RESULT.value,
+        tool_call_id="auto_compress_100k",
+    )
+    tool_result.metadata = {
+        "tool_name": "compress_conversation_history",
+        "auto_generated": True,
+        "status": "success",
+    }
+
+    async def fake_compress(messages, session_id):
+        assert session_id == "sess-100k"
+        assert (
+            MessageManager.calculate_messages_token_length(messages) > configured_limit
+        )
+        yield [tool_call]
+        yield [tool_result]
+
+    monkeypatch.setattr(agent, "_compress_messages_with_tool", fake_compress)
+
+    (
+        result_messages,
+        emitted_chunks,
+        still_over_limit,
+    ) = await agent._persistently_compress_raw_messages_if_needed(
+        raw_messages,
+        session_id="sess-100k",
+        limit=configured_limit,
+        force=True,
+        message_manager=message_manager,
+    )
+
+    assert emitted_chunks == [tool_call, tool_result]
+    assert still_over_limit is False
+    assert (
+        MessageManager.calculate_messages_token_length(result_messages)
+        < configured_limit
+    )
+    assert raw_messages[1] not in result_messages
+    assert message_manager.messages[-2:] == [tool_call, tool_result]
+    assert message_manager.active_start_index == len(message_manager.messages) - 2
+
+
+@pytest.mark.asyncio
+async def test_execute_loop_compresses_real_oversized_raw_context_before_llm(
+    monkeypatch,
+):
+    agent = SimpleAgent(
+        model=None,
+        model_config={
+            "max_model_len": 128_000,
+            "persistent_compression_threshold": 100_000,
+        },
+    )
+    message_manager = MessageManager()
+    raw_messages = [
+        _msg(MessageRole.USER.value, "continue the task", MessageType.USER_INPUT.value),
+        _msg(
+            MessageRole.ASSISTANT.value,
+            "A" * 600_000,
+            MessageType.ASSISTANT_TEXT.value,
+        ),
+    ]
+    message_manager.add_messages(raw_messages)
+    raw_tokens = MessageManager.calculate_messages_token_length(raw_messages)
+    assert raw_tokens > 128_000
+
+    session_context = SimpleNamespace(
+        session_id=None,
+        agent_config={"max_loop_count": 3},
+        audit_status={},
+        message_manager=message_manager,
+        get_language=lambda: "zh",
+    )
+    tool_call = _msg(MessageRole.ASSISTANT.value, "", MessageType.TOOL_CALL.value)
+    tool_call.tool_calls = [
+        {
+            "id": "auto_compress_loop",
+            "type": "function",
+            "function": {
+                "name": "compress_conversation_history",
+                "arguments": '{"session_id": "sess-loop"}',
+            },
+        }
+    ]
+    tool_result = _msg(
+        MessageRole.TOOL.value,
+        "压缩摘要：主循环中的旧历史已经被总结。",
+        MessageType.TOOL_CALL_RESULT.value,
+        tool_call_id="auto_compress_loop",
+    )
+    tool_result.metadata = {
+        "tool_name": "compress_conversation_history",
+        "auto_generated": True,
+        "status": "success",
+    }
+    llm_inputs = []
+
+    async def fake_compress(messages, session_id):
+        assert session_id == "sess-loop"
+        assert raw_messages[1] in messages
+        yield [tool_call]
+        yield [tool_result]
+
+    async def fake_call_llm_and_process_response(
+        messages_input,
+        tools_json,
+        tool_manager,
+        session_id,
+        force_tool_choice_required=False,
+        force_tool_choice_auto=False,
+    ):
+        llm_inputs.append(messages_input)
+        yield (
+            [
+                _msg(
+                    MessageRole.ASSISTANT.value,
+                    "done",
+                    MessageType.ASSISTANT_TEXT.value,
+                )
+            ],
+            True,
+        )
+
+    monkeypatch.setattr(agent, "_compress_messages_with_tool", fake_compress)
+    monkeypatch.setattr(
+        agent,
+        "_call_llm_and_process_response",
+        fake_call_llm_and_process_response,
+    )
+
+    yielded_chunks = []
+    async for chunks in agent._execute_loop(
+        messages_input=raw_messages,
+        tools_json=[],
+        tool_manager=None,
+        session_id="sess-loop",
+        session_context=session_context,
+    ):
+        yielded_chunks.extend(chunks)
+
+    assert yielded_chunks[:2] == [tool_call, tool_result]
+    assert len(llm_inputs) == 1
+    assert raw_messages[1] not in llm_inputs[0]
+    assert MessageManager.calculate_messages_token_length(llm_inputs[0]) < 128_000
+    assert message_manager.messages[-2:] == [tool_call, tool_result]
+    assert message_manager.active_start_index == len(message_manager.messages) - 2
+
+
+def test_persistent_compression_threshold_can_be_configured_from_agent_config():
+    agent = SimpleAgent(model=None, model_config={"max_model_len": 200_000})
+    session_context = SimpleNamespace(
+        agent_config={"persistent_compression_threshold": 123_456}
+    )
+
+    assert (
+        agent._resolve_persistent_compression_threshold(session_context, 1_000_000)
+        == 123_456
+    )
+
+
+def test_persistent_compression_threshold_can_be_configured_from_model_config():
+    agent = SimpleAgent(
+        model=None,
+        model_config={
+            "max_model_len": 300_000,
+            "persistent_compression_threshold": 234_567,
+        },
+    )
+    session_context = SimpleNamespace(agent_config={})
+
+    assert (
+        agent._resolve_persistent_compression_threshold(session_context, 1_000_000)
+        == 234_567
+    )
+
+
+def test_persistent_compression_threshold_can_be_configured_from_env(monkeypatch):
+    monkeypatch.setenv("SAGE_PERSISTENT_COMPRESSION_THRESHOLD", "34567")
+    agent = SimpleAgent(model=None, model_config={"max_model_len": 64_000})
+    session_context = SimpleNamespace(agent_config={})
+
+    assert (
+        agent._resolve_persistent_compression_threshold(session_context, 1_000_000)
+        == 34_567
+    )
+
+
+def test_persistent_compression_threshold_is_capped_by_max_model_len():
+    agent = SimpleAgent(
+        model=None,
+        model_config={
+            "max_model_len": 64_000,
+            "persistent_compression_threshold": 100_000,
+        },
+    )
+    session_context = SimpleNamespace(agent_config={})
+
+    assert (
+        agent._resolve_persistent_compression_threshold(session_context, 1_000_000)
+        == 64_000
+    )
+
+
+def test_max_model_input_len_defaults_to_max_model_len():
+    agent = SimpleAgent(model=None, model_config={"max_model_len": 128_000})
+
+    assert agent.max_model_input_len == 128_000
+
+
+def test_max_model_input_len_is_capped_by_max_model_len():
+    agent = SimpleAgent(
+        model=None,
+        model_config={"max_model_len": 128_000, "max_model_input_len": 2_000_000},
+    )
+
+    assert agent.max_model_input_len == 128_000


### PR DESCRIPTION
修复问题：SimpleAgent 之前只会在请求 LLM 前临时压缩 prepared_messages，但不会把压缩结果写回 messages_input 或 message_manager。raw 会话账本会继续膨胀，最终触发 max_model_input_len 兜底并暂停。

修改范围：调整 AgentBase 的 max_model_input_len 默认值和上限，使其对齐 max_model_len；在 SimpleAgent 中增加 raw 上下文持久压缩阈值解析、压缩 tool_call/tool_result 写回 message_manager、压缩后按锚点裁剪当前 messages_input；raw 超限时先尝试持久压缩，压缩后仍超限才暂停。

配置行为：persistent_compression_threshold 可通过 agent_config、model_config 或 SAGE_PERSISTENT_COMPRESSION_THRESHOLD 配置；max_model_input_len 可通过 agent_config、model_config 或 SAGE_MAX_MODEL_INPUT_LEN 配置；两者最终有效值都不会超过 max_model_len。

测试：新增 SimpleAgent raw context compression 测试，覆盖 100k+ helper 场景和真实 _execute_loop 超过 max_model_len 后先持久压缩再请求 LLM 的场景。验证命令：.venv/bin/pytest -q tests/sagents/agent/test_simple_agent_raw_context_compression.py。