### PR TITLE
feat(docs)去掉已经废弃的环境变量逻辑，并增加说明

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,9 +130,3 @@ SAGE_EMBEDDING_API_KEY=
 SAGE_EMBEDDING_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1/
 SAGE_EMBEDDING_MODEL=text-embedding-v4
 SAGE_EMBEDDING_DIMS=1024
-
-# SimpleAgent 任务完成判断：assistant 文本中"处理中 / 正在…"关键词检测开关
-# 仅控制该关键词规则；tool 结果后继续 / 工具调用失败 / 以 ":"、"..." 结尾 等其它规则不受影响。
-# 默认 true：命中关键词时强制继续（已做弱关键词 + 非问句约束，误判概率较低）。
-# 设为 false：跳过关键词检测，适用于"正在处理中呢？"这类反问用户场景被误判导致死循环时的应急关闭。
-SAGE_CONTINUE_ON_PROCESSING_KEYWORDS=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+2026-06-26 文档与示例清理：移除已下线的 `SAGE_CONTINUE_ON_PROCESSING_KEYWORDS` 示例配置；将 `SAGE_AGENT_STATUS_PROTOCOL_ENABLED`、`SAGE_CONTINUE_ON_PROCESSING_KEYWORDS`、`SAGE_FORCE_TOOL_CHOICE_REQUIRED` 迁入 ENV 文档废弃章节；精简 SimpleAgent 任务完成规则相关测试。
+
 2026-05-26 部署与观测持续收敛：`deploy/compose.sh` 优化单服务/分环境启动与原生输出；Prometheus/Loki/Grafana 面板与指标多轮调整，补环境与容器维度；去除 dev/test 部署冗余依赖；修复 Fibre agent 返回 agent 名称参数；Windows desktop 构建补 ensurepip。
 
 2026-05-26 server web 渲染改造：精简文件/Markdown/高亮渲染链路，移除多类重型嵌入式文档渲染组件，调整前端依赖与 wiki nginx 配置。

--- a/docs/en/ENV_VARS.md
+++ b/docs/en/ENV_VARS.md
@@ -173,7 +173,6 @@ Advanced overrides are not listed in `.env.example` unless a deployment needs to
 | `SAGE_TOOL_SUGGESTION_DIRECT_THRESHOLD` | `15` | When the available tool count is at or below this value, skip the LLM tool-suggestion call and pass all available tools through |
 | `SAGE_EMIT_TOOL_CALL_ON_COMPLETE` | `true` | Re-emit tool_call chunks once the LLM stream completes |
 | `SAGE_ECHO_SHELL_OUTPUT` | `false` | Echo background-shell stdout/stderr into the main stream |
-| `SAGE_FORCE_TOOL_CHOICE_REQUIRED` | `false` | Deprecated compatibility switch. It is ignored for normal tool calls and can only force `tool_choice=required` when `SAGE_TASK_COMPLETION_MODE=turn_status` and the request exposes only the internal `turn_status` protocol tool. |
 | `SAGE_TOOL_PROGRESS_ENABLED` | `true` | Enable the tool live-progress channel (NDJSON `type=tool_progress` events for the UI only; never sent to MessageManager or the LLM) |
 | `SAGE_TOOL_PROGRESS_FLUSH_INTERVAL_MS` | `50` | Coalesce window (ms). Multiple `emit_tool_progress` calls within the window for the same `(tool_call, stream)` are merged into one event. Set to `0` to disable coalescing and emit immediately |
 | `SAGE_TOOL_PROGRESS_FLUSH_BYTES` | `16384` | Per-stream byte threshold; once accumulated text reaches it, flush immediately (prevents fast-producing commands from saturating the channel) |
@@ -237,6 +236,9 @@ Advanced overrides are not listed in `.env.example` unless a deployment needs to
 
 | Variable | Replacement / status |
 | --- | --- |
+| `SAGE_AGENT_STATUS_PROTOCOL_ENABLED` | Removed and ignored. Use `SAGE_TASK_COMPLETION_MODE=turn_status` / `no_tool_call` / `llm_judge`. |
+| `SAGE_CONTINUE_ON_PROCESSING_KEYWORDS` | Removed and ignored. The SimpleAgent "processing keyword" must-continue rule has been removed. |
+| `SAGE_FORCE_TOOL_CHOICE_REQUIRED` | Deprecated and ignored. `tool_choice=required` for turn_status-only rounds is controlled internally by the agent loop; code support will be removed in a future release. |
 | `SAGE_COMPLETE_ON_NO_TOOL_CALL` | Removed and ignored. Use `SAGE_TASK_COMPLETION_MODE=no_tool_call`. |
 | `SAGE_SPLIT_SYSTEM` | Deprecated and ignored. Split system messages are always enabled. |
 | `SAGE_STABLE_TOOLS_ORDER` | Deprecated and ignored. Tools are always sorted by `function.name` before LLM requests. |

--- a/docs/zh/ENV_VARS.md
+++ b/docs/zh/ENV_VARS.md
@@ -183,7 +183,6 @@ Kubernetes 模板单独保留 `NAMESPACE`、`SAGE_HOST`、`SAGE_PUBLIC_URL`、`I
 | `SAGE_TOOL_SUGGESTION_DIRECT_THRESHOLD`        | `15`    | 可用工具数小于等于该值时跳过 LLM 工具推荐调用，直接透传所有可用工具                                                                                                                                            |
 | `SAGE_EMIT_TOOL_CALL_ON_COMPLETE`              | `true`  | LLM 完整产出后是否补发 tool_call chunk                                                                                                                                                |
 | `SAGE_ECHO_SHELL_OUTPUT`                       | `false` | 后台 shell 输出是否回显到主流                                                                                                                                                           |
-| `SAGE_FORCE_TOOL_CHOICE_REQUIRED`             | `false` | 已废弃的兼容开关。普通工具调用会忽略它；只有在 `SAGE_TASK_COMPLETION_MODE=turn_status` 且本次请求只暴露内部 `turn_status` 协议工具时，才可能强制 `tool_choice=required`。 |
 | `SAGE_TOOL_PROGRESS_ENABLED`                   | `true`  | 是否启用工具实时过程通道（NDJSON `type=tool_progress` 事件，仅给前端 UI，不进 MessageManager / 不喂 LLM）                                                                                          |
 | `SAGE_TOOL_PROGRESS_FLUSH_INTERVAL_MS`         | `50`    | 工具过程合并时间窗（毫秒）。同 `(tool_call, stream)` 维度下窗口内的多次 emit 合并成一条事件下发；设 `0` 关闭合并立即推送                                                                                          |
 | `SAGE_TOOL_PROGRESS_FLUSH_BYTES`               | `16384` | 单 stream 累计字节阈值，达到即立即 flush（防极快产生输出的命令挤爆通道）                                                                                                                       |
@@ -254,6 +253,9 @@ Kubernetes 模板单独保留 `NAMESPACE`、`SAGE_HOST`、`SAGE_PUBLIC_URL`、`I
 
 | 变量 | 替代方案 / 状态 |
 | --- | --- |
+| `SAGE_AGENT_STATUS_PROTOCOL_ENABLED` | 已移除并忽略。请使用 `SAGE_TASK_COMPLETION_MODE=turn_status` / `no_tool_call` / `llm_judge`。 |
+| `SAGE_CONTINUE_ON_PROCESSING_KEYWORDS` | 已移除并忽略。SimpleAgent「处理中关键词」强制继续规则已下线。 |
+| `SAGE_FORCE_TOOL_CHOICE_REQUIRED` | 已废弃且忽略。turn_status-only 轮次的 `tool_choice=required` 由 agent 主循环内部控制；后续版本将移除代码读取。 |
 | `SAGE_COMPLETE_ON_NO_TOOL_CALL` | 已移除并忽略。请使用 `SAGE_TASK_COMPLETION_MODE=no_tool_call`。 |
 | `SAGE_SPLIT_SYSTEM` | 已废弃且忽略。system message 拆分现在固定开启。 |
 | `SAGE_STABLE_TOOLS_ORDER` | 已废弃且忽略。LLM 请求前 tools 固定按 `function.name` 排序。 |

--- a/tests/sagents/agent/test_simple_agent_task_complete.py
+++ b/tests/sagents/agent/test_simple_agent_task_complete.py
@@ -9,20 +9,9 @@ class DummyModel:
         yield None
 
 
-@pytest.fixture
-def disable_keywords(monkeypatch):
-    """显式跳过"处理中关键词"规则（默认是启用）。"""
-    monkeypatch.setenv("SAGE_CONTINUE_ON_PROCESSING_KEYWORDS", "false")
-    yield
-
-
-# ---- 规则 1 / 2 / 4：不受 env 影响，始终运行 ----
-
-
 @pytest.mark.asyncio
-async def test_must_continue_when_last_role_is_tool(monkeypatch):
-    """规则 1：tool 结果后必须继续。不受关键词开关影响。"""
-    monkeypatch.delenv("SAGE_CONTINUE_ON_PROCESSING_KEYWORDS", raising=False)
+async def test_must_continue_when_last_role_is_tool():
+    """规则 1：tool 结果后必须继续。"""
     agent = SimpleAgent(model=DummyModel(), model_config={})
     messages = [
         MessageChunk(
@@ -36,9 +25,8 @@ async def test_must_continue_when_last_role_is_tool(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_must_continue_when_last_assistant_ends_with_colon(monkeypatch):
-    """规则 4：':' 结尾必须继续。不受关键词开关影响。"""
-    monkeypatch.delenv("SAGE_CONTINUE_ON_PROCESSING_KEYWORDS", raising=False)
+async def test_must_continue_when_last_assistant_ends_with_colon():
+    """规则 4：':' 结尾必须继续。"""
     agent = SimpleAgent(model=DummyModel(), model_config={})
     messages = [
         MessageChunk(
@@ -51,8 +39,7 @@ async def test_must_continue_when_last_assistant_ends_with_colon(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_not_must_continue_for_normal_assistant_message(monkeypatch):
-    monkeypatch.delenv("SAGE_CONTINUE_ON_PROCESSING_KEYWORDS", raising=False)
+async def test_not_must_continue_for_normal_assistant_message():
     agent = SimpleAgent(model=DummyModel(), model_config={})
     messages = [
         MessageChunk(
@@ -62,9 +49,6 @@ async def test_not_must_continue_for_normal_assistant_message(monkeypatch):
         ),
     ]
     assert await agent._must_continue_by_rules(messages) is False
-
-
-# ---- 关键词规则已移除：以下测试验证"中文关键词不再触发强制继续" ----
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

清理三个已下线/废弃环境变量的文档与示例残留，不改运行时行为。

- 从 `.env.example` 移除 `SAGE_CONTINUE_ON_PROCESSING_KEYWORDS`
- 将 `SAGE_AGENT_STATUS_PROTOCOL_ENABLED`、`SAGE_CONTINUE_ON_PROCESSING_KEYWORDS`、`SAGE_FORCE_TOOL_CHOICE_REQUIRED` 迁入 ENV 文档 §9.1 废弃章节，并从 §5 主表格移除 `SAGE_FORCE_TOOL_CHOICE_REQUIRED`
- 精简 `test_simple_agent_task_complete.py`，去掉对已无效 env var 的 `setenv`/`delenv`