### PR TITLE
Fix rerun guidance preserving session history

### DIFF
--- a/sagents/session_runtime.py
+++ b/sagents/session_runtime.py
@@ -663,6 +663,16 @@ class Session:
         await self.session_context.init_more()
 
         self._cache_session_workspace(session_id, self.session_context)
+        if not self.session_context.message_manager.messages:
+            persisted_messages = self._load_persisted_messages()
+            if persisted_messages:
+                self.session_context.message_manager.messages = list(
+                    persisted_messages
+                )
+                logger.debug(
+                    f"SessionRuntime: restored {len(persisted_messages)} persisted "
+                    f"messages before merging new input, session_id={session_id}"
+                )
         return self.session_context
 
     def _get_agent(self, agent_key: str) -> AgentBase:

--- a/sagents/session_runtime.py
+++ b/sagents/session_runtime.py
@@ -666,9 +666,7 @@ class Session:
         if not self.session_context.message_manager.messages:
             persisted_messages = self._load_persisted_messages()
             if persisted_messages:
-                self.session_context.message_manager.messages = list(
-                    persisted_messages
-                )
+                self.session_context.message_manager.messages = list(persisted_messages)
                 logger.debug(
                     f"SessionRuntime: restored {len(persisted_messages)} persisted "
                     f"messages before merging new input, session_id={session_id}"

--- a/tests/sagents/context/test_context_budget_config.py
+++ b/tests/sagents/context/test_context_budget_config.py
@@ -1,8 +1,11 @@
 import asyncio
+import json
 
 from sagents.context.messages.context_budget import ContextBudgetManager
+from sagents.context.messages.message import MessageChunk, MessageRole
 from sagents.context.session_context import SessionContext, SessionStatus
 from sagents.session_runtime import Session
+from sagents.utils.sandbox.config import VolumeMount
 
 
 def test_overflow_budget_is_persisted_on_manager():
@@ -109,3 +112,61 @@ def test_reused_session_context_normalizes_camel_case_budget_config():
 
     manager = session.session_context.message_manager.context_budget_manager
     assert manager.max_model_len == 128000
+
+
+def test_new_session_context_restores_persisted_messages_before_merge(tmp_path):
+    session_id = "s1"
+    session_workspace = tmp_path / session_id
+    session_workspace.mkdir()
+    persisted = [
+        MessageChunk(
+            role=MessageRole.USER.value,
+            content="first",
+            message_id="m1",
+        ).to_dict(),
+        MessageChunk(
+            role=MessageRole.ASSISTANT.value,
+            content="reply",
+            message_id="m2",
+        ).to_dict(),
+    ]
+    (session_workspace / "messages.json").write_text(
+        json.dumps(persisted),
+        encoding="utf-8",
+    )
+
+    session = Session(session_id=session_id, enable_obs=False)
+    session.session_root_space = str(tmp_path)
+    session.agent_id = "a1"
+    agent_workspace = tmp_path / "agent_workspace"
+    agent_workspace.mkdir()
+    session.sandbox_agent_workspace = str(agent_workspace)
+    session.volume_mounts = [
+        VolumeMount(host_path=str(agent_workspace), mount_path=str(agent_workspace))
+    ]
+    session.sandbox_id = None
+
+    context = asyncio.run(
+        session._ensure_session_context(
+            session_id=session_id,
+            user_id="u1",
+            system_context={"rerun_from_guidance": True},
+            context_budget_config=None,
+            tool_manager=None,
+            skill_manager=None,
+        )
+    )
+
+    context.add_messages(
+        MessageChunk(
+            role=MessageRole.USER.value,
+            content="guidance",
+            message_id="guidance-1",
+        )
+    )
+
+    assert [message.message_id for message in context.message_manager.messages] == [
+        "m1",
+        "m2",
+        "guidance-1",
+    ]


### PR DESCRIPTION
## Summary
- restore persisted session messages when a new SessionContext is created before merging rerun/guidance input
- prevent rerun guidance from overwriting messages.json with only the guidance-era messages
- add regression coverage for persisted history plus a new guidance message

## Tests
- .venv/bin/pytest tests/sagents/context/test_context_budget_config.py -q
- git diff --check -- sagents/session_runtime.py tests/sagents/context/test_context_budget_config.py
- .venv/bin/python -m py_compile sagents/session_runtime.py tests/sagents/context/test_context_budget_config.py