### PR TITLE
Detect repeated tool calls and render inline protocol cards

### DIFF
--- a/app/desktop/ui/src/components/chat/DeliveryCollapsedGroup.vue
+++ b/app/desktop/ui/src/components/chat/DeliveryCollapsedGroup.vue
@@ -27,7 +27,7 @@
         :extract-workbench-items="false"
         :hide-assistant-avatar="true"
         @download-file="$emit('downloadFile', $event)"
-        @sendMessage="$emit('sendMessage', $event)"
+        @sendMessage="(...args) => $emit('sendMessage', ...args)"
         @openSubSession="$emit('openSubSession', $event)"
       />
     </div>

--- a/app/desktop/ui/src/components/chat/InlineArtifactsCard.vue
+++ b/app/desktop/ui/src/components/chat/InlineArtifactsCard.vue
@@ -1,0 +1,180 @@
+<template>
+  <div class="artifacts-card w-full max-w-md">
+    <div class="rounded-lg border border-border/70 bg-white/85 shadow-sm backdrop-blur-xl transition-colors dark:bg-card/80">
+      <div class="flex items-center gap-3 border-b border-border/70 p-3">
+        <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <PackageOpen class="h-4 w-4" />
+        </div>
+        <div class="min-w-0 flex-1">
+          <div class="truncate text-sm font-medium text-foreground">
+            {{ artifacts.title || 'Artifacts' }}
+          </div>
+        </div>
+        <Badge variant="outline" class="text-[10px]">
+          {{ artifacts.items.length }}
+        </Badge>
+      </div>
+
+      <div class="space-y-2 p-3">
+        <button
+          v-for="item in artifacts.items"
+          :key="item.id || item.path"
+          type="button"
+          class="group flex w-full cursor-pointer items-center gap-3 rounded-md border border-border/70 bg-background/70 p-3 text-left transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          @click="openArtifact(item)"
+        >
+          <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+            <component :is="iconForItem(item)" class="h-4 w-4" />
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class="truncate text-sm font-medium leading-5 text-foreground">
+              {{ item.title }}
+            </div>
+            <div class="truncate text-xs leading-5 text-muted-foreground">
+              {{ item.path }}
+            </div>
+          </div>
+          <Badge v-if="item.status" variant="outline" class="shrink-0 text-[10px]">
+            {{ item.status }}
+          </Badge>
+          <ExternalLink class="h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import {
+  ExternalLink,
+  File,
+  FileArchive,
+  FileImage,
+  FileSpreadsheet,
+  FileText,
+  FileVideo,
+  PackageOpen,
+  Presentation,
+} from 'lucide-vue-next'
+import { Badge } from '@/components/ui/badge'
+import { useWorkbenchStore } from '@/stores/workbench.js'
+import { usePanelStore } from '@/stores/panel.js'
+import { resolveAgentWorkspacePath } from '@/utils/agentWorkspacePath'
+
+const props = defineProps({
+  artifacts: {
+    type: Object,
+    required: true,
+  },
+  messageId: {
+    type: String,
+    default: '',
+  },
+  agentId: {
+    type: String,
+    default: '',
+  },
+})
+
+const workbenchStore = useWorkbenchStore()
+const panelStore = usePanelStore()
+
+function iconForItem(item) {
+  switch (item.type) {
+    case 'markdown':
+    case 'text':
+    case 'pdf':
+      return FileText
+    case 'image':
+      return FileImage
+    case 'video':
+      return FileVideo
+    case 'spreadsheet':
+      return FileSpreadsheet
+    case 'presentation':
+      return Presentation
+    case 'archive':
+      return FileArchive
+    default:
+      return File
+  }
+}
+
+async function openArtifact(item) {
+  const resolvedPath = await resolveAgentWorkspacePath(item.path, props.agentId)
+  const normalizedPath = normalizePath(resolvedPath || item.path)
+  const stableKey = props.messageId
+    ? `file:${props.messageId}:${normalizedPath}`
+    : `file:${normalizedPath}`
+
+  panelStore.openWorkbench()
+  workbenchStore.setRealtime(false)
+
+  const targetByMessage = (workbenchStore.items || []).find((entry) => entry?.stableKey === stableKey)
+  if (jumpToWorkbenchItem(targetByMessage)) return
+
+  const targetByPath = [...(workbenchStore.items || [])].reverse().find((entry) => (
+    (entry?.type === 'file' || entry?.type === 'image') &&
+    normalizePath(workbenchPathForItem(entry)) === normalizedPath
+  ))
+  if (jumpToWorkbenchItem(targetByPath)) return
+
+  const createdItem = workbenchStore.addItem({
+    type: item.type === 'image' ? 'image' : 'file',
+    role: 'assistant',
+    timestamp: Date.now(),
+    messageId: props.messageId || null,
+    stableKey,
+    data: {
+      filePath: normalizedPath,
+      path: normalizedPath,
+      fileName: item.title || fileNameFromPath(normalizedPath),
+      src: item.type === 'image' ? normalizedPath : undefined,
+    },
+  })
+  jumpToWorkbenchItem(createdItem)
+}
+
+function jumpToWorkbenchItem(item) {
+  if (!item) return false
+  if (item.sessionId) {
+    workbenchStore.setSessionId(item.sessionId, { autoJumpToLast: false })
+  }
+  const index = (workbenchStore.filteredItems || []).findIndex((entry) => entry?.id === item.id)
+  if (index !== -1) {
+    workbenchStore.setCurrentIndex(index)
+    return true
+  }
+  return false
+}
+
+function workbenchPathForItem(item) {
+  const data = item?.data || {}
+  if (item?.type === 'image') return data.src || data.filePath || data.path || ''
+  return data.filePath || data.path || data.src || ''
+}
+
+function normalizePath(path) {
+  if (!path) return ''
+  let normalized = String(path)
+  try {
+    normalized = decodeURIComponent(normalized).trim()
+  } catch {
+    normalized = String(path).trim()
+  }
+  if (normalized.startsWith('`') && normalized.endsWith('`')) {
+    normalized = normalized.slice(1, -1)
+  }
+  if (normalized.startsWith('/sage-workspace/')) {
+    normalized = normalized.replace('/sage-workspace/', '/')
+  }
+  if (normalized.startsWith('file://')) {
+    normalized = normalized.replace(/^file:\/\/\/?/i, '/')
+  }
+  return normalized
+}
+
+function fileNameFromPath(path) {
+  return String(path || '').split('/').filter(Boolean).pop() || 'file'
+}
+</script>

--- a/app/desktop/ui/src/components/chat/InlineQuestionnaireCard.vue
+++ b/app/desktop/ui/src/components/chat/InlineQuestionnaireCard.vue
@@ -1,0 +1,289 @@
+<template>
+  <div class="questionnaire-card w-full max-w-md">
+    <div class="rounded-lg border border-border/70 bg-white/85 shadow-sm backdrop-blur-xl transition-colors dark:bg-card/80">
+      <div class="flex items-center gap-3 border-b border-border/70 p-3">
+        <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <ClipboardList class="h-4 w-4" />
+        </div>
+        <div class="min-w-0 flex-1">
+          <div class="truncate text-sm font-medium text-foreground">
+            {{ questionnaire.title || t('tools.questionnaire.title') }}
+          </div>
+        </div>
+        <Badge v-if="submitted" variant="outline" class="text-[10px]">
+          {{ t('tools.questionnaire.completed') }}
+        </Badge>
+        <div v-else-if="questionnaire.questions.length > 1" class="text-xs font-medium text-muted-foreground">
+          {{ currentIndex + 1 }}/{{ questionnaire.questions.length }}
+        </div>
+      </div>
+
+      <div v-if="questionnaire.questions.length > 1" class="h-1 bg-muted/50">
+        <div
+          class="h-full rounded-full bg-primary/80 transition-[width] duration-200"
+          :style="{ width: `${progress}%` }"
+        />
+      </div>
+
+      <div class="space-y-4 p-4">
+        <InlineQuestionnaireResponse
+          v-if="submittedResponse"
+          :response="submittedResponse"
+        />
+
+        <template v-else-if="currentQuestion">
+          <div class="space-y-3 rounded-md bg-muted/30 p-3">
+            <div class="text-sm font-medium leading-6 text-foreground">
+              {{ currentQuestion.text }}
+            </div>
+
+            <div v-if="currentQuestion.type === 'single_choice'" class="flex flex-wrap gap-2">
+              <button
+                v-for="option in currentQuestion.options"
+                :key="option.value"
+                type="button"
+                class="inline-flex min-h-9 cursor-pointer items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                :class="singleValue === option.value ? selectedChoiceClass : idleChoiceClass"
+                :disabled="!canEdit"
+                @click="setSingleValue(option.value)"
+              >
+                <CircleDot v-if="singleValue === option.value" class="h-4 w-4" />
+                <Circle v-else class="h-4 w-4" />
+                <span>{{ option.label }}</span>
+              </button>
+              <button
+                v-if="currentQuestion.allowOther"
+                type="button"
+                class="inline-flex min-h-9 cursor-pointer items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                :class="singleValue === otherValue ? selectedChoiceClass : idleChoiceClass"
+                :disabled="!canEdit"
+                @click="setSingleValue(otherValue)"
+              >
+                <CircleDot v-if="singleValue === otherValue" class="h-4 w-4" />
+                <Circle v-else class="h-4 w-4" />
+                <span>其他</span>
+              </button>
+            </div>
+
+            <div v-else-if="currentQuestion.type === 'multi_choice'" class="flex flex-wrap gap-2">
+              <button
+                v-for="option in currentQuestion.options"
+                :key="option.value"
+                type="button"
+                class="inline-flex min-h-9 cursor-pointer items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                :class="multiValues.includes(option.value) ? selectedChoiceClass : idleChoiceClass"
+                :disabled="!canEdit"
+                @click="toggleMultiValue(option.value)"
+              >
+                <CheckSquare v-if="multiValues.includes(option.value)" class="h-4 w-4" />
+                <Square v-else class="h-4 w-4" />
+                <span>{{ option.label }}</span>
+              </button>
+              <button
+                v-if="currentQuestion.allowOther"
+                type="button"
+                class="inline-flex min-h-9 cursor-pointer items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                :class="multiValues.includes(otherValue) ? selectedChoiceClass : idleChoiceClass"
+                :disabled="!canEdit"
+                @click="toggleMultiValue(otherValue)"
+              >
+                <CheckSquare v-if="multiValues.includes(otherValue)" class="h-4 w-4" />
+                <Square v-else class="h-4 w-4" />
+                <span>其他</span>
+              </button>
+            </div>
+
+            <Textarea
+              v-if="currentQuestion.type === 'free_text'"
+              v-model="textValue"
+              rows="3"
+              class="resize-none bg-background/70"
+              :disabled="!canEdit"
+            />
+            <Textarea
+              v-else-if="showOtherInput"
+              v-model="otherText"
+              rows="2"
+              class="resize-none bg-background/70"
+              :disabled="!canEdit"
+            />
+          </div>
+
+          <div class="flex items-center gap-2 border-t border-border/70 pt-3">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              class="h-9 w-10 px-0"
+              :disabled="currentIndex === 0 || isSubmitting || submitted"
+              @click="goBack"
+            >
+              <ChevronLeft class="h-4 w-4" />
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              class="h-9 flex-1"
+              :disabled="isSubmitting || submitted || (isLastQuestion && !canSubmit)"
+              @click="handlePrimary"
+            >
+              <Loader2 v-if="isSubmitting" class="mr-2 h-4 w-4 animate-spin" />
+              <template v-else-if="isLastQuestion">
+                <Send class="mr-2 h-4 w-4" />
+                {{ t('tools.questionnaire.submit') }}
+              </template>
+              <template v-else>
+                {{ t('common.next') || '继续' }}
+                <ChevronRight class="ml-2 h-4 w-4" />
+              </template>
+            </Button>
+          </div>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  CheckSquare,
+  ChevronLeft,
+  ChevronRight,
+  Circle,
+  CircleDot,
+  ClipboardList,
+  Loader2,
+  Send,
+  Square,
+} from 'lucide-vue-next'
+import { useLanguage } from '@/utils/i18n'
+import { buildQuestionnaireSubmission, initialQuestionnaireDraft } from '@/utils/inlineQuestionnaire.js'
+import InlineQuestionnaireResponse from './InlineQuestionnaireResponse.vue'
+
+const otherValue = '__questionnaire_other__'
+const selectedChoiceClass = 'border-primary/60 bg-primary/10 text-primary dark:bg-primary/15'
+const idleChoiceClass = 'border-border/80 bg-background/70 text-foreground hover:bg-muted/60'
+
+const props = defineProps({
+  questionnaire: {
+    type: Object,
+    required: true,
+  },
+  canSubmit: {
+    type: Boolean,
+    default: true,
+  },
+})
+
+const emit = defineEmits(['submit'])
+const { t } = useLanguage()
+
+const draft = ref(initialQuestionnaireDraft(props.questionnaire))
+const currentIndex = ref(0)
+const isSubmitting = ref(false)
+const submittedResponse = ref(null)
+
+const submitted = computed(() => submittedResponse.value !== null)
+const canEdit = computed(() => props.canSubmit && !isSubmitting.value && !submitted.value)
+const currentQuestion = computed(() => props.questionnaire.questions[currentIndex.value] || null)
+const isLastQuestion = computed(() => currentIndex.value >= props.questionnaire.questions.length - 1)
+const progress = computed(() => {
+  const count = props.questionnaire.questions.length || 1
+  return Math.round(((currentIndex.value + 1) / count) * 100)
+})
+
+const singleValue = computed(() => {
+  if (currentQuestion.value?.type !== 'single_choice') return ''
+  return draft.value[currentQuestion.value.id]?.value || ''
+})
+const multiValues = computed(() => {
+  if (currentQuestion.value?.type !== 'multi_choice') return []
+  return draft.value[currentQuestion.value.id]?.values || []
+})
+const textValue = computed({
+  get() {
+    if (currentQuestion.value?.type !== 'free_text') return ''
+    return draft.value[currentQuestion.value.id] || ''
+  },
+  set(value) {
+    if (currentQuestion.value?.type !== 'free_text') return
+    draft.value[currentQuestion.value.id] = value
+  },
+})
+const otherText = computed({
+  get() {
+    const question = currentQuestion.value
+    if (!question || question.type === 'free_text') return ''
+    return draft.value[question.id]?.otherText || ''
+  },
+  set(value) {
+    const question = currentQuestion.value
+    if (!question || question.type === 'free_text') return
+    draft.value[question.id] = {
+      ...(draft.value[question.id] || {}),
+      otherText: value,
+    }
+  },
+})
+const showOtherInput = computed(() => {
+  const question = currentQuestion.value
+  if (!question?.allowOther) return false
+  if (question.type === 'single_choice') return singleValue.value === otherValue
+  if (question.type === 'multi_choice') return multiValues.value.includes(otherValue)
+  return false
+})
+
+function setSingleValue(value) {
+  if (!canEdit.value || !currentQuestion.value) return
+  draft.value[currentQuestion.value.id] = {
+    ...(draft.value[currentQuestion.value.id] || {}),
+    value,
+  }
+}
+
+function toggleMultiValue(value) {
+  if (!canEdit.value || !currentQuestion.value) return
+  const questionId = currentQuestion.value.id
+  const existing = draft.value[questionId]?.values || []
+  const values = existing.includes(value)
+    ? existing.filter((item) => item !== value)
+    : [...existing, value]
+  draft.value[questionId] = {
+    ...(draft.value[questionId] || {}),
+    values,
+  }
+}
+
+function goBack() {
+  currentIndex.value = Math.max(0, currentIndex.value - 1)
+}
+
+function handlePrimary() {
+  if (!isLastQuestion.value) {
+    currentIndex.value = Math.min(props.questionnaire.questions.length - 1, currentIndex.value + 1)
+    return
+  }
+  submit()
+}
+
+async function submit() {
+  if (!props.canSubmit || isSubmitting.value || submitted.value) return
+  isSubmitting.value = true
+  try {
+    const submission = buildQuestionnaireSubmission(props.questionnaire, draft.value)
+    submittedResponse.value = {
+      tag: props.questionnaire.tag,
+      questionnaireId: props.questionnaire.id,
+      status: 'submitted',
+      answers: submission.answers,
+    }
+    emit('submit', submission)
+  } finally {
+    isSubmitting.value = false
+  }
+}
+</script>

--- a/app/desktop/ui/src/components/chat/InlineQuestionnaireRenderer.vue
+++ b/app/desktop/ui/src/components/chat/InlineQuestionnaireRenderer.vue
@@ -1,0 +1,71 @@
+<template>
+  <div class="inline-questionnaire-renderer flex w-full flex-col gap-3">
+    <template v-for="part in parts" :key="part.key">
+      <MarkdownRendererWithPreview
+        v-if="part.type === 'markdown' && part.content.trim()"
+        :content="part.content"
+        :compact="compact"
+        :message-id="messageId"
+        :agent-id="agentId"
+      />
+      <InlineQuestionnaireCard
+        v-else-if="part.type === 'questionnaire'"
+        :questionnaire="part.payload"
+        :can-submit="canSubmit"
+        @submit="handleSubmit"
+      />
+      <InlineQuestionnaireResponse
+        v-else-if="part.type === 'questionnaire_response'"
+        :response="part.payload"
+      />
+      <InlineArtifactsCard
+        v-else-if="part.type === 'artifacts'"
+        :artifacts="part.payload"
+        :message-id="messageId"
+        :agent-id="agentId"
+      />
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import MarkdownRendererWithPreview from './MarkdownRendererWithPreview.vue'
+import InlineQuestionnaireCard from './InlineQuestionnaireCard.vue'
+import InlineQuestionnaireResponse from './InlineQuestionnaireResponse.vue'
+import InlineArtifactsCard from './InlineArtifactsCard.vue'
+import { splitInlineQuestionnaireContent } from '@/utils/inlineQuestionnaire.js'
+
+const props = defineProps({
+  content: {
+    type: String,
+    default: '',
+  },
+  compact: {
+    type: Boolean,
+    default: false,
+  },
+  messageId: {
+    type: String,
+    default: '',
+  },
+  agentId: {
+    type: String,
+    default: '',
+  },
+  canSubmit: {
+    type: Boolean,
+    default: true,
+  },
+})
+
+const emit = defineEmits(['sendMessage'])
+
+const parts = computed(() => (
+  splitInlineQuestionnaireContent(props.content, props.messageId || 'assistant_questionnaire')
+))
+
+function handleSubmit(submission) {
+  emit('sendMessage', submission.agentText, { displayContent: submission.displayText })
+}
+</script>

--- a/app/desktop/ui/src/components/chat/InlineQuestionnaireResponse.vue
+++ b/app/desktop/ui/src/components/chat/InlineQuestionnaireResponse.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="space-y-3 rounded-md bg-muted/30 p-3">
+    <div class="flex items-center gap-2 text-sm font-medium text-green-600 dark:text-green-400">
+      <CheckCircle2 class="h-4 w-4" />
+      <span>{{ statusText }}</span>
+    </div>
+    <div class="space-y-3">
+      <div
+        v-for="(answer, index) in response.answers"
+        :key="answer.question_id || answer.question || index"
+        class="space-y-1"
+      >
+        <div class="text-sm font-medium leading-6 text-foreground">
+          {{ answer.question || answer.question_id }}
+        </div>
+        <div class="text-sm leading-6 text-muted-foreground">
+          {{ displayValueForAnswer(answer) }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { CheckCircle2 } from 'lucide-vue-next'
+import { useLanguage } from '@/utils/i18n'
+import { displayValueForAnswer } from '@/utils/inlineQuestionnaire.js'
+
+const props = defineProps({
+  response: {
+    type: Object,
+    required: true,
+  },
+})
+
+const { t } = useLanguage()
+
+const statusText = computed(() => (
+  props.response.status === 'timeout_default'
+    ? t('tools.questionnaire.autoSubmitted')
+    : t('tools.questionnaire.submitted')
+))
+</script>

--- a/app/desktop/ui/src/components/chat/MessageRenderer.vue
+++ b/app/desktop/ui/src/components/chat/MessageRenderer.vue
@@ -76,8 +76,11 @@
               class="overflow-hidden transition-[max-height] duration-200 ease-out"
               :class="{ 'max-h-[200px]': isUserContentCollapsed && isUserContentLong }"
             >
-              <MarkdownRenderer
+              <InlineQuestionnaireRenderer
                 :content="formatMessageContent(getTextContent(message.content))"
+                :message-id="message.message_id || message.id"
+                :agent-id="agentId"
+                :can-submit="false"
               />
             </div>
             <!-- 折叠时底部渐隐遮罩，提示有更多内容 -->
@@ -195,10 +198,12 @@
           <div
             v-if="getTextContent(message.content)"
             class="text-foreground/90 overflow-hidden break-words w-full font-sans text-sm leading-6">
-            <MarkdownRendererWithPreview
+            <InlineQuestionnaireRenderer
               :content="formatMessageContent(getTextContent(message.content))"
               :message-id="message.message_id || message.id"
               :agent-id="agentId"
+              :can-submit="!readonly && isLatestMessage"
+              @sendMessage="handleSendMessage"
             />
           </div>
           <!-- 兜底：没有 markdown 引用的孤立 image_url -->
@@ -292,8 +297,7 @@
 import { computed, h, ref, onMounted, watch } from 'vue'
 import { useLanguage } from '../../utils/i18n.js'
 import MessageAvatar from './MessageAvatar.vue'
-import MarkdownRenderer from './MarkdownRenderer.vue'
-import MarkdownRendererWithPreview from './MarkdownRendererWithPreview.vue'
+import InlineQuestionnaireRenderer from './InlineQuestionnaireRenderer.vue'
 import EChartsRenderer from './EChartsRenderer.vue'
 import SyntaxHighlighter from './SyntaxHighlighter.vue'
 import TokenUsage from './TokenUsage.vue'
@@ -662,8 +666,8 @@ const handleDownloadFile = (filePath) => {
   emit('downloadFile', filePath)
 }
 
-const handleSendMessage = (text) => {
-  emit('sendMessage', text)
+const handleSendMessage = (text, options) => {
+  emit('sendMessage', text, options)
 }
 
 const handleStartEditUserMessage = () => {

--- a/app/desktop/ui/src/utils/__tests__/inlineQuestionnaire.spec.js
+++ b/app/desktop/ui/src/utils/__tests__/inlineQuestionnaire.spec.js
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildQuestionnaireSubmission,
+  displayTextForAnswers,
+  initialQuestionnaireDraft,
+  splitInlineQuestionnaireContent,
+} from '../inlineQuestionnaire.js'
+
+describe('inlineQuestionnaire', () => {
+  it('parses movo artifacts and keeps them in message order', () => {
+    const parts = splitInlineQuestionnaireContent(
+      String.raw`本次产出：
+<movo-artifacts>{\"title\":\"本次更新\",\"items\":[{\"type\":\"markdown\",\"title\":\"正式视频计划\",\"path\":\"video_projects/dog-owner-bond-20260615/videos/video-01/video_plan.md\",\"status\":\"created\"}]}</movo-artifacts>
+继续。`,
+      'artifacts_1'
+    )
+
+    expect(parts).toHaveLength(3)
+    expect(parts[1]).toMatchObject({
+      type: 'artifacts',
+      tag: 'movo-artifacts',
+    })
+    expect(parts[1].payload.title).toBe('本次更新')
+    expect(parts[1].payload.items[0]).toMatchObject({
+      type: 'markdown',
+      title: '正式视频计划',
+      path: 'video_projects/dog-owner-bond-20260615/videos/video-01/video_plan.md',
+      status: 'created',
+    })
+  })
+
+  it('supports all artifacts tag aliases', () => {
+    for (const tag of ['ling-artifacts', 'sage-artifacts', 'artifacts']) {
+      const parts = splitInlineQuestionnaireContent(
+        `<${tag}>{"items":[{"title":"报告","path":"reports/out.pdf","status":"created"}]}</${tag}>`,
+        tag
+      )
+      expect(parts[0].type).toBe('artifacts')
+      expect(parts[0].payload.tag).toBe(tag)
+      expect(parts[0].payload.items[0]).toMatchObject({
+        type: 'pdf',
+        title: '报告',
+        path: 'reports/out.pdf',
+      })
+    }
+  })
+
+  it('parses movo questionnaire tags at their markdown position', () => {
+    const parts = splitInlineQuestionnaireContent(
+      '先确认。\n\n<movo-questionnaire>{"title":"小狗视频确认","questions":[{"type":"single_choice","text":"成片画幅？","options":["9:16","16:9"],"default":"9:16"},{"type":"free_text","text":"补充？","default":""}]}</movo-questionnaire>',
+      'assistant_1'
+    )
+
+    expect(parts).toHaveLength(2)
+    expect(parts[0]).toMatchObject({ type: 'markdown' })
+    expect(parts[1]).toMatchObject({
+      type: 'questionnaire',
+      tag: 'movo-questionnaire',
+    })
+    expect(parts[1].payload.title).toBe('小狗视频确认')
+    expect(parts[1].payload.questions[0]).toMatchObject({
+      id: 'q1',
+      type: 'single_choice',
+      text: '成片画幅？',
+      defaultValue: '9:16',
+    })
+  })
+
+  it('supports all questionnaire tag aliases and multiple choice synonyms', () => {
+    for (const tag of ['ling-questionnaire', 'sage-questionnaire', 'questionnaire']) {
+      const parts = splitInlineQuestionnaireContent(
+        `<${tag}>{"questions":[{"type":"multiple_choice","text":"选项？","options":["A","B"],"default":["A"]}]}</${tag}>`,
+        tag
+      )
+      expect(parts[0].type).toBe('questionnaire')
+      expect(parts[0].payload.tag).toBe(tag)
+      expect(parts[0].payload.questions[0].type).toBe('multi_choice')
+      expect(parts[0].payload.questions[0].defaultValues).toEqual(['A'])
+    }
+  })
+
+  it('parses html entity and escaped transport payloads', () => {
+    const htmlParts = splitInlineQuestionnaireContent(
+      '&lt;ling-questionnaire&gt;{&quot;questions&quot;:[{&quot;type&quot;:&quot;single_choice&quot;,&quot;text&quot;:&quot;能量？&quot;,&quot;options&quot;:[&quot;低&quot;,&quot;高&quot;]}]}&lt;/ling-questionnaire&gt;',
+      'html'
+    )
+    expect(htmlParts[0].payload.questions[0].text).toBe('能量？')
+
+    const escapedParts = splitInlineQuestionnaireContent(
+      String.raw`<sage-questionnaire>{\"questions\":[{\"type\":\"free_text\",\"text\":\"补充？\",\"default\":\"先轻一点\"}]}<\/sage-questionnaire>`,
+      'escaped'
+    )
+    expect(escapedParts[0].payload.questions[0]).toMatchObject({
+      type: 'free_text',
+      defaultText: '先轻一点',
+    })
+  })
+
+  it('builds a frontend submission input and display text', () => {
+    const questionnaire = splitInlineQuestionnaireContent(
+      '<movo-questionnaire>{"questions":[{"type":"single_choice","text":"画幅？","options":["9:16","16:9"],"default":"9:16"},{"type":"multi_choice","text":"风格？","options":["温暖","活泼"]},{"type":"free_text","text":"补充？","default":"无"}]}</movo-questionnaire>',
+      'assistant'
+    )[0].payload
+    const draft = initialQuestionnaireDraft(questionnaire)
+    draft.q1.value = '16:9'
+    draft.q2.values = ['温暖', '活泼']
+    draft.q3 = '不要字幕'
+
+    const submission = buildQuestionnaireSubmission(questionnaire, draft)
+
+    expect(submission.agentText).toContain('<movo-questionnaire-response>')
+    expect(submission.agentText).toContain('"questionnaire_id":"assistant_q1"')
+    expect(submission.displayText).toBe(
+      displayTextForAnswers(submission.answers)
+    )
+    expect(submission.displayText).toContain('画幅？：16:9')
+    expect(submission.displayText).toContain('风格？：温暖、活泼')
+    expect(submission.displayText).toContain('补充？：不要字幕')
+  })
+})

--- a/app/desktop/ui/src/utils/inlineQuestionnaire.js
+++ b/app/desktop/ui/src/utils/inlineQuestionnaire.js
@@ -1,0 +1,427 @@
+const QUESTIONNAIRE_TAGS = ['movo-questionnaire', 'ling-questionnaire', 'sage-questionnaire', 'questionnaire']
+const RESPONSE_TAGS = QUESTIONNAIRE_TAGS.map((tag) => `${tag}-response`)
+const ARTIFACT_TAGS = ['movo-artifacts', 'ling-artifacts', 'sage-artifacts', 'artifacts']
+
+const TAG_PATTERN = new RegExp(
+  `<(${[...QUESTIONNAIRE_TAGS, ...RESPONSE_TAGS, ...ARTIFACT_TAGS].join('|')})(\\s[^>]*)?>([\\s\\S]*?)<\\\\?/\\1\\s*>`,
+  'gi'
+)
+
+const BASIC_HTML_ENTITIES = [
+  [/&quot;/g, '"'],
+  [/&#34;/g, '"'],
+  [/&apos;/g, "'"],
+  [/&#39;/g, "'"],
+  [/&lt;/g, '<'],
+  [/&gt;/g, '>'],
+  [/&amp;/g, '&'],
+]
+
+export function splitInlineQuestionnaireContent(content, keyPrefix = 'questionnaire') {
+  const text = normalizeTransportText(String(content || ''))
+  const parts = []
+  let lastIndex = 0
+  let match
+  let count = 0
+
+  TAG_PATTERN.lastIndex = 0
+  while ((match = TAG_PATTERN.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push({
+        type: 'markdown',
+        key: `${keyPrefix}-text-${count}`,
+        content: text.slice(lastIndex, match.index),
+      })
+    }
+
+    const tag = match[1].toLowerCase()
+    const attrs = parseAttributes(match[2] || '')
+    const rawJson = match[3] || ''
+    const isResponse = tag.endsWith('-response')
+    const isArtifacts = ARTIFACT_TAGS.includes(tag)
+    const baseTag = isResponse ? tag.slice(0, -'-response'.length) : tag
+    const payload = isArtifacts
+      ? parseArtifacts(rawJson, { tag })
+      : isResponse
+        ? parseQuestionnaireResponse(rawJson, baseTag)
+        : parseQuestionnaire(rawJson, {
+            attrs,
+            tag: baseTag,
+            id: `${keyPrefix}_q${count + 1}`,
+          })
+
+    if (payload) {
+      parts.push({
+        type: isArtifacts ? 'artifacts' : isResponse ? 'questionnaire_response' : 'questionnaire',
+        key: `${keyPrefix}-${isArtifacts ? 'artifacts' : isResponse ? 'response' : 'questionnaire'}-${count}`,
+        tag: baseTag,
+        payload,
+      })
+    } else {
+      parts.push({
+        type: 'markdown',
+        key: `${keyPrefix}-invalid-${count}`,
+        content: match[0],
+      })
+    }
+
+    count += 1
+    lastIndex = TAG_PATTERN.lastIndex
+  }
+
+  if (lastIndex < text.length) {
+    parts.push({
+      type: 'markdown',
+      key: `${keyPrefix}-text-${count}`,
+      content: text.slice(lastIndex),
+    })
+  }
+
+  return parts
+}
+
+export function parseArtifacts(rawJson, { tag = 'artifacts' } = {}) {
+  const decoded = decodeJsonObject(rawJson)
+  if (!decoded || !Array.isArray(decoded.items)) return null
+
+  const items = decoded.items
+    .map((item, index) => normalizeArtifactItem(item, index))
+    .filter(Boolean)
+
+  if (items.length === 0) return null
+
+  return {
+    tag,
+    title: asString(decoded.title).trim(),
+    items,
+  }
+}
+
+export function parseQuestionnaire(rawJson, { attrs = {}, tag = 'questionnaire', id = 'questionnaire_q1' } = {}) {
+  const decoded = decodeJsonObject(rawJson)
+  if (!decoded || !Array.isArray(decoded.questions)) return null
+
+  const questions = decoded.questions
+    .map((rawQuestion, index) => normalizeQuestion(rawQuestion, index))
+    .filter(Boolean)
+
+  if (questions.length === 0) return null
+
+  const attrTimeout = parsePositiveInt(attrs.timeout_seconds)
+  const payloadTimeout = parsePositiveInt(decoded.timeout_seconds)
+
+  return {
+    id,
+    tag,
+    title: asString(decoded.title).trim(),
+    timeoutSeconds: attrTimeout || payloadTimeout || 0,
+    questions,
+  }
+}
+
+export function buildQuestionnaireSubmission(questionnaire, draftAnswers, status = 'submitted') {
+  const answers = questionnaire.questions.map((question) => {
+    const draft = draftAnswers?.[question.id]
+    if (question.type === 'free_text') {
+      return {
+        question_id: question.id,
+        question: question.text,
+        type: 'free_text',
+        answer: asString(draft).trim(),
+      }
+    }
+
+    if (question.type === 'multi_choice') {
+      const values = Array.isArray(draft?.values) ? draft.values : []
+      const labels = values.map((value) => labelForValue(question, value)).filter(Boolean)
+      const answer = {
+        question_id: question.id,
+        question: question.text,
+        type: 'multi_choice',
+        answer: values,
+        values,
+        labels,
+      }
+      if (asString(draft?.otherText).trim()) answer.other_text = asString(draft.otherText).trim()
+      return answer
+    }
+
+    const value = asString(draft?.value).trim()
+    const answer = {
+      question_id: question.id,
+      question: question.text,
+      type: 'single_choice',
+      answer: value,
+      value,
+      label: labelForValue(question, value),
+    }
+    if (asString(draft?.otherText).trim()) answer.other_text = asString(draft.otherText).trim()
+    return answer
+  })
+
+  const responseTag = `${questionnaire.tag}-response`
+  const payload = {
+    type: `${questionnaire.tag.replace(/-/g, '_')}_response`,
+    questionnaire_id: questionnaire.id,
+    status,
+    answers,
+  }
+
+  return {
+    agentText: `<${responseTag}>${JSON.stringify(payload)}</${responseTag}>`,
+    displayText: displayTextForAnswers(answers),
+    answers,
+  }
+}
+
+export function parseQuestionnaireResponse(rawJson, tag = 'questionnaire') {
+  const decoded = decodeJsonObject(rawJson)
+  if (!decoded || !Array.isArray(decoded.answers)) return null
+  return {
+    tag,
+    questionnaireId: asString(decoded.questionnaire_id).trim(),
+    status: asString(decoded.status).trim() || 'submitted',
+    answers: decoded.answers.map(normalizeAnswer).filter(Boolean),
+  }
+}
+
+export function displayTextForAnswers(answers) {
+  const lines = ['问卷回答']
+  for (const answer of answers || []) {
+    lines.push(`${answer.question || answer.question_id || '问题'}：${displayValueForAnswer(answer)}`)
+  }
+  return lines.join('\n')
+}
+
+export function displayValueForAnswer(answer) {
+  if (!answer) return '未填写'
+  if (answer.type === 'free_text') {
+    const text = asString(answer.answer || answer.text).trim()
+    return text || '未填写'
+  }
+
+  const parts = []
+  const labels = Array.isArray(answer.labels) && answer.labels.length
+    ? answer.labels
+    : Array.isArray(answer.answer)
+      ? answer.answer
+      : [answer.label || answer.answer || answer.value]
+
+  for (const item of labels) {
+    const value = asString(item).trim()
+    if (value) parts.push(value)
+  }
+  const otherText = asString(answer.other_text || answer.otherText).trim()
+  if (otherText) parts.push(otherText)
+  return parts.length ? parts.join('、') : '未选择'
+}
+
+export function initialQuestionnaireDraft(questionnaire) {
+  const draft = {}
+  for (const question of questionnaire.questions || []) {
+    if (question.type === 'free_text') {
+      draft[question.id] = question.defaultText || ''
+    } else if (question.type === 'multi_choice') {
+      draft[question.id] = {
+        values: [...question.defaultValues],
+        otherText: '',
+      }
+    } else {
+      draft[question.id] = {
+        value: question.defaultValue || '',
+        otherText: '',
+      }
+    }
+  }
+  return draft
+}
+
+function normalizeQuestion(rawQuestion, index) {
+  if (!rawQuestion || typeof rawQuestion !== 'object') return null
+  const type = normalizeQuestionType(rawQuestion.type)
+  const text = asString(rawQuestion.text).trim()
+  if (!type || !text) return null
+
+  const id = asString(rawQuestion.id).trim() || `q${index + 1}`
+  const options = Array.isArray(rawQuestion.options)
+    ? rawQuestion.options.map(normalizeOption).filter(Boolean)
+    : []
+
+  if (type !== 'free_text' && options.length === 0) return null
+
+  const defaultRaw = rawQuestion.default ?? rawQuestion.default_value
+  const defaultValues = Array.isArray(defaultRaw)
+    ? defaultRaw.map((value) => asString(value).trim()).filter(Boolean)
+    : []
+  const defaultValue = !Array.isArray(defaultRaw) ? asString(defaultRaw).trim() : ''
+
+  return {
+    id,
+    type,
+    text,
+    options,
+    allowOther: rawQuestion.allow_other === true,
+    defaultValue,
+    defaultValues,
+    defaultText: type === 'free_text' ? defaultValue || asString(rawQuestion.default_text).trim() : '',
+  }
+}
+
+function normalizeQuestionType(type) {
+  const value = asString(type).trim()
+  if (value === 'single_choice') return 'single_choice'
+  if (value === 'multi_choice' || value === 'multiple_choice') return 'multi_choice'
+  if (value === 'free_text' || value === 'text') return 'free_text'
+  return null
+}
+
+function normalizeOption(rawOption) {
+  if (typeof rawOption === 'string') {
+    const value = rawOption.trim()
+    return value ? { value, label: value } : null
+  }
+  if (!rawOption || typeof rawOption !== 'object') return null
+  const value = asString(rawOption.value).trim() || asString(rawOption.label).trim()
+  const label = asString(rawOption.label).trim() || value
+  return value && label ? { value, label } : null
+}
+
+function normalizeArtifactItem(rawItem, index) {
+  if (!rawItem || typeof rawItem !== 'object') return null
+  const path = asString(rawItem.path).trim()
+  if (!path) return null
+  return {
+    id: asString(rawItem.id).trim() || `artifact_${index + 1}`,
+    type: asString(rawItem.type).trim() || inferArtifactType(path),
+    title: asString(rawItem.title).trim() || fileNameFromPath(path),
+    path,
+    status: asString(rawItem.status).trim(),
+  }
+}
+
+function inferArtifactType(path) {
+  const extension = path.split('.').pop()?.toLowerCase() || ''
+  if (['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'].includes(extension)) return 'image'
+  if (['mp4', 'mov', 'webm'].includes(extension)) return 'video'
+  if (['csv', 'xlsx', 'xls'].includes(extension)) return 'spreadsheet'
+  if (['ppt', 'pptx'].includes(extension)) return 'presentation'
+  if (extension === 'pdf') return 'pdf'
+  if (['md', 'markdown'].includes(extension)) return 'markdown'
+  return 'file'
+}
+
+function fileNameFromPath(path) {
+  return path.split('/').filter(Boolean).pop() || path
+}
+
+function normalizeAnswer(rawAnswer) {
+  if (!rawAnswer || typeof rawAnswer !== 'object') return null
+  const type = normalizeQuestionType(rawAnswer.type)
+  const question = asString(rawAnswer.question).trim()
+  if (!type || !question) return null
+  return {
+    ...rawAnswer,
+    type,
+    question,
+  }
+}
+
+function decodeJsonObject(rawJson) {
+  for (const candidate of jsonDecodeCandidates(rawJson)) {
+    try {
+      const decoded = JSON.parse(candidate)
+      if (decoded && typeof decoded === 'object' && !Array.isArray(decoded)) {
+        return decoded
+      }
+      if (typeof decoded === 'string') {
+        const nestedDecoded = JSON.parse(decoded)
+        if (nestedDecoded && typeof nestedDecoded === 'object' && !Array.isArray(nestedDecoded)) {
+          return nestedDecoded
+        }
+      }
+    } catch {
+      // Try the next normalization candidate.
+    }
+  }
+  return null
+}
+
+function jsonDecodeCandidates(rawJson) {
+  const normalized = String(rawJson || '').trim()
+  if (!normalized) return []
+  const htmlDecoded = decodeBasicHtmlEntities(normalized)
+  const unescaped = unescapeTransportJson(normalized)
+  const htmlDecodedUnescaped = unescapeTransportJson(htmlDecoded)
+  return [...new Set([
+    normalized,
+    unescaped,
+    htmlDecoded,
+    htmlDecodedUnescaped,
+    normalizeSmartJsonQuotes(normalized),
+    normalizeSmartJsonQuotes(unescaped),
+    normalizeSmartJsonQuotes(htmlDecoded),
+    normalizeSmartJsonQuotes(htmlDecodedUnescaped),
+  ])]
+}
+
+function normalizeTransportText(value) {
+  const trimmed = String(value || '')
+  if (!trimmed.startsWith('"') || !trimmed.endsWith('"')) {
+    return decodeBasicHtmlEntities(trimmed)
+  }
+  try {
+    const decoded = JSON.parse(trimmed)
+    return typeof decoded === 'string' ? decodeBasicHtmlEntities(decoded) : decodeBasicHtmlEntities(trimmed)
+  } catch {
+    return decodeBasicHtmlEntities(trimmed)
+  }
+}
+
+function unescapeTransportJson(value) {
+  return value
+    .replace(/\\"/g, '"')
+    .replace(/\\n/g, '\n')
+    .replace(/\\r/g, '\r')
+    .replace(/\\t/g, '\t')
+    .replace(/<\\\//g, '</')
+}
+
+function decodeBasicHtmlEntities(value) {
+  return BASIC_HTML_ENTITIES.reduce((text, [pattern, replacement]) => (
+    text.replace(pattern, replacement)
+  ), value)
+}
+
+function normalizeSmartJsonQuotes(value) {
+  return value
+    .replace(/\u201c/g, '"')
+    .replace(/\u201d/g, '"')
+    .replace(/\u2018/g, "'")
+    .replace(/\u2019/g, "'")
+}
+
+function parseAttributes(rawAttrs) {
+  const attrs = {}
+  const pattern = /([a-zA-Z_:-][a-zA-Z0-9_:-]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+))/g
+  let match
+  while ((match = pattern.exec(rawAttrs || '')) !== null) {
+    attrs[match[1]] = match[2] ?? match[3] ?? match[4] ?? ''
+  }
+  return attrs
+}
+
+function parsePositiveInt(value) {
+  const parsed = Number.parseInt(String(value || ''), 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+}
+
+function labelForValue(question, value) {
+  const stringValue = asString(value).trim()
+  if (!stringValue) return ''
+  if (stringValue === '__questionnaire_other__') return '其他'
+  return question.options.find((option) => option.value === stringValue)?.label || stringValue
+}
+
+function asString(value) {
+  return typeof value === 'string' ? value : ''
+}

--- a/sagents/utils/repeat_pattern.py
+++ b/sagents/utils/repeat_pattern.py
@@ -56,9 +56,7 @@ def _function_attr(function: Any, name: str, default: Any = "") -> Any:
     return getattr(function, name, default)
 
 
-def _append_tool_call_signature(
-    tool_call_parts: List[str], fn: Any, args: Any
-) -> None:
+def _append_tool_call_signature(tool_call_parts: List[str], fn: Any, args: Any) -> None:
     fn_norm = normalize_text(str(fn or ""))
     tool_call_parts.append(f"{fn_norm}:{short_hash(stable_json(args))}")
 

--- a/sagents/utils/repeat_pattern.py
+++ b/sagents/utils/repeat_pattern.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from sagents.context.messages.message import MessageChunk, MessageRole, MessageType
 
@@ -12,8 +12,17 @@ def normalize_text(text: str) -> str:
     return re.sub(r"\s+", " ", (text or "").strip())
 
 
-def stable_json(raw: str) -> str:
-    raw = (raw or "").strip()
+def stable_json(raw: Any) -> str:
+    if raw is None:
+        return ""
+    if not isinstance(raw, str):
+        try:
+            return json.dumps(
+                raw, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+            )
+        except Exception:
+            return normalize_text(str(raw))
+    raw = raw.strip()
     if not raw:
         return ""
     try:
@@ -29,30 +38,108 @@ def short_hash(text: str) -> str:
     return hashlib.sha1((text or "").encode("utf-8")).hexdigest()[:12]
 
 
+def _tool_call_attr(tool_call: Any, name: str, default: Any = None) -> Any:
+    if isinstance(tool_call, dict):
+        return tool_call.get(name, default)
+    return getattr(tool_call, name, default)
+
+
+def _tool_call_function(tool_call: Any) -> Any:
+    if isinstance(tool_call, dict):
+        return tool_call.get("function") or {}
+    return getattr(tool_call, "function", None)
+
+
+def _function_attr(function: Any, name: str, default: Any = "") -> Any:
+    if isinstance(function, dict):
+        return function.get(name, default)
+    return getattr(function, name, default)
+
+
+def _append_tool_call_signature(
+    tool_call_parts: List[str], fn: Any, args: Any
+) -> None:
+    fn_norm = normalize_text(str(fn or ""))
+    tool_call_parts.append(f"{fn_norm}:{short_hash(stable_json(args))}")
+
+
+def _build_tool_call_parts(chunks: List[MessageChunk]) -> List[str]:
+    """Normalize streamed tool-call deltas into complete name+argument entries."""
+    tool_call_parts: List[str] = []
+    pending_by_key: Dict[str, Dict[str, Any]] = {}
+    key_by_index: Dict[int, str] = {}
+    pending_order: List[str] = []
+    last_key: Optional[str] = None
+
+    for chunk in chunks:
+        for tool_call in chunk.tool_calls or []:
+            tc_id = _tool_call_attr(tool_call, "id", "") or ""
+            tc_index = _tool_call_attr(tool_call, "index", None)
+            fn_obj = _tool_call_function(tool_call)
+            fn = _function_attr(fn_obj, "name", "") or ""
+            args = _function_attr(fn_obj, "arguments", "") or ""
+
+            # Dict tool calls from non-streaming responses normally have no index and
+            # already contain complete arguments, so they can be signed directly.
+            if tc_index is None and isinstance(tool_call, dict):
+                _append_tool_call_signature(tool_call_parts, fn, args)
+                continue
+
+            key: Optional[str] = None
+            if tc_id:
+                key = tc_id
+                if tc_index is not None:
+                    key_by_index[tc_index] = key
+            elif tc_index is not None and tc_index in key_by_index:
+                key = key_by_index[tc_index]
+            elif tc_index is not None:
+                key = f"index:{tc_index}"
+                key_by_index[tc_index] = key
+            elif last_key:
+                key = last_key
+
+            if key is None:
+                _append_tool_call_signature(tool_call_parts, fn, args)
+                continue
+
+            entry = pending_by_key.get(key)
+            if entry is None:
+                entry = {"name": "", "arguments": ""}
+                pending_by_key[key] = entry
+                pending_order.append(key)
+            if fn:
+                entry["name"] = fn
+            if args:
+                entry["arguments"] += args
+            last_key = key
+
+    for key in pending_order:
+        entry = pending_by_key[key]
+        _append_tool_call_signature(
+            tool_call_parts, entry.get("name", ""), entry.get("arguments", "")
+        )
+
+    return tool_call_parts
+
+
+def _signature_has_tool_calls(signature: str) -> bool:
+    try:
+        parsed = json.loads(signature)
+    except Exception:
+        return False
+    tool_calls = parsed.get("tool_calls") if isinstance(parsed, dict) else None
+    return bool(tool_calls)
+
+
 def build_loop_signature(chunks: List[MessageChunk]) -> str:
     """
     构建单轮执行签名（文本 + 工具调用 + 工具结果）。
     """
     text_parts: List[str] = []
-    tool_call_parts: List[str] = []
+    tool_call_parts = _build_tool_call_parts(chunks)
     tool_result_parts: List[str] = []
 
     for chunk in chunks:
-        if chunk.tool_calls:
-            for tool_call in chunk.tool_calls:
-                fn = ""
-                args = ""
-                if isinstance(tool_call, dict):
-                    fn = (tool_call.get("function") or {}).get("name") or ""
-                    args = (tool_call.get("function") or {}).get("arguments") or ""
-                else:
-                    fn = getattr(getattr(tool_call, "function", None), "name", "") or ""
-                    args = (
-                        getattr(getattr(tool_call, "function", None), "arguments", "")
-                        or ""
-                    )
-                tool_call_parts.append(f"{fn}:{short_hash(stable_json(args))}")
-
         if chunk.role == MessageRole.ASSISTANT.value and (chunk.content or "").strip():  # pyright: ignore[reportAttributeAccessIssue]
             if chunk.message_type != MessageType.REASONING_CONTENT.value:
                 text_parts.append(normalize_text(chunk.content))  # pyright: ignore[reportArgumentType]
@@ -101,7 +188,12 @@ def detect_repeat_pattern(
             idx -= period
 
         if cycles >= min_cycles:
-            if period == 1 and cycles == 2 and idx > 0:
+            if (
+                period == 1
+                and cycles == 2
+                and idx > 0
+                and not _signature_has_tool_calls(pattern[0])
+            ):
                 continue
             return {
                 "period": period,

--- a/tests/sagents/agent/test_simple_agent_repeat_pattern.py
+++ b/tests/sagents/agent/test_simple_agent_repeat_pattern.py
@@ -1,4 +1,8 @@
 import time
+from types import SimpleNamespace
+
+import pytest
+
 from sagents.context.messages.message import MessageChunk, MessageRole, MessageType
 from sagents.utils.repeat_pattern import build_loop_signature, detect_repeat_pattern
 
@@ -27,6 +31,57 @@ def _assistant_tool_call(name: str, arguments: str) -> MessageChunk:
         ],
         message_type=MessageType.TOOL_CALL.value,
     )
+
+
+def _assistant_tool_calls(tool_calls) -> MessageChunk:
+    return MessageChunk(
+        role=MessageRole.ASSISTANT.value,
+        content="",
+        tool_calls=tool_calls,
+        message_type=MessageType.TOOL_CALL.value,
+    )
+
+
+def _assistant_tool_call_delta(
+    *,
+    call_id: str = "",
+    index: int = 0,
+    name: str = "",
+    arguments: str = "",
+) -> MessageChunk:
+    return MessageChunk(
+        role=MessageRole.ASSISTANT.value,
+        content="",
+        tool_calls=[
+            SimpleNamespace(
+                id=call_id,
+                index=index,
+                type="function",
+                function=SimpleNamespace(name=name, arguments=arguments),
+            )
+        ],
+        message_type=MessageType.TOOL_CALL.value,
+    )
+
+
+def _dict_tool_call(
+    *,
+    call_id: str = "call_1",
+    name: str,
+    arguments,
+    index=None,
+) -> dict:
+    tool_call = {
+        "id": call_id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": arguments,
+        },
+    }
+    if index is not None:
+        tool_call["index"] = index
+    return tool_call
 
 
 def _tool_result(content: str, tool_name: str = "unknown_tool") -> MessageChunk:
@@ -101,6 +156,22 @@ def test_detect_repeat_pattern_abcaabca():
     assert pattern["cycles"] == 2
 
 
+def test_detect_repeat_pattern_adjacent_repeat_after_different_signature():
+    signatures = [
+        build_loop_signature([_assistant_text("先查一下今天的消息。")]),
+        build_loop_signature(
+            [_assistant_tool_call("web_search", '{"query":"智谱 02513 今天"}')]
+        ),
+        build_loop_signature(
+            [_assistant_tool_call("web_search", '{"query":"智谱 02513 今天"}')]
+        ),
+    ]
+    pattern = detect_repeat_pattern(signatures)
+    assert pattern is not None
+    assert pattern["period"] == 1
+    assert pattern["cycles"] == 2
+
+
 def test_no_false_positive_for_non_repeating_sequence():
     signatures = ["A", "B", "C", "D", "E", "F", "G"]
     pattern = detect_repeat_pattern(signatures)
@@ -138,6 +209,250 @@ def test_signature_distinguishes_tool_name_even_same_args():
     sig_1 = build_loop_signature(chunks_1)
     sig_2 = build_loop_signature(chunks_2)
     assert sig_1 != sig_2
+
+
+def test_signature_coalesces_streamed_tool_call_deltas():
+    chunks_1 = [
+        _assistant_tool_call_delta(
+            call_id="call_1",
+            index=0,
+            name="web_search",
+            arguments='{"query":"智谱',
+        ),
+        _assistant_tool_call_delta(
+            index=0,
+            arguments=' 02513 今天","count":10',
+        ),
+        _assistant_tool_call_delta(
+            index=0,
+            arguments=',"recency_filter":"oneDay"}',
+        ),
+    ]
+    chunks_2 = [
+        _assistant_tool_call_delta(
+            call_id="call_2",
+            index=0,
+            name="web_search",
+            arguments='{"query":"智谱 02513 今天",',
+        ),
+        _assistant_tool_call_delta(
+            index=0,
+            arguments='"count":10,"recency_filter":"oneDay"}',
+        ),
+    ]
+
+    assert build_loop_signature(chunks_1) == build_loop_signature(chunks_2)
+
+
+@pytest.mark.parametrize(
+    ("left_chunks", "right_chunks"),
+    [
+        pytest.param(
+            [
+                _assistant_tool_call(
+                    "web_search",
+                    '{"query":"智谱 02513 今天","count":10,"recency_filter":"oneDay"}',
+                )
+            ],
+            [
+                _assistant_tool_call(
+                    "web_search",
+                    '{"recency_filter":"oneDay","count":10,"query":"智谱 02513 今天"}',
+                )
+            ],
+            id="dict-tool-call-json-key-order",
+        ),
+        pytest.param(
+            [
+                _assistant_tool_calls(
+                    [
+                        _dict_tool_call(
+                            name="web_search",
+                            arguments={
+                                "query": "智谱 02513 今天",
+                                "count": 10,
+                                "recency_filter": "oneDay",
+                            },
+                        )
+                    ]
+                )
+            ],
+            [
+                _assistant_tool_call(
+                    "web_search",
+                    '{"query":"智谱 02513 今天","count":10,"recency_filter":"oneDay"}',
+                )
+            ],
+            id="dict-arguments-vs-json-string",
+        ),
+        pytest.param(
+            [
+                _assistant_tool_call_delta(
+                    call_id="call_1",
+                    index=0,
+                    name="web_search",
+                    arguments='{"query":"智谱',
+                ),
+                _assistant_tool_call_delta(
+                    index=0,
+                    arguments=' 02513 今天","count":10',
+                ),
+                _assistant_tool_call_delta(
+                    index=0,
+                    arguments=',"recency_filter":"oneDay"}',
+                ),
+            ],
+            [
+                _assistant_tool_call_delta(
+                    call_id="call_2",
+                    index=0,
+                    name="web_search",
+                    arguments='{"query":"智谱 02513 今天",',
+                ),
+                _assistant_tool_call_delta(
+                    index=0,
+                    arguments='"count":10,"recency_filter":"oneDay"}',
+                ),
+            ],
+            id="object-streamed-different-splits",
+        ),
+        pytest.param(
+            [
+                _assistant_tool_call_delta(
+                    index=0,
+                    name="web_search",
+                    arguments='{"query":"智谱 02513 今天"',
+                ),
+                _assistant_tool_call_delta(
+                    index=0,
+                    arguments=',"count":10}',
+                ),
+            ],
+            [
+                _assistant_tool_call_delta(
+                    index=0,
+                    name="web_search",
+                    arguments='{"count":10,',
+                ),
+                _assistant_tool_call_delta(
+                    index=0,
+                    arguments='"query":"智谱 02513 今天"}',
+                ),
+            ],
+            id="streamed-without-id-by-index",
+        ),
+        pytest.param(
+            [
+                _assistant_tool_calls(
+                    [
+                        _dict_tool_call(
+                            call_id="call_a",
+                            name="web_search",
+                            arguments='{"query":"智谱"}',
+                        ),
+                        _dict_tool_call(
+                            call_id="call_b",
+                            name="fetch_webpages",
+                            arguments='{"urls":["https://example.com"]}',
+                        ),
+                    ]
+                )
+            ],
+            [
+                _assistant_tool_calls(
+                    [
+                        _dict_tool_call(
+                            call_id="call_x",
+                            name="web_search",
+                            arguments='{"query":"智谱"}',
+                        ),
+                        _dict_tool_call(
+                            call_id="call_y",
+                            name="fetch_webpages",
+                            arguments='{"urls":["https://example.com"]}',
+                        ),
+                    ]
+                )
+            ],
+            id="multi-tool-same-order-different-call-ids",
+        ),
+    ],
+)
+def test_signature_equivalence_matrix_for_tool_calls(left_chunks, right_chunks):
+    assert build_loop_signature(left_chunks) == build_loop_signature(right_chunks)
+
+
+@pytest.mark.parametrize(
+    ("left_chunks", "right_chunks"),
+    [
+        pytest.param(
+            [_assistant_tool_call("web_search", '{"query":"智谱"}')],
+            [_assistant_tool_call("web_search", '{"query":"阿里"}')],
+            id="same-tool-different-args",
+        ),
+        pytest.param(
+            [_assistant_tool_call("web_search", '{"query":"智谱"}')],
+            [_assistant_tool_call("memory_recall", '{"query":"智谱"}')],
+            id="same-args-different-tool",
+        ),
+        pytest.param(
+            [
+                _assistant_tool_calls(
+                    [
+                        _dict_tool_call(
+                            call_id="call_a",
+                            name="web_search",
+                            arguments='{"query":"智谱"}',
+                        ),
+                        _dict_tool_call(
+                            call_id="call_b",
+                            name="fetch_webpages",
+                            arguments='{"urls":["https://example.com"]}',
+                        ),
+                    ]
+                )
+            ],
+            [
+                _assistant_tool_calls(
+                    [
+                        _dict_tool_call(
+                            call_id="call_y",
+                            name="fetch_webpages",
+                            arguments='{"urls":["https://example.com"]}',
+                        ),
+                        _dict_tool_call(
+                            call_id="call_x",
+                            name="web_search",
+                            arguments='{"query":"智谱"}',
+                        ),
+                    ]
+                )
+            ],
+            id="multi-tool-order-is-significant",
+        ),
+        pytest.param(
+            [
+                _assistant_tool_call_delta(
+                    call_id="call_1",
+                    index=0,
+                    name="web_search",
+                    arguments='{"query":"智谱"}',
+                )
+            ],
+            [
+                _assistant_tool_call_delta(
+                    call_id="call_2",
+                    index=0,
+                    name="web_search",
+                    arguments='{"query":"智谱","count":10}',
+                )
+            ],
+            id="streamed-same-tool-different-final-args",
+        ),
+    ],
+)
+def test_signature_distinction_matrix_for_tool_calls(left_chunks, right_chunks):
+    assert build_loop_signature(left_chunks) != build_loop_signature(right_chunks)
 
 
 def test_signature_distinguishes_tool_result_tool_name():
@@ -179,6 +494,38 @@ def test_replay_detects_tool_call_cycle():
     ]
     hit_steps = _detect_steps_from_rounds(rounds)
     assert hit_steps and hit_steps[0] == 4
+
+
+def test_replay_detects_repeated_streamed_tool_call_with_same_args():
+    rounds = [
+        [_assistant_text("先查一下今天的消息。")],
+        [
+            _assistant_tool_call_delta(
+                call_id="call_1",
+                index=0,
+                name="web_search",
+                arguments='{"query":"智谱 02513 今天","count":',
+            ),
+            _assistant_tool_call_delta(
+                index=0,
+                arguments='10,"recency_filter":"oneDay"}',
+            ),
+        ],
+        [
+            _assistant_tool_call_delta(
+                call_id="call_2",
+                index=0,
+                name="web_search",
+                arguments='{"query":"智谱 02513 今天",',
+            ),
+            _assistant_tool_call_delta(
+                index=0,
+                arguments='"count":10,"recency_filter":"oneDay"}',
+            ),
+        ],
+    ]
+    hit_steps = _detect_steps_from_rounds(rounds)
+    assert hit_steps == [3]
 
 
 def test_replay_not_detected_for_progressive_tool_plan():


### PR DESCRIPTION
## Summary
- normalize streamed and non-streamed tool calls into stable name+argument signatures
- detect adjacent repeated tool calls across repeated tool-call patterns
- render inline questionnaire tags in chat messages and submit them as response-tag user input
- render inline artifacts tags as clickable file artifact cards in the conversation flow

## Tests
- .venv/bin/pytest tests/sagents/agent/test_simple_agent_repeat_pattern.py -q
- git diff --check
- lightweight SFC compile checks for inline questionnaire/artifacts components
- lightweight JS parsing checks for escaped questionnaire and artifacts payloads

Note: targeted Vitest/Vite runs for the desktop UI were killed by the local environment with exit 137 before assertions ran.