### PR TITLE
Document environment variable coverage

### DIFF
--- a/docs/en/ENV_VARS.md
+++ b/docs/en/ENV_VARS.md
@@ -42,17 +42,30 @@ Advanced overrides are not listed in `.env.example` unless a deployment needs to
 | `SAGE_DEFAULT_LLM_MAX_TOKENS` | `4096` | Default max output tokens |
 | `SAGE_DEFAULT_LLM_TEMPERATURE` | `0.2` | Default sampling temperature |
 | `SAGE_DEFAULT_LLM_MAX_MODEL_LEN` | `52000` | Default context length |
+| `SAGE_DEFAULT_LLM_TOP_P` | `1.0` | Default nucleus sampling value |
+| `SAGE_DEFAULT_LLM_PRESENCE_PENALTY` | `0.0` | Default presence penalty |
+| `SAGE_REASONING_EFFORT_OFF` | `low` | Reasoning effort to use for OpenAI reasoning models when thinking is disabled; accepts provider-supported values such as `minimal` / `low` / `medium` / `high` |
 
 ## 2. Service ports & directories
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `SAGE_HOST` | — | Public deployment hostname/IP, mainly used by K8s URL derivation; not the server bind address |
+| `SAGE_ENV` | `development` | Application environment name |
+| `SAGE_AUTH_MODE` | `native` | Server auth mode |
+| `SAGE_LOG_LEVEL` | `info` | Server log level |
 | `SAGE_PORT` | `8001` (server) / dynamic (desktop) | Service port |
 | `SAGE_ROOT` | `~/.sage` | Root for sessions/agents/logs |
+| `SAGE_SESSION_DIR` | `$SAGE_ROOT/sessions` | Server/terminal session directory |
+| `SAGE_LOGS_DIR_PATH` | `$SAGE_ROOT/logs` | Log directory |
+| `SAGE_AGENTS_DIR` | `$SAGE_ROOT/agents` | Server/terminal agent directory |
+| `SAGE_USER_DIR` | `$SAGE_ROOT/users` | User data directory |
+| `SAGE_DB_FILE` | `$SAGE_ROOT/sage.db` | SQLite/file database path |
+| `SAGE_SKILL_WORKSPACE` | `$SAGE_ROOT/skills` | Skill workspace directory |
 | `SAGE_SESSIONS_PATH` | `$SAGE_ROOT/sessions` | Session persistence directory |
 | `SAGE_AGENTS_PATH` | `$SAGE_ROOT/agents` | Agent config directory |
 | `SAGE_MCP_CONFIG_PATH` | `$SAGE_ROOT/mcp.json` | MCP server config file |
+| `SAGE_PRESET_RUNNING_CONFIG_PATH` | — | Optional preset running config path |
 
 ## 3. User identity
 
@@ -62,6 +75,29 @@ Advanced overrides are not listed in `.env.example` unless a deployment needs to
 | `SAGE_DESKTOP_USER_ROLE` | `user` | Default desktop user role |
 | `SAGE_CLI_USER_ID` | `cli_default_user` | Default CLI user id |
 | `SAGE_TASK_SCHEDULER_USER_ID` | — | Identity used by the task scheduler |
+
+## 3.1 Server auth, cookies & CORS
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SAGE_AUTH_PROVIDERS` | — | JSON array of enabled upstream auth providers |
+| `SAGE_TRUSTED_IDENTITY_PROXY_IPS` | — | Comma-separated trusted proxy IPs for identity headers |
+| `SAGE_BOOTSTRAP_ADMIN_USERNAME` | `admin` | Initial admin username |
+| `SAGE_BOOTSTRAP_ADMIN_PASSWORD` | — | Initial admin password |
+| `SAGE_JWT_KEY` | — | JWT signing secret |
+| `SAGE_JWT_EXPIRE_HOURS` | `24` | JWT lifetime in hours |
+| `SAGE_REFRESH_TOKEN_SECRET` | — | Refresh-token signing secret |
+| `SAGE_SESSION_SECRET` | — | Server session secret |
+| `SAGE_SESSION_COOKIE_NAME` | `sage_session` | Session cookie name |
+| `SAGE_SESSION_COOKIE_SECURE` | `false` | Whether session cookies require HTTPS |
+| `SAGE_SESSION_COOKIE_SAME_SITE` | `lax` | Session cookie SameSite policy |
+| `SAGE_CORS_ALLOWED_ORIGINS` | — | CORS allowed origins |
+| `SAGE_CORS_ALLOW_CREDENTIALS` | `true` | CORS credentials flag |
+| `SAGE_CORS_ALLOW_METHODS` | — | CORS allowed methods |
+| `SAGE_CORS_ALLOW_HEADERS` | — | CORS allowed request headers |
+| `SAGE_CORS_EXPOSE_HEADERS` | — | CORS exposed response headers |
+| `SAGE_CORS_MAX_AGE` | `600` | CORS preflight max age |
+| `SAGE_WEB_BASE_PATH` | `/` | Web app base path |
 
 ## 4. Sandbox & execution
 
@@ -82,6 +118,9 @@ Advanced overrides are not listed in `.env.example` unless a deployment needs to
 | `SAGE_BUNDLED_NODE_BIN` | — | Bundled Node binary (desktop installs) |
 | `SAGE_NODE_HOST` | — | Bundled Node service host |
 | `SAGE_NODE_MODULES_DIR` | — | Shared `node_modules` directory |
+| `SAGE_NODE_PATH` | — | Desktop bundled Node module lookup path |
+| `SAGE_NODE_EXECUTABLE` / `SAGE_NPM_CLI` | — | Desktop Node/npm executable overrides |
+| `SAGE_PYTHON` | — | Python executable override used by desktop/terminal launchers |
 
 ### 4.1 OpenSandbox (remote)
 
@@ -103,14 +142,34 @@ Advanced overrides are not listed in `.env.example` unless a deployment needs to
 | `SAGE_EMBEDDING_MODEL` | `text-embedding-v4` | Embedding model |
 | `SAGE_EMBEDDING_DIMS` | `1024` | Embedding dimensions |
 
+## 4.3 Storage, observability & integrations
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SAGE_S3_ENDPOINT` / `SAGE_S3_ACCESS_KEY` / `SAGE_S3_SECRET_KEY` | — | S3-compatible object storage connection |
+| `SAGE_S3_SECURE` | `false` | Use HTTPS for S3-compatible storage |
+| `SAGE_S3_BUCKET_NAME` | — | Object storage bucket |
+| `SAGE_S3_PUBLIC_BASE_URL` | — | Public base URL for stored objects |
+| `SAGE_MYSQL_HOST` / `SAGE_MYSQL_PORT` / `SAGE_MYSQL_USER` / `SAGE_MYSQL_PASSWORD` / `SAGE_MYSQL_DATABASE` | — | MySQL connection settings |
+| `SAGE_ELASTICSEARCH_URL` / `SAGE_ELASTICSEARCH_API_KEY` / `SAGE_ELASTICSEARCH_USERNAME` / `SAGE_ELASTICSEARCH_PASSWORD` | — | Elasticsearch connection settings |
+| `SAGE_TRACE_JAEGER_URL` | — | Internal Jaeger query URL |
+| `SAGE_TRACE_JAEGER_ENDPOINT` | — | Jaeger OTLP endpoint |
+| `SAGE_TRACE_JAEGER_PUBLIC_URL` | `http://127.0.0.1:30051/jaeger` | Public Jaeger URL |
+| `SAGE_GRAFANA_PUBLIC_URL` | — | Public Grafana URL used by deployments |
+| `SAGE_LOKI_PUSH_URL` | — | Loki push endpoint |
+| `SAGE_KB_MCP_URL` / `SAGE_KB_MCP_API_KEY` | — | Knowledge-base MCP integration |
+| `SAGE_OAUTH2_CLIENTS` / `SAGE_OAUTH2_ISSUER` / `SAGE_OAUTH2_ACCESS_TOKEN_EXPIRES_IN` | — | Built-in OAuth2 provider settings |
+| `SAGE_EML_ENDPOINT` / `SAGE_EML_ACCESS_KEY_ID` / `SAGE_EML_ACCESS_KEY_SECRET` / `SAGE_EML_SECURITY_TOKEN` | — | Email provider credentials |
+| `SAGE_EML_ACCOUNT_NAME` / `SAGE_EML_TEMPLATE_ID` / `SAGE_EML_REGISTER_SUBJECT` / `SAGE_EML_ADDRESS_TYPE` / `SAGE_EML_REPLY_TO_ADDRESS` | — | Email sender/template defaults |
+
 ## 5. Agent loop & prompt cache
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `SAGE_TASK_COMPLETION_MODE` | `turn_status` | Select how SimpleAgent decides that a turn is complete. `turn_status` exposes the `turn_status` protocol tool and lets the model report `task_done` / `need_user_input` / `blocked` / `continue_work`; `llm_judge` disables `turn_status` and uses the legacy rule-first + LLM `task_complete_judge` check; `no_tool_call` disables `turn_status` and treats an LLM response without tool calls as complete. |
-| `SAGE_AGENT_STATUS_PROTOCOL_ENABLED` | — | Deprecated compatibility fallback. Used only when `SAGE_TASK_COMPLETION_MODE` is unset; `false` maps to `llm_judge`. |
-| `SAGE_COMPLETE_ON_NO_TOOL_CALL` | — | Deprecated compatibility fallback. Used only when `SAGE_TASK_COMPLETION_MODE` is unset; `true` maps to `no_tool_call`. |
+| `SAGE_RUNTIME_CONTEXT_IN_USER` | `true` | Move volatile runtime context (`system_context`, workspace files, active ToDo) out of system messages and freeze it into the latest user message inference metadata. Set `false` only for legacy behaviour where volatile context stays in system. |
 | `SAGE_CLI_MAX_LOOP_COUNT` | — | Max loops per CLI turn |
+| `SAGE_CONTEXT_HISTORY_RATIO` / `SAGE_CONTEXT_ACTIVE_RATIO` / `SAGE_CONTEXT_MAX_NEW_MESSAGE_RATIO` / `SAGE_CONTEXT_RECENT_TURNS` | code defaults | Context budget allocation knobs |
 | `SAGE_TOOL_SUGGESTION_DIRECT_THRESHOLD` | `15` | When the available tool count is at or below this value, skip the LLM tool-suggestion call and pass all available tools through |
 | `SAGE_EMIT_TOOL_CALL_ON_COMPLETE` | `true` | Re-emit tool_call chunks once the LLM stream completes |
 | `SAGE_ECHO_SHELL_OUTPUT` | `false` | Echo background-shell stdout/stderr into the main stream |
@@ -139,6 +198,13 @@ Advanced overrides are not listed in `.env.example` unless a deployment needs to
 | `SAGE_DEFAULT_ANYTOOL_TIMEOUT` | — | AnyTool call timeout |
 | `SAGE_LS_PATH` | — | Default root for the MCP `list_dir` tool |
 | `SAGE_LS_HIDDEN` | `false` | Whether `list_dir` shows hidden files |
+| `SAGE_MCP_PER_CONNECTION_CONCURRENCY` | `100` | Max concurrent MCP calls per pooled connection |
+| `SAGE_MCP_MAX_CONNECTIONS_PER_SERVER` | `0` | Max pooled MCP connections per server; `0` means no fixed cap |
+| `SAGE_MCP_SESSION_IDLE_TTL_SECONDS` | `1800` | Idle TTL for MCP pooled sessions |
+| `SAGE_MCP_REFRESH_DRAIN_TIMEOUT_SECONDS` | `30` | Grace period while draining refreshed MCP connections |
+| `SAGE_MCP_CALL_TIMEOUT_SECONDS` | `1800` | MCP tool call timeout |
+| `SAGE_MCP_LIST_TOOLS_RETRY_ON_CONNECTION_ERROR` | `true` | Retry MCP `list_tools` once on connection-like errors |
+| `SAGE_MCP_CALL_RETRY_ON_CONNECTION_ERROR` | `true` | Retry MCP tool calls once on connection-like errors |
 
 ## 8. Desktop & install
 
@@ -146,6 +212,12 @@ Advanced overrides are not listed in `.env.example` unless a deployment needs to
 | --- | --- | --- |
 | `SAGE_HOST_PID` | — | Parent process PID (desktop shell watcher) |
 | `SAGE_UPDATE_URL` | — | Desktop auto-updater URL |
+| `SAGE_INTERNAL_DESKTOP_PROCESS` | — | Internal desktop process marker |
+| `SAGE_TERMINAL_BIN` | — | Terminal binary override |
+| `SAGE_TERMINAL_CLI` | — | Terminal launcher CLI override |
+| `SAGE_TERMINAL_RUNTIME_ROOT` | — | Terminal packaged runtime root |
+| `SAGE_TERMINAL_STATE_ROOT` | — | Terminal state root |
+| `SAGE_TERMINAL_DEBUG_LAUNCH` | `0` | Print terminal launcher diagnostics |
 | `HOST_WEBDAV_SERVER_ROOT` | — | WebDAV server root |
 | `ENABLE_DEBUG_WEBDAV` | `false` | Enable WebDAV debug output |
 
@@ -155,7 +227,23 @@ Advanced overrides are not listed in `.env.example` unless a deployment needs to
 | --- | --- | --- |
 | `TESTING` | `false` | Test mode; some background tasks are skipped |
 | `SAGENTS_PROFILING_TOOL_DECORATOR` | `false` | Profile every `@tool` call |
+| `SAGE_DISABLE_SAGENTS_FILE_LOGGING` | `false` | Disable sagents file logging |
+| `AGENT_BROWSER_HEADED` | `1` in desktop core | Run the bundled browser automation in headed mode |
+| `SAGE_TERMINAL_TEST_PERSIST_PREFERENCES` | — | Test-only terminal preferences persistence override |
+| `VITE_SAGE_API_BASE_URL` / `VITE_BACKEND_API_PREFIX` / `VITE_SAGE_GRAFANA_URL` | — | Frontend build/runtime API URL overrides |
 | `PYTHON_BIN` / `CONDA_PYTHON_EXE` / `CONDA_PREFIX` / `CONDA_ROOT` | — | Python interpreter discovery (install-time) |
+
+## 9.1 Deprecated / legacy compatibility variables
+
+| Variable | Replacement / status |
+| --- | --- |
+| `SAGE_AGENT_STATUS_PROTOCOL_ENABLED` | Deprecated. Used only when `SAGE_TASK_COMPLETION_MODE` is unset; `false` maps to `llm_judge`. |
+| `SAGE_COMPLETE_ON_NO_TOOL_CALL` | Deprecated. Used only when `SAGE_TASK_COMPLETION_MODE` is unset; `true` maps to `no_tool_call`. |
+| `SAGE_SPLIT_SYSTEM` | Deprecated and ignored. Split system messages are always enabled. |
+| `SAGE_STABLE_TOOLS_ORDER` | Deprecated and ignored. Tools are always sorted by `function.name` before LLM requests. |
+| `SAGE_AUTO_LINT` | Deprecated and ignored. File-tool linting is always enabled. |
+| `SAGE_SESSION_DIR_PATH` | Legacy alias for `SAGE_SESSION_DIR` in CLI stream code. |
+| `LLM_API_KEY` / `LLM_API_BASE_URL` / `LLM_MODEL_NAME` | Legacy names; use `SAGE_DEFAULT_LLM_API_KEY` / `SAGE_DEFAULT_LLM_API_BASE_URL` / `SAGE_DEFAULT_LLM_MODEL_NAME`. |
 
 ## 10. Standard system variables (consumed but not set by Sage)
 

--- a/docs/zh/ENV_VARS.md
+++ b/docs/zh/ENV_VARS.md
@@ -42,6 +42,9 @@ Kubernetes 模板单独保留 `NAMESPACE`、`SAGE_HOST`、`SAGE_PUBLIC_URL`、`I
 | `SAGE_DEFAULT_LLM_MAX_TOKENS`   | `4096` | 默认最大输出 token |
 | `SAGE_DEFAULT_LLM_TEMPERATURE`  | `0.2` | 默认采样温度 |
 | `SAGE_DEFAULT_LLM_MAX_MODEL_LEN` | `52000` | 默认上下文长度 |
+| `SAGE_DEFAULT_LLM_TOP_P` | `1.0` | 默认 nucleus sampling 参数 |
+| `SAGE_DEFAULT_LLM_PRESENCE_PENALTY` | `0.0` | 默认 presence penalty |
+| `SAGE_REASONING_EFFORT_OFF` | `low` | thinking 关闭时，OpenAI reasoning 模型使用的 reasoning effort；可设为 provider 支持的 `minimal` / `low` / `medium` / `high` 等 |
 
 
 ## 2. 服务端口与目录
@@ -50,11 +53,21 @@ Kubernetes 模板单独保留 `NAMESPACE`、`SAGE_HOST`、`SAGE_PUBLIC_URL`、`I
 | 变量                     | 默认值                   | 说明                            |
 | ---------------------- | --------------------- | ----------------------------- |
 | `SAGE_HOST`            | —                     | 部署对外访问域名/IP，主要用于 K8s 地址派生；不是服务端监听地址 |
+| `SAGE_ENV`             | `development`         | 应用环境名 |
+| `SAGE_AUTH_MODE`       | `native`              | 服务端认证模式 |
+| `SAGE_LOG_LEVEL`       | `info`                | 服务端日志级别 |
 | `SAGE_PORT`            | `8001`（server）/ 桌面端动态 | 服务端口                          |
 | `SAGE_ROOT`            | `~/.sage`             | 全局根目录，下设 sessions/agents/logs |
+| `SAGE_SESSION_DIR`     | `$SAGE_ROOT/sessions` | server / terminal 会话目录 |
+| `SAGE_LOGS_DIR_PATH`   | `$SAGE_ROOT/logs`     | 日志目录 |
+| `SAGE_AGENTS_DIR`      | `$SAGE_ROOT/agents`   | server / terminal Agent 目录 |
+| `SAGE_USER_DIR`        | `$SAGE_ROOT/users`    | 用户数据目录 |
+| `SAGE_DB_FILE`         | `$SAGE_ROOT/sage.db`  | SQLite / file 数据库路径 |
+| `SAGE_SKILL_WORKSPACE` | `$SAGE_ROOT/skills`   | Skill 工作区目录 |
 | `SAGE_SESSIONS_PATH`   | `$SAGE_ROOT/sessions` | 会话持久化目录                       |
 | `SAGE_AGENTS_PATH`     | `$SAGE_ROOT/agents`   | Agent 配置目录                    |
 | `SAGE_MCP_CONFIG_PATH` | `$SAGE_ROOT/mcp.json` | MCP 服务配置文件路径                  |
+| `SAGE_PRESET_RUNNING_CONFIG_PATH` | — | 可选的预置运行配置路径 |
 
 
 ## 3. 用户身份
@@ -66,6 +79,29 @@ Kubernetes 模板单独保留 `NAMESPACE`、`SAGE_HOST`、`SAGE_PUBLIC_URL`、`I
 | `SAGE_DESKTOP_USER_ROLE`      | `user`                 | 桌面端默认用户角色   |
 | `SAGE_CLI_USER_ID`            | `cli_default_user`     | CLI 默认用户 ID |
 | `SAGE_TASK_SCHEDULER_USER_ID` | —                      | 计划任务执行身份    |
+
+## 3.1 服务端认证、Cookie 与 CORS
+
+| 变量 | 默认值 | 说明 |
+| --- | --- | --- |
+| `SAGE_AUTH_PROVIDERS` | — | 上游认证 provider JSON 数组 |
+| `SAGE_TRUSTED_IDENTITY_PROXY_IPS` | — | 可信身份代理 IP，逗号分隔 |
+| `SAGE_BOOTSTRAP_ADMIN_USERNAME` | `admin` | 初始管理员用户名 |
+| `SAGE_BOOTSTRAP_ADMIN_PASSWORD` | — | 初始管理员密码 |
+| `SAGE_JWT_KEY` | — | JWT 签名密钥 |
+| `SAGE_JWT_EXPIRE_HOURS` | `24` | JWT 过期时间（小时） |
+| `SAGE_REFRESH_TOKEN_SECRET` | — | refresh token 签名密钥 |
+| `SAGE_SESSION_SECRET` | — | 服务端 session 密钥 |
+| `SAGE_SESSION_COOKIE_NAME` | `sage_session` | session cookie 名 |
+| `SAGE_SESSION_COOKIE_SECURE` | `false` | session cookie 是否仅 HTTPS |
+| `SAGE_SESSION_COOKIE_SAME_SITE` | `lax` | session cookie SameSite 策略 |
+| `SAGE_CORS_ALLOWED_ORIGINS` | — | CORS 允许来源 |
+| `SAGE_CORS_ALLOW_CREDENTIALS` | `true` | CORS 是否允许 credentials |
+| `SAGE_CORS_ALLOW_METHODS` | — | CORS 允许方法 |
+| `SAGE_CORS_ALLOW_HEADERS` | — | CORS 允许请求头 |
+| `SAGE_CORS_EXPOSE_HEADERS` | — | CORS 暴露响应头 |
+| `SAGE_CORS_MAX_AGE` | `600` | CORS preflight 缓存时间 |
+| `SAGE_WEB_BASE_PATH` | `/` | Web 应用 base path |
 
 
 ## 4. 沙箱与执行
@@ -88,6 +124,9 @@ Kubernetes 模板单独保留 `NAMESPACE`、`SAGE_HOST`、`SAGE_PUBLIC_URL`、`I
 | `SAGE_BUNDLED_NODE_BIN`           | —             | 内置 Node 可执行文件路径（桌面端打包）                     |
 | `SAGE_NODE_HOST`                  | —             | 内置 Node 服务地址                               |
 | `SAGE_NODE_MODULES_DIR`           | —             | 共享 node_modules 目录                         |
+| `SAGE_NODE_PATH`                  | —             | 桌面端内置 Node 模块查找路径 |
+| `SAGE_NODE_EXECUTABLE` / `SAGE_NPM_CLI` | — | 桌面端 Node/npm 可执行文件覆盖 |
+| `SAGE_PYTHON`                     | —             | 桌面端 / terminal launcher 使用的 Python 可执行文件覆盖 |
 
 
 ### 4.1 OpenSandbox（远程）
@@ -111,6 +150,26 @@ Kubernetes 模板单独保留 `NAMESPACE`、`SAGE_HOST`、`SAGE_PUBLIC_URL`、`I
 | `SAGE_EMBEDDING_MODEL` | `text-embedding-v4` | Embedding 模型 |
 | `SAGE_EMBEDDING_DIMS` | `1024` | 向量维度 |
 
+## 4.3 存储、可观测性与集成
+
+| 变量 | 默认值 | 说明 |
+| --- | --- | --- |
+| `SAGE_S3_ENDPOINT` / `SAGE_S3_ACCESS_KEY` / `SAGE_S3_SECRET_KEY` | — | S3 兼容对象存储连接 |
+| `SAGE_S3_SECURE` | `false` | S3 兼容存储是否使用 HTTPS |
+| `SAGE_S3_BUCKET_NAME` | — | 对象存储 bucket |
+| `SAGE_S3_PUBLIC_BASE_URL` | — | 对象公开访问 base URL |
+| `SAGE_MYSQL_HOST` / `SAGE_MYSQL_PORT` / `SAGE_MYSQL_USER` / `SAGE_MYSQL_PASSWORD` / `SAGE_MYSQL_DATABASE` | — | MySQL 连接配置 |
+| `SAGE_ELASTICSEARCH_URL` / `SAGE_ELASTICSEARCH_API_KEY` / `SAGE_ELASTICSEARCH_USERNAME` / `SAGE_ELASTICSEARCH_PASSWORD` | — | Elasticsearch 连接配置 |
+| `SAGE_TRACE_JAEGER_URL` | — | 内部 Jaeger 查询地址 |
+| `SAGE_TRACE_JAEGER_ENDPOINT` | — | Jaeger OTLP endpoint |
+| `SAGE_TRACE_JAEGER_PUBLIC_URL` | `http://127.0.0.1:30051/jaeger` | 对外 Jaeger 地址 |
+| `SAGE_GRAFANA_PUBLIC_URL` | — | 部署环境对外 Grafana 地址 |
+| `SAGE_LOKI_PUSH_URL` | — | Loki push endpoint |
+| `SAGE_KB_MCP_URL` / `SAGE_KB_MCP_API_KEY` | — | 知识库 MCP 集成 |
+| `SAGE_OAUTH2_CLIENTS` / `SAGE_OAUTH2_ISSUER` / `SAGE_OAUTH2_ACCESS_TOKEN_EXPIRES_IN` | — | 内置 OAuth2 provider 配置 |
+| `SAGE_EML_ENDPOINT` / `SAGE_EML_ACCESS_KEY_ID` / `SAGE_EML_ACCESS_KEY_SECRET` / `SAGE_EML_SECURITY_TOKEN` | — | 邮件 provider 凭据 |
+| `SAGE_EML_ACCOUNT_NAME` / `SAGE_EML_TEMPLATE_ID` / `SAGE_EML_REGISTER_SUBJECT` / `SAGE_EML_ADDRESS_TYPE` / `SAGE_EML_REPLY_TO_ADDRESS` | — | 邮件发送账号 / 模板默认值 |
+
 
 ## 5. Agent 主循环 & Prompt Cache
 
@@ -118,9 +177,9 @@ Kubernetes 模板单独保留 `NAMESPACE`、`SAGE_HOST`、`SAGE_PUBLIC_URL`、`I
 | 变量                                             | 默认值     | 说明                                                                                                                                                                           |
 | ---------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `SAGE_TASK_COMPLETION_MODE`                    | `turn_status` | SimpleAgent 的任务完成判定模式。`turn_status` 会暴露 `turn_status` 协议工具，由模型报告 `task_done` / `need_user_input` / `blocked` / `continue_work`；`llm_judge` 不暴露 `turn_status`，回退到旧的“规则优先 + LLM `task_complete_judge`”完成判断；`no_tool_call` 不暴露 `turn_status`，当 LLM 输出不包含工具调用时判定本轮完成。 |
-| `SAGE_AGENT_STATUS_PROTOCOL_ENABLED`           | —       | 已废弃的兼容 fallback。仅当 `SAGE_TASK_COMPLETION_MODE` 未设置时读取；`false` 映射为 `llm_judge`。 |
-| `SAGE_COMPLETE_ON_NO_TOOL_CALL`                | —       | 已废弃的兼容 fallback。仅当 `SAGE_TASK_COMPLETION_MODE` 未设置时读取；`true` 映射为 `no_tool_call`。 |
+| `SAGE_RUNTIME_CONTEXT_IN_USER`                 | `true`  | 将动态 runtime context（`system_context`、workspace files、活跃 ToDo）从 system message 移出，并冻结到最新 user 的 inference metadata 中。仅在兼容旧行为时设为 `false`，此时动态上下文仍进入 system。 |
 | `SAGE_CLI_MAX_LOOP_COUNT`                      | —       | CLI 单轮最大循环次数                                                                                                                                                                 |
+| `SAGE_CONTEXT_HISTORY_RATIO` / `SAGE_CONTEXT_ACTIVE_RATIO` / `SAGE_CONTEXT_MAX_NEW_MESSAGE_RATIO` / `SAGE_CONTEXT_RECENT_TURNS` | 代码默认值 | 上下文预算分配参数 |
 | `SAGE_TOOL_SUGGESTION_DIRECT_THRESHOLD`        | `15`    | 可用工具数小于等于该值时跳过 LLM 工具推荐调用，直接透传所有可用工具                                                                                                                                            |
 | `SAGE_EMIT_TOOL_CALL_ON_COMPLETE`              | `true`  | LLM 完整产出后是否补发 tool_call chunk                                                                                                                                                |
 | `SAGE_ECHO_SHELL_OUTPUT`                       | `false` | 后台 shell 输出是否回显到主流                                                                                                                                                           |
@@ -152,6 +211,13 @@ Kubernetes 模板单独保留 `NAMESPACE`、`SAGE_HOST`、`SAGE_PUBLIC_URL`、`I
 | `SAGE_DEFAULT_ANYTOOL_TIMEOUT` | —       | AnyTool 调用超时时间           |
 | `SAGE_LS_PATH`                 | —       | `list_dir` 工具默认根（mcp 内部） |
 | `SAGE_LS_HIDDEN`               | `false` | `list_dir` 是否包含隐藏文件      |
+| `SAGE_MCP_PER_CONNECTION_CONCURRENCY` | `100` | 每个 MCP pooled connection 的最大并发调用数 |
+| `SAGE_MCP_MAX_CONNECTIONS_PER_SERVER` | `0` | 每个 MCP server 的最大连接数；`0` 表示不固定限制 |
+| `SAGE_MCP_SESSION_IDLE_TTL_SECONDS` | `1800` | MCP pooled session 空闲 TTL |
+| `SAGE_MCP_REFRESH_DRAIN_TIMEOUT_SECONDS` | `30` | MCP 连接刷新时 draining 宽限时间 |
+| `SAGE_MCP_CALL_TIMEOUT_SECONDS` | `1800` | MCP 工具调用超时 |
+| `SAGE_MCP_LIST_TOOLS_RETRY_ON_CONNECTION_ERROR` | `true` | MCP `list_tools` 遇到连接类错误时重试一次 |
+| `SAGE_MCP_CALL_RETRY_ON_CONNECTION_ERROR` | `true` | MCP 工具调用遇到连接类错误时重试一次 |
 
 
 ## 8. 桌面端 / 安装期
@@ -161,6 +227,12 @@ Kubernetes 模板单独保留 `NAMESPACE`、`SAGE_HOST`、`SAGE_PUBLIC_URL`、`I
 | ------------------------- | ------- | ---------------- |
 | `SAGE_HOST_PID`           | —       | 父进程 PID（用于桌面壳监控） |
 | `SAGE_UPDATE_URL`         | —       | 桌面端自动更新地址        |
+| `SAGE_INTERNAL_DESKTOP_PROCESS` | — | 桌面端内部进程标记 |
+| `SAGE_TERMINAL_BIN` | — | Terminal 二进制覆盖 |
+| `SAGE_TERMINAL_CLI` | — | Terminal launcher CLI 覆盖 |
+| `SAGE_TERMINAL_RUNTIME_ROOT` | — | Terminal 打包 runtime 根目录 |
+| `SAGE_TERMINAL_STATE_ROOT` | — | Terminal 状态根目录 |
+| `SAGE_TERMINAL_DEBUG_LAUNCH` | `0` | 打印 terminal launcher 诊断信息 |
 | `HOST_WEBDAV_SERVER_ROOT` | —       | 文件服务 WebDAV 根    |
 | `ENABLE_DEBUG_WEBDAV`     | `false` | 调试 WebDAV 开关     |
 
@@ -172,7 +244,23 @@ Kubernetes 模板单独保留 `NAMESPACE`、`SAGE_HOST`、`SAGE_PUBLIC_URL`、`I
 | ----------------------------------------------------------------- | ------- | ------------------ |
 | `TESTING`                                                         | `false` | 测试模式开关，部分背景任务会跳过   |
 | `SAGENTS_PROFILING_TOOL_DECORATOR`                                | `false` | 是否对 @tool 装饰器做调用计时 |
+| `SAGE_DISABLE_SAGENTS_FILE_LOGGING`                               | `false` | 关闭 sagents 文件日志 |
+| `AGENT_BROWSER_HEADED`                                            | 桌面端 core 中为 `1` | 内置浏览器自动化是否 headed |
+| `SAGE_TERMINAL_TEST_PERSIST_PREFERENCES`                          | —       | Terminal 测试专用 preferences 持久化开关 |
+| `VITE_SAGE_API_BASE_URL` / `VITE_BACKEND_API_PREFIX` / `VITE_SAGE_GRAFANA_URL` | — | 前端构建 / 运行时 API 地址覆盖 |
 | `PYTHON_BIN` / `CONDA_PYTHON_EXE` / `CONDA_PREFIX` / `CONDA_ROOT` | —       | Python 解释器探测，安装期使用 |
+
+## 9.1 已废弃 / 兼容变量
+
+| 变量 | 替代方案 / 状态 |
+| --- | --- |
+| `SAGE_AGENT_STATUS_PROTOCOL_ENABLED` | 已废弃。仅当 `SAGE_TASK_COMPLETION_MODE` 未设置时读取；`false` 映射为 `llm_judge`。 |
+| `SAGE_COMPLETE_ON_NO_TOOL_CALL` | 已废弃。仅当 `SAGE_TASK_COMPLETION_MODE` 未设置时读取；`true` 映射为 `no_tool_call`。 |
+| `SAGE_SPLIT_SYSTEM` | 已废弃且忽略。system message 拆分现在固定开启。 |
+| `SAGE_STABLE_TOOLS_ORDER` | 已废弃且忽略。LLM 请求前 tools 固定按 `function.name` 排序。 |
+| `SAGE_AUTO_LINT` | 已废弃且忽略。file tool lint 固定开启。 |
+| `SAGE_SESSION_DIR_PATH` | `SAGE_SESSION_DIR` 的旧兼容别名，仅 CLI stream 代码读取。 |
+| `LLM_API_KEY` / `LLM_API_BASE_URL` / `LLM_MODEL_NAME` | 旧名称；请使用 `SAGE_DEFAULT_LLM_API_KEY` / `SAGE_DEFAULT_LLM_API_BASE_URL` / `SAGE_DEFAULT_LLM_MODEL_NAME`。 |
 
 
 ## 10. 系统标准变量（仅引用，不由 Sage 设置）


### PR DESCRIPTION
## Summary
- document missing runtime environment variables, including SAGE_RUNTIME_CONTEXT_IN_USER
- add server auth/CORS, storage/observability, MCP pool, desktop/terminal, and frontend env groups
- mark deprecated/ignored legacy env switches such as SAGE_SPLIT_SYSTEM, SAGE_STABLE_TOOLS_ORDER, SAGE_AUTO_LINT, SAGE_AGENT_STATUS_PROTOCOL_ENABLED, and SAGE_COMPLETE_ON_NO_TOOL_CALL

## Tests
- git diff --cached --check before commit
- git diff --check