### PR TITLE
fix: memory call base64 redacted

### DIFF
--- a/sagents/agent/memory_recall_agent.py
+++ b/sagents/agent/memory_recall_agent.py
@@ -15,6 +15,7 @@ from sagents.context.messages.message import MessageChunk, MessageRole, MessageT
 from sagents.context.messages.message_manager import MessageManager
 from sagents.context.session_context import SessionContext
 from sagents.utils.logger import logger
+from sagents.utils.llm_request_utils import redact_base64_data_urls_in_value
 from sagents.utils.prompt_manager import PromptManager
 
 
@@ -137,6 +138,7 @@ class MemoryRecallAgent(AgentBase):
         """
         logger.info("MemoryRecallAgent: 开始分析并召回记忆")
 
+        tool_call_id = None
         try:
             # 准备消息
             clean_messages = MessageManager.convert_messages_to_dict_for_request(
@@ -212,13 +214,16 @@ class MemoryRecallAgent(AgentBase):
             logger.error(traceback.format_exc())
             logger.error(f"MemoryRecallAgent: 召回记忆时发生错误: {str(e)}")
 
-            # 返回错误信息作为 tool result
+            role = (
+                MessageRole.TOOL.value if tool_call_id else MessageRole.ASSISTANT.value
+            )
+
             error_chunk = MessageChunk(
-                role=MessageRole.TOOL.value,
+                role=role,
                 content=json.dumps(
                     {"status": "error", "error": str(e)}, ensure_ascii=False
                 ),
-                tool_call_id=f"call_memory_recall_{str(uuid.uuid4())[:8]}",
+                tool_call_id=tool_call_id,
                 message_type=MessageType.ERROR.value,
                 agent_name=self.agent_name,
             )
@@ -244,8 +249,10 @@ class MemoryRecallAgent(AgentBase):
             "memory_recall_template", language=session_context.get_language()
         )
 
+        recall_messages = redact_base64_data_urls_in_value(messages)
+
         prompt = memory_query_template.format(
-            messages=json.dumps(messages, ensure_ascii=False, indent=2)
+            messages=json.dumps(recall_messages, ensure_ascii=False, indent=2)
         )
 
         llm_request_messages = await self.prepare_llm_request_messages(

--- a/tests/sagents/test_memory_recall_agent.py
+++ b/tests/sagents/test_memory_recall_agent.py
@@ -1,0 +1,85 @@
+import asyncio
+import json
+from types import SimpleNamespace
+
+from sagents.agent.memory_recall_agent import MemoryRecallAgent
+from sagents.context.messages.message import MessageChunk, MessageRole, MessageType
+
+
+def test_memory_recall_error_does_not_emit_orphan_tool_message():
+    chunks = asyncio.run(_collect_memory_recall_error_chunks())
+
+    assert len(chunks) == 1
+    assert chunks[0].role == MessageRole.ASSISTANT.value
+    assert chunks[0].message_type == MessageType.ERROR.value
+    assert chunks[0].tool_call_id is None
+    assert json.loads(chunks[0].content)["error"] == "context_length_exceeded"
+
+
+async def _collect_memory_recall_error_chunks():
+    agent = MemoryRecallAgent(model=None)
+
+    async def raise_token_error(*_args, **_kwargs):
+        raise RuntimeError("context_length_exceeded")
+
+    agent._generate_search_query = raise_token_error  # pyright: ignore[reportAttributeAccessIssue]
+    chunks = []
+
+    async for chunk in agent._recall_memories_stream(
+        messages_input=[MessageChunk(role=MessageRole.USER.value, content="hello")],
+        session_context=None,  # pyright: ignore[reportArgumentType]
+    ):
+        chunks.extend(chunk)
+
+    return chunks
+
+
+def test_memory_recall_query_generation_redacts_base64_image_content():
+    async def _run():
+        agent = MemoryRecallAgent(model=None)
+        base64_payload = "a" * 50000
+        data_url = f"data:image/png;base64,{base64_payload}"
+        captured = {}
+
+        async def fake_get_search_query(llm_request_messages, session_id):
+            captured["messages"] = llm_request_messages
+            return "video_maker candidate_stories"
+
+        async def fake_prepare_llm_request_messages(**kwargs):
+            return kwargs["extra_messages"]
+
+        agent._get_search_query = fake_get_search_query  # pyright: ignore[reportAttributeAccessIssue]
+        agent.prepare_llm_request_messages = fake_prepare_llm_request_messages  # pyright: ignore[reportMethodAssign]
+
+        session_context = SimpleNamespace(
+            session_id="session-memory-large-user",
+            get_language=lambda: "zh",
+        )
+
+        query = await agent._generate_search_query(
+            messages=[
+                {
+                    "role": MessageRole.USER.value,
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "video_maker candidate_stories 参考这张图生成故事",
+                        },
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": data_url},
+                        },
+                    ],
+                }
+            ],
+            session_context=session_context,  # pyright: ignore[reportArgumentType]
+        )
+
+        prompt = captured["messages"][0].content
+        assert query == "video_maker candidate_stories"
+        assert "video_maker candidate_stories" in prompt
+        assert base64_payload not in prompt
+        assert "data:image/png;base64" not in prompt
+        assert "<redacted data URL; base64_len=50000>" in prompt
+
+    asyncio.run(_run())

--- a/tests/sagents/utils/test_message_sanitizer.py
+++ b/tests/sagents/utils/test_message_sanitizer.py
@@ -74,7 +74,9 @@ def test_drop_invalid_tool_calls_removes_interrupted_tool_call_from_request_view
     )
 
     assert out == [user]
-    assert assistant["tool_calls"][0]["function"]["arguments"] == '{"event_id": "evt_123'
+    assert (
+        assistant["tool_calls"][0]["function"]["arguments"] == '{"event_id": "evt_123'
+    )
 
 
 def test_drop_invalid_tool_calls_preserves_valid_calls_on_same_message():


### PR DESCRIPTION
## Summary

Fix memory recall query generation to redact base64 data URLs before building the LLM prompt.

## Changes

- Redacts base64 image data URLs from memory recall input messages before formatting the recall prompt.
- Preserves normal text content so memory search queries can still capture useful user intent.
- Adds coverage for large base64 image payloads to ensure raw image data is not sent into the recall prompt.
