### PR TITLE
Preserve session-scoped runtime messages

### DIFF
--- a/app/desktop/ui/src/composables/chat/useChatPage.js
+++ b/app/desktop/ui/src/composables/chat/useChatPage.js
@@ -400,7 +400,7 @@ export const useChatPage = (props) => {
     if (!res) return null
     const normalizedMessages = (res.messages || []).map(msg => ({
       ...msg,
-      session_id: msg.session_id || sessionId
+      session_id: msg.session_id || msg.metadata?.session_id || sessionId
     }))
 
     // 加载历史消息后，检查哪些工具调用没有对应的结果

--- a/common/schemas/chat.py
+++ b/common/schemas/chat.py
@@ -7,6 +7,8 @@ from pydantic import BaseModel, Field
 class Message(BaseModel):
     message_id: Optional[str] = None
     role: str
+    type: Optional[str] = None
+    message_type: Optional[str] = None
     # content 可以是字符串或列表（支持多模态，如图片+文本）
     # 列表格式: [{"type": "text", "text": "..."}, {"type": "image_url", "image_url": {"url": "..."}}]
     content: Optional[Union[str, List[Dict[str, Any]]]] = None

--- a/sagents/agent/fibre/backend_client.py
+++ b/sagents/agent/fibre/backend_client.py
@@ -446,6 +446,8 @@ class FibreBackendClient:
                     if not data:
                         continue
 
+                    data.setdefault("session_id", session_id)
+
                     # 获取 message_id，如果没有则生成一个临时 ID
                     message_id = (
                         data.get("message_id")
@@ -455,7 +457,6 @@ class FibreBackendClient:
 
                     # 没有 role 的控制事件（如 stream_end）也要原样透传给父流。
                     if "role" not in data:
-                        data.setdefault("session_id", session_id)
                         yield [data]
                         continue
 

--- a/sagents/context/messages/message.py
+++ b/sagents/context/messages/message.py
@@ -57,6 +57,7 @@ class MessageType(Enum):
     QUERY_SUGGEST = "query_suggest"
     MEMORY_EXTRACTION = "memory_extraction"
     DO_SUBTASK_RESULT = "do_subtask_result"
+    SYSTEM_TRIGGERED_RUN = "system_triggered_run"
 
     # 推理内容
     REASONING_CONTENT = "reasoning_content"

--- a/sagents/context/messages/message_manager.py
+++ b/sagents/context/messages/message_manager.py
@@ -1658,6 +1658,7 @@ class MessageManager:
                 MessageType.TOOL_CALL_RESULT.value,
                 MessageType.SKILL_OBSERVATION.value,
                 MessageType.AGENT_EXECUTION_ERROR.value,
+                MessageType.SYSTEM_TRIGGERED_RUN.value,
             ]
 
         # 全量消息进入；压缩覆盖关系由 build_inference_view 统一处理。

--- a/sagents/session_runtime.py
+++ b/sagents/session_runtime.py
@@ -1183,6 +1183,7 @@ class Session:
                 role=MessageRole.ASSISTANT.value,
                 content="",
                 message_type=MessageType.TOKEN_USAGE.value,
+                session_id=session_id,
                 metadata={
                     "token_usage": token_usage,
                     "model": primary_model,

--- a/tests/common/schemas/test_chat_message.py
+++ b/tests/common/schemas/test_chat_message.py
@@ -1,0 +1,15 @@
+from common.schemas.chat import Message
+
+
+def test_message_preserves_type_fields_for_runtime_context():
+    message = Message(
+        role="assistant",
+        content="<system_triggered_run>context</system_triggered_run>",
+        type="system_triggered_run",
+        message_type="system_triggered_run",
+    )
+
+    payload = message.model_dump()
+
+    assert payload["type"] == "system_triggered_run"
+    assert payload["message_type"] == "system_triggered_run"

--- a/tests/sagents/agent/test_fibre_backend_client.py
+++ b/tests/sagents/agent/test_fibre_backend_client.py
@@ -92,7 +92,9 @@ async def test_backend_client_preserves_roleless_control_events(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_backend_client_backfills_session_id_for_complete_role_messages(monkeypatch):
+async def test_backend_client_backfills_session_id_for_complete_role_messages(
+    monkeypatch,
+):
     lines = [
         json.dumps(
             {

--- a/tests/sagents/agent/test_fibre_backend_client.py
+++ b/tests/sagents/agent/test_fibre_backend_client.py
@@ -89,3 +89,47 @@ async def test_backend_client_preserves_roleless_control_events(monkeypatch):
     assert received[0]["session_id"] == "child"
     assert isinstance(received[1], MessageChunk)
     assert received[1].content == "done"
+
+
+@pytest.mark.asyncio
+async def test_backend_client_backfills_session_id_for_complete_role_messages(monkeypatch):
+    lines = [
+        json.dumps(
+            {
+                "role": "assistant",
+                "type": "token_usage",
+                "content": "",
+                "message_id": "m-token",
+                "metadata": {"session_id": "child", "token_usage": {}},
+            }
+        ),
+        json.dumps(
+            {
+                "role": "assistant",
+                "type": "assistant_text",
+                "content": "done",
+                "message_id": "m-child",
+            }
+        ),
+    ]
+    monkeypatch.setitem(
+        sys.modules,
+        "aiohttp",
+        SimpleNamespace(ClientSession=lambda: _FakeClientSession(lines)),
+    )
+
+    client = FibreBackendClient()
+    client.base_url = "http://localhost:1"
+    client._available = True
+
+    received = []
+    async for chunks in client.stream_chat(
+        agent_id="agent",
+        messages=[{"role": "user", "content": "hi"}],
+        session_id="child",
+        max_loop_count=3,
+    ):
+        received.extend(chunks)
+
+    assert all(isinstance(item, MessageChunk) for item in received)
+    assert [item.session_id for item in received] == ["child", "child"]

--- a/tests/sagents/messages/test_message_manager_compression.py
+++ b/tests/sagents/messages/test_message_manager_compression.py
@@ -80,6 +80,37 @@ class TestExtractAllContextMessages:
         assert result[0].role == MessageRole.USER.value
         print("OK: No compression tool - normal extraction")
 
+    def test_system_triggered_run_stays_in_default_context(self):
+        """System-triggered assistant context should reach LLM requests."""
+        mm = MessageManager(session_id="test_session_system_triggered")
+
+        messages = [
+            self.create_message(MessageRole.USER.value, "Set a package reminder"),
+            self.create_message(
+                MessageRole.ASSISTANT.value,
+                "Package reminder created",
+                msg_type=MessageType.FINAL_ANSWER.value,
+            ),
+            self.create_message(
+                MessageRole.ASSISTANT.value,
+                "<system_triggered_run>\nassistant_message_to_user:\nWant to visit the restaurant again?\n</system_triggered_run>",
+                msg_type=MessageType.SYSTEM_TRIGGERED_RUN.value,
+            ),
+            self.create_message(MessageRole.USER.value, "Yes, today too"),
+        ]
+        mm.messages = messages
+
+        result = mm.extract_all_context_messages(
+            recent_turns=0, last_turn_user_only=False
+        )
+        request_messages = MessageManager.convert_messages_to_dict_for_request(result)
+
+        assert any(
+            message["role"] == MessageRole.ASSISTANT.value
+            and "Want to visit the restaurant again?" in message["content"]
+            for message in request_messages
+        )
+
     def test_single_compression_tool(self):
         """Test: extract from corresponding User when single compression tool exists"""
         mm = MessageManager(session_id="test_session_2")

--- a/tests/sagents/test_session_token_usage_chunk.py
+++ b/tests/sagents/test_session_token_usage_chunk.py
@@ -1,0 +1,26 @@
+import asyncio
+from types import SimpleNamespace
+
+from sagents.context.messages.message import MessageType
+from sagents.session_runtime import Session
+
+
+def test_token_usage_chunk_has_top_level_session_id():
+    session = Session.__new__(Session)
+    session_context = SimpleNamespace(
+        get_tokens_usage_info=lambda: {
+            "total_info": {"total_tokens": 7},
+            "per_step_info": [],
+            "models": [],
+        },
+        agent_config={"llmConfig": {"model": "test-model"}},
+    )
+
+    chunks = asyncio.run(
+        session._emit_token_usage_if_any(session_context, "child-session")
+    )
+
+    assert len(chunks) == 1
+    assert chunks[0].type == MessageType.TOKEN_USAGE.value
+    assert chunks[0].session_id == "child-session"
+    assert chunks[0].metadata["session_id"] == "child-session"


### PR DESCRIPTION
## Summary
- ensure child-session token usage and backend child stream messages carry top-level session_id
- preserve metadata.session_id when desktop reloads historical chat messages
- keep system_triggered_run/type metadata in chat request schemas and default context extraction

## Review
- Reviewed the extra working-tree changes after fetching latest origin/main; no blocking issues found.
- Removed generated pytest bytecode before staging.

## Tests
- /Users/zhangzheng/opt/anaconda3/envs/sage-desktop-env/bin/python -m pytest tests/common/schemas/test_chat_message.py tests/sagents/messages/test_message_manager_compression.py::TestExtractAllContextMessages::test_system_triggered_run_stays_in_default_context tests/sagents/agent/test_fibre_backend_client.py::test_backend_client_backfills_session_id_for_complete_role_messages tests/sagents/test_session_token_usage_chunk.py -q
- /Users/zhangzheng/opt/anaconda3/envs/sage-desktop-env/bin/python -m py_compile common/schemas/chat.py sagents/context/messages/message.py sagents/context/messages/message_manager.py sagents/session_runtime.py sagents/agent/fibre/backend_client.py
- git diff --check