### PR TITLE
fix: llm judge replace base64 to place holder

### DIFF
--- a/sagents/agent/simple_agent.py
+++ b/sagents/agent/simple_agent.py
@@ -19,6 +19,7 @@ from sagents.utils.completion_mode import (
     is_no_tool_call_mode,
     is_turn_status_mode,
 )
+from sagents.utils.llm_request_utils import redact_base64_data_urls_in_value
 import json
 import uuid
 from copy import deepcopy
@@ -675,6 +676,7 @@ class SimpleAgent(AgentBase):
         clean_messages = MessageManager.convert_messages_to_dict_for_request(
             messages_for_complete
         )
+        clean_messages = redact_base64_data_urls_in_value(clean_messages)
 
         task_complete_template = PromptManager().get_agent_prompt_auto(
             "task_complete_template", language=session_context.get_language()

--- a/tests/common/services/test_skill_router_service_batch.py
+++ b/tests/common/services/test_skill_router_service_batch.py
@@ -91,8 +91,12 @@ async def test_import_desktop_skills_by_paths_returns_per_path_results(monkeypat
     monkeypatch.setattr(skill_service, "_is_desktop_mode", lambda: True)
     monkeypatch.setattr(skill_service, "get_skill_manager", lambda: object())
     monkeypatch.setattr(skill_service, "_collect_skill_path_candidates", fake_collect)
-    monkeypatch.setattr(skill_service, "_process_desktop_dir_and_register", fake_process_dir)
-    monkeypatch.setattr(skill_service, "_process_desktop_zip_and_register", fake_process_zip)
+    monkeypatch.setattr(
+        skill_service, "_process_desktop_dir_and_register", fake_process_dir
+    )
+    monkeypatch.setattr(
+        skill_service, "_process_desktop_zip_and_register", fake_process_zip
+    )
 
     result = await skill_service.import_desktop_skills_by_paths(["/bundle"], "u_1")
 

--- a/tests/sagents/agent/test_simple_agent_finish_summary.py
+++ b/tests/sagents/agent/test_simple_agent_finish_summary.py
@@ -555,6 +555,75 @@ def test_task_complete_judge_uses_composed_system_prefix_in_llm_judge_mode(
     assert "找不到prompt" not in captured["llm_messages"][0]["content"]
 
 
+def test_task_complete_judge_redacts_multimodal_image_payloads(monkeypatch):
+    monkeypatch.setenv("SAGE_TASK_COMPLETION_MODE", "llm_judge")
+    agent = _agent()
+    captured = {}
+
+    async def _never_must_continue(messages):
+        return False
+
+    async def _fake_system_text(**kwargs):
+        return "system prompt"
+
+    async def _fake_llm_streaming(*args, **kwargs):
+        captured["llm_messages"] = kwargs["messages"]
+        yield SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        content='{"task_interrupted": true, "reason": "done"}'
+                    )
+                )
+            ]
+        )
+
+    monkeypatch.setattr(agent, "_must_continue_by_rules", _never_must_continue)
+    monkeypatch.setattr(agent, "prepare_llm_system_prompt_text", _fake_system_text)
+    monkeypatch.setattr(agent, "_call_llm_streaming", _fake_llm_streaming)
+
+    msg_manager = SimpleNamespace(
+        context_budget_manager=SimpleNamespace(budget_info={"active_budget": 3000}),
+    )
+    session_context = SimpleNamespace(
+        message_manager=msg_manager,
+        get_language=lambda: "en",
+    )
+    image_payload = "data:image/png;base64," + ("a" * 10000)
+    messages = [
+        MessageChunk(
+            role=MessageRole.USER.value,
+            content=[
+                {"type": "text", "text": "please inspect this image"},
+                {"type": "image_url", "image_url": {"url": image_payload}},
+            ],
+            message_type=MessageType.USER_INPUT.value,
+        ),
+        MessageChunk(
+            role=MessageRole.ASSISTANT.value,
+            content="done",
+            message_type=MessageType.ASSISTANT_TEXT.value,
+        ),
+    ]
+
+    assert (
+        asyncio.run(
+            agent._is_task_complete(
+                messages_input=messages,
+                session_id="s1",
+                tool_manager=None,
+                session_context=session_context,  # pyright: ignore[reportArgumentType]
+            )
+        )
+        is True
+    )
+
+    prompt = captured["llm_messages"][0]["content"]
+    assert image_payload not in prompt
+    assert "data:image/png;base64" not in prompt
+    assert "<redacted data URL; base64_len=10000>" in prompt
+
+
 def test_llm_judge_skips_completion_check_after_direct_tool_activity(monkeypatch):
     monkeypatch.setenv("SAGE_TASK_COMPLETION_MODE", "llm_judge")
     agent = _agent()


### PR DESCRIPTION
## Summary

Fix `llm_judge` completion checks accidentally embedding multimodal image base64 payloads into the judge prompt.

## Changes

- Redact `data:image/...;base64,...` values from `clean_messages` before serializing them into the `task_complete_judge` text prompt.
- Preserve the original message structure and non-image text so the judge can still reason over the conversation.
- Add a regression test covering multimodal user messages in `llm_judge` mode.

## Root Cause

`task_complete_judge` converts recent messages to JSON and injects them into a plain text prompt. For multimodal messages, this included full `image_url` base64 data, causing images to be counted as normal text and triggering huge token usage / context overflow.