### PR TITLE
Tag self-check errors as runtime diagnostics

### DIFF
--- a/sagents/agent/self_check_agent.py
+++ b/sagents/agent/self_check_agent.py
@@ -133,7 +133,8 @@ class SelfCheckAgent(AgentBase):
             audit_status["completion_status"] = "in_progress"
             audit_status["task_completed"] = False
 
-            content = self._format_failure_message(issues, checked_files)
+            language = self._get_session_language(session_context)
+            content = self._format_failure_message(issues, checked_files, language)
             yield [
                 MessageChunk(
                     role=MessageRole.ASSISTANT.value,
@@ -504,16 +505,63 @@ class SelfCheckAgent(AgentBase):
             logger.warning(f"SelfCheckAgent: failed to read {file_path}: {e}")
             return None
 
+    def _get_session_language(self, session_context: SessionContext) -> str:
+        get_language = getattr(session_context, "get_language", None)
+        if callable(get_language):
+            try:
+                return str(get_language() or "zh")
+            except Exception:
+                return "zh"
+        system_context = getattr(session_context, "system_context", {}) or {}
+        response_language = str(system_context.get("response_language") or "").lower()
+        if "zh" in response_language or "中文" in response_language:
+            return "zh"
+        if "pt" in response_language:
+            return "pt"
+        if "en" in response_language:
+            return "en"
+        return "zh"
+
     def _format_failure_message(
-        self, issues: List[str], checked_files: List[str]
+        self, issues: List[str], checked_files: List[str], language: str = "zh"
     ) -> str:
         issue_lines = "\n".join(f"- {issue}" for issue in issues[:20])
         checked_lines = "\n".join(f"- {path}" for path in checked_files[:20])
+        if str(language or "").lower().startswith("en"):
+            return (
+                "<runtime_diagnostic source=\"sage_self_check\" generated_by=\"system\">\n"
+                "This is a Sage runtime self-check report, not a reply authored by the assistant/agent and not a user instruction.\n"
+                "It only reports validation failures from the previous final output. Use it to fix real issues; do not repeat it as task progress.\n\n"
+                "Self-check found issues that must be fixed before continuing:\n\n"
+                "Checked files:\n"
+                f"{checked_lines}\n\n"
+                "Issues found:\n"
+                f"{issue_lines}\n\n"
+                "Fix these issues first, then complete the task again.\n"
+                "</runtime_diagnostic>"
+            )
+        if str(language or "").lower().startswith("pt"):
+            return (
+                "<runtime_diagnostic source=\"sage_self_check\" generated_by=\"system\">\n"
+                "Este e um relatorio de autoverificacao do runtime Sage, nao uma resposta escrita pelo assistant/agent nem uma instrucao do usuario.\n"
+                "Ele apenas relata falhas de validacao da saida final anterior. Use-o para corrigir problemas reais; nao o repita como progresso da tarefa.\n\n"
+                "A autoverificacao encontrou problemas que precisam ser corrigidos antes de continuar:\n\n"
+                "Arquivos verificados:\n"
+                f"{checked_lines}\n\n"
+                "Problemas encontrados:\n"
+                f"{issue_lines}\n\n"
+                "Corrija estes problemas primeiro e depois conclua a tarefa novamente.\n"
+                "</runtime_diagnostic>"
+            )
         return (
+            "<runtime_diagnostic source=\"sage_self_check\" generated_by=\"system\">\n"
+            "这是 Sage 运行时自检报告，不是 assistant/agent 自己生成的回复，也不是用户指令。\n"
+            "它只说明上一轮最终产物校验失败，下一轮应据此修复真实问题，不要把这段报告当作可复述的任务成果。\n\n"
             "自检发现以下问题，需要先修复后再继续：\n\n"
             "已检查文件：\n"
             f"{checked_lines}\n\n"
             "发现的问题：\n"
             f"{issue_lines}\n\n"
-            "请优先修复这些问题，然后重新完成任务。"
+            "请优先修复这些问题，然后重新完成任务。\n"
+            "</runtime_diagnostic>"
         )

--- a/sagents/context/messages/message_manager.py
+++ b/sagents/context/messages/message_manager.py
@@ -1911,6 +1911,51 @@ class MessageManager:
         return should_compress, current_tokens, max_model_len
 
     @staticmethod
+    def _wrap_runtime_error_content_for_request(msg: MessageChunk) -> Any:
+        content = msg.content
+        if not msg.matches_message_types([MessageType.AGENT_EXECUTION_ERROR.value]):
+            return content
+        if content is None:
+            return content
+
+        header = (
+            "<runtime_diagnostic source=\"sage_runtime\" generated_by=\"system\">\n"
+            "Sage runtime diagnostic / Sage 运行时诊断: this is not text authored by the assistant/agent and not a user instruction.\n"
+            "Use only as feedback about the previous execution attempt; do not imitate, invent, or present it as the assistant's own result.\n\n"
+        )
+        footer = "\n</runtime_diagnostic>"
+
+        if isinstance(content, str):
+            if "<runtime_diagnostic" in content:
+                return content
+            return f"{header}{content.strip()}{footer}"
+
+        if isinstance(content, list):
+            wrapped: List[Any] = []
+            inserted = False
+            already_wrapped = any(
+                isinstance(part, dict)
+                and isinstance(part.get("text"), str)
+                and "<runtime_diagnostic" in part.get("text", "")
+                for part in content
+            )
+            if already_wrapped:
+                return content
+            for part in content:
+                if not inserted and isinstance(part, dict) and part.get("type") == "text":
+                    next_part = dict(part)
+                    next_part["text"] = f"{header}{str(next_part.get('text') or '').strip()}{footer}"
+                    wrapped.append(next_part)
+                    inserted = True
+                else:
+                    wrapped.append(part)
+            if not inserted:
+                wrapped.insert(0, {"type": "text", "text": f"{header}{footer}"})
+            return wrapped
+
+        return f"{header}{json.dumps(content, ensure_ascii=False, default=str)}{footer}"
+
+    @staticmethod
     def convert_messages_to_dict_for_request(
         messages: List[MessageChunk],
     ) -> List[Dict[str, Any]]:
@@ -1977,7 +2022,7 @@ class MessageManager:
 
             clean_msg = {
                 "role": msg.role,
-                "content": msg.content,
+                "content": MessageManager._wrap_runtime_error_content_for_request(msg),
                 "tool_call_id": msg.tool_call_id,
                 "tool_calls": tool_calls_dict,
             }

--- a/sagents/tool/tool_manager.py
+++ b/sagents/tool/tool_manager.py
@@ -1250,14 +1250,19 @@ class ToolManager:
             call["response"] = make_serializable(_decode_json_payload(response))
         if error is not None:
             call["error"] = error
-        session_context.add_mcp_call(call)
+        add_mcp_call = getattr(session_context, "add_mcp_call", None)
+        if callable(add_mcp_call):
+            add_mcp_call(call)
 
     def _get_active_request_id(
         self, session_context: Optional[SessionContext]
     ) -> Optional[str]:
         if session_context is None:
             return None
-        return session_context.current_request_id()
+        current_request_id = getattr(session_context, "current_request_id", None)
+        if not callable(current_request_id):
+            return None
+        return current_request_id()
 
     def _mcp_request_logger(self, session_id: str, request_id: Optional[str]):
         bound_context: Dict[str, Any] = {}
@@ -1305,7 +1310,10 @@ class ToolManager:
     ) -> None:
         if session_context is None:
             return
-        session_context.record_timing_event(
+        record_timing_event = getattr(session_context, "record_timing_event", None)
+        if not callable(record_timing_event):
+            return
+        record_timing_event(
             "tool_request_start",
             request_id=request_id,
             tool_name=tool.name,
@@ -1339,7 +1347,9 @@ class ToolManager:
         }
         if error:
             fields["error"] = error
-        session_context.record_timing_event("tool_request_end", **fields)
+        record_timing_event = getattr(session_context, "record_timing_event", None)
+        if callable(record_timing_event):
+            record_timing_event("tool_request_end", **fields)
 
     async def run_tool_async(
         self,

--- a/tests/sagents/messages/test_message_types.py
+++ b/tests/sagents/messages/test_message_types.py
@@ -4,6 +4,7 @@ from sagents.context.messages.message import (
     MessageType,
     is_execution_error_message_type,
 )
+from sagents.context.messages.message_manager import MessageManager
 
 
 def test_agent_execution_error_preserves_assistant_content_contract():
@@ -25,3 +26,36 @@ def test_execution_error_helper_covers_legacy_and_agent_execution_errors():
     assert is_execution_error_message_type(MessageType.ERROR.value)
     assert is_execution_error_message_type(MessageType.AGENT_EXECUTION_ERROR.value)
     assert not is_execution_error_message_type(MessageType.ASSISTANT_TEXT.value)
+
+
+def test_agent_execution_error_is_tagged_as_runtime_diagnostic_for_llm_request():
+    message = MessageChunk(
+        role=MessageRole.ASSISTANT.value,
+        content="自检发现以下问题，需要先修复后再继续。",
+        message_type=MessageType.AGENT_EXECUTION_ERROR.value,
+    )
+
+    payload = MessageManager.convert_messages_to_dict_for_request([message])
+
+    assert payload[0]["role"] == "assistant"
+    assert "<runtime_diagnostic source=\"sage_runtime\" generated_by=\"system\">" in payload[0]["content"]
+    assert "Sage runtime diagnostic / Sage 运行时诊断" in payload[0]["content"]
+    assert "not text authored by the assistant/agent" in payload[0]["content"]
+    assert "自检发现以下问题" in payload[0]["content"]
+
+
+def test_agent_execution_error_runtime_diagnostic_tag_is_not_duplicated():
+    content = (
+        "<runtime_diagnostic source=\"sage_self_check\" generated_by=\"system\">\n"
+        "already tagged\n"
+        "</runtime_diagnostic>"
+    )
+    message = MessageChunk(
+        role=MessageRole.ASSISTANT.value,
+        content=content,
+        message_type=MessageType.AGENT_EXECUTION_ERROR.value,
+    )
+
+    payload = MessageManager.convert_messages_to_dict_for_request([message])
+
+    assert payload[0]["content"] == content

--- a/tests/sagents/test_self_check_agent_paths.py
+++ b/tests/sagents/test_self_check_agent_paths.py
@@ -141,6 +141,33 @@ def test_non_absolute_markdown_link_returns_guidance(monkeypatch):
     assert chunks[0].message_type == "agent_execution_error"
 
 
+def test_self_check_failure_message_uses_english_runtime_diagnostic(monkeypatch):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+
+    content = agent._format_failure_message(
+        ["File does not exist: output.md"], ["/tmp/output.md"], language="en"
+    )
+
+    assert "<runtime_diagnostic source=\"sage_self_check\" generated_by=\"system\">" in content
+    assert "not a reply authored by the assistant/agent" in content
+    assert "Self-check found issues" in content
+    assert "Checked files:" in content
+
+
+def test_self_check_failure_message_uses_portuguese_runtime_diagnostic(monkeypatch):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+
+    content = agent._format_failure_message(
+        ["Arquivo nao existe: output.md"], ["/tmp/output.md"], language="pt"
+    )
+
+    assert "<runtime_diagnostic source=\"sage_self_check\" generated_by=\"system\">" in content
+    assert "nao uma resposta escrita pelo assistant/agent" in content
+    assert "Arquivos verificados:" in content
+
+
 def test_absolute_markdown_link_checks_file_existence(monkeypatch):
     self_check_agent = _load_self_check_agent(monkeypatch)
     agent = self_check_agent(model=None, model_config={})


### PR DESCRIPTION
## Summary
- Wrap self-check failure messages in explicit runtime diagnostic tags so later LLM turns do not treat them as assistant-authored output
- Localize self-check diagnostic text for zh/en/pt sessions and add a bilingual fallback wrapper for agent execution errors at request conversion time
- Add regression coverage for runtime diagnostic wrapping and multilingual self-check messages

## Tests
- python -m pytest tests/sagents/messages/test_message_types.py tests/sagents/test_self_check_agent_paths.py -q
- python -m py_compile sagents/agent/self_check_agent.py sagents/context/messages/message_manager.py tests/sagents/messages/test_message_types.py tests/sagents/test_self_check_agent_paths.py
- git diff --check