### PR TITLE
feat: sanitize runtime context persistence

### DIFF
--- a/common/models/conversation.py
+++ b/common/models/conversation.py
@@ -8,6 +8,7 @@ from sqlalchemy import JSON, String, Text, func, or_, select, update
 from sqlalchemy.orm import Mapped, load_only, mapped_column
 
 from common.models.base import Base, BaseDao, get_local_now
+from common.utils.message_persistence import sanitize_messages_for_persistence
 
 
 class Conversation(Base):
@@ -96,13 +97,14 @@ class ConversationDao(BaseDao):
         title: str,
         messages: List[Dict[str, Any]],
     ) -> bool:
+        clean_messages = sanitize_messages_for_persistence(messages or [])
         conversation = Conversation(
             user_id=user_id,
             session_id=session_id,
             agent_id=agent_id,
             agent_name=agent_name,
             title=title,
-            messages=messages or [],
+            messages=clean_messages,
         )
         conversation.updated_at = get_local_now()
         return await BaseDao.save(self, conversation)
@@ -203,12 +205,13 @@ class ConversationDao(BaseDao):
     async def update_conversation_messages(
         self, session_id: str, messages: List[Dict[str, Any]]
     ) -> bool:
+        clean_messages = sanitize_messages_for_persistence(messages or [])
         db = await self._get_db()
         async with db.get_session() as session:  # type: ignore[attr-defined]
             stmt = (
                 update(Conversation)
                 .where(Conversation.session_id == session_id)
-                .values(messages=messages or [], updated_at=get_local_now())
+                .values(messages=clean_messages, updated_at=get_local_now())
             )
             result = await session.execute(stmt)
             return bool(result.rowcount)  # pyright: ignore[reportAttributeAccessIssue]

--- a/common/services/conversation_service.py
+++ b/common/services/conversation_service.py
@@ -28,6 +28,7 @@ from common.models.conversation import Conversation, ConversationDao
 from common.schemas.conversation import ConversationInfo
 from common.services.chat_processor import ContentProcessor
 from common.services.chat_utils import get_sessions_root
+from common.utils.message_persistence import sanitize_messages_for_persistence
 
 _SESSION_PERSISTENCE_TASKS: Dict[str, asyncio.Task] = {}
 
@@ -729,9 +730,10 @@ def _write_session_files(session_id: str, messages: List[Dict[str, Any]]) -> Non
         return
 
     workspace_path.mkdir(parents=True, exist_ok=True)
+    clean_messages = sanitize_messages_for_persistence(messages)
 
     with open(messages_path, "w", encoding="utf-8") as f:
-        json.dump(messages, f, ensure_ascii=False, indent=4)
+        json.dump(clean_messages, f, ensure_ascii=False, indent=4)
 
     if context_path.exists():
         try:
@@ -758,7 +760,7 @@ def _write_session_files(session_id: str, messages: List[Dict[str, Any]]) -> Non
                 json.dump(context_data, f, ensure_ascii=False, indent=4)
 
     tools_usage: Dict[str, int] = {}
-    for message in messages:
+    for message in clean_messages:
         for tool_call in (message or {}).get("tool_calls", []) or []:
             tool_name = (tool_call or {}).get("function", {}).get("name")
             if tool_name:

--- a/common/utils/message_persistence.py
+++ b/common/utils/message_persistence.py
@@ -38,6 +38,11 @@ def sanitize_messages_for_persistence(messages: List[Any]) -> List[Dict[str, Any
     return [_sanitize_message_for_persistence(message) for message in messages or []]
 
 
+def extract_current_time_context_tag(content: Any) -> str | None:
+    """Extract the original ``<current_time>...</current_time>`` tag."""
+    return _extract_current_time_tag(content)
+
+
 def _sanitize_message_for_persistence(message: Any) -> Dict[str, Any]:
     if hasattr(message, "to_dict") and callable(message.to_dict):
         data = copy.deepcopy(message.to_dict())

--- a/common/utils/message_persistence.py
+++ b/common/utils/message_persistence.py
@@ -1,0 +1,154 @@
+"""Helpers for storing clean conversation history."""
+
+from __future__ import annotations
+
+import copy
+import re
+from typing import Any, Dict, List
+
+
+_CURRENT_TIME_RE = re.compile(
+    r"<current_time\b[^>]*>.*?</current_time>",
+    re.IGNORECASE | re.DOTALL,
+)
+_RUNTIME_CONTEXT_RE = re.compile(
+    r"<runtime_context\b[^>]*>.*?</runtime_context>",
+    re.IGNORECASE | re.DOTALL,
+)
+_USER_REQUEST_RE = re.compile(
+    r"<user_request\b[^>]*>\s*(.*?)\s*</user_request>",
+    re.IGNORECASE | re.DOTALL,
+)
+_RUNTIME_METADATA_KEYS = {
+    "frozen_user_inference",
+    "runtime_context_injected",
+    "inference_view_only",
+    "frozen_user_inference_version",
+}
+_CURRENT_TIME_METADATA_KEY = "current_time_context"
+
+
+def sanitize_messages_for_persistence(messages: List[Any]) -> List[Dict[str, Any]]:
+    """Return a persistence-safe copy of messages.
+
+    Runtime context belongs to the per-request inference view. Persisted history
+    keeps user-visible content clean while preserving the current-time tag as
+    metadata for audit/debug use.
+    """
+    return [_sanitize_message_for_persistence(message) for message in messages or []]
+
+
+def _sanitize_message_for_persistence(message: Any) -> Dict[str, Any]:
+    if hasattr(message, "to_dict") and callable(message.to_dict):
+        data = copy.deepcopy(message.to_dict())
+    elif isinstance(message, dict):
+        data = copy.deepcopy(message)
+    else:
+        data = copy.deepcopy(getattr(message, "__dict__", {}))
+
+    current_time_tag = _extract_current_time_tag(data.get("content"))
+    metadata = data.get("metadata")
+    if isinstance(metadata, dict):
+        frozen = metadata.get("frozen_user_inference")
+        if isinstance(frozen, dict):
+            current_time_tag = current_time_tag or _extract_current_time_tag(
+                frozen.get("content")
+            )
+
+    if "content" in data:
+        data["content"] = _sanitize_content(data.get("content"))
+    _sanitize_metadata(data, current_time_tag)
+    return data
+
+
+def _sanitize_metadata(
+    message: Dict[str, Any],
+    current_time_tag: str | None,
+) -> None:
+    metadata = message.get("metadata")
+    if not isinstance(metadata, dict):
+        if current_time_tag:
+            message["metadata"] = {_CURRENT_TIME_METADATA_KEY: current_time_tag}
+        return
+
+    clean_metadata = copy.deepcopy(metadata)
+    for key in _RUNTIME_METADATA_KEYS:
+        clean_metadata.pop(key, None)
+    if current_time_tag:
+        clean_metadata[_CURRENT_TIME_METADATA_KEY] = current_time_tag
+
+    if clean_metadata:
+        message["metadata"] = clean_metadata
+    else:
+        message.pop("metadata", None)
+
+
+def _extract_current_time_tag(content: Any) -> str | None:
+    if isinstance(content, str):
+        if "<runtime_context" not in content and "<current_time" not in content:
+            return None
+        match = _CURRENT_TIME_RE.search(content)
+        return match.group(0).strip() if match else None
+    if isinstance(content, list):
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            match = _extract_current_time_tag(part.get("text") or part.get("content"))
+            if match:
+                return match
+    return None
+
+
+def _sanitize_content(content: Any) -> Any:
+    if isinstance(content, str):
+        return _sanitize_text_content(content)
+    if isinstance(content, list):
+        return _sanitize_multimodal_content(content)
+    return content
+
+
+def _sanitize_text_content(text: str) -> str:
+    if "<runtime_context" not in text:
+        return text
+
+    user_request = _USER_REQUEST_RE.search(text)
+    if user_request:
+        return user_request.group(1).strip()
+
+    cleaned = _RUNTIME_CONTEXT_RE.sub("", text)
+    cleaned = re.sub(r"</?user_request\b[^>]*>", "", cleaned, flags=re.IGNORECASE)
+    return cleaned.strip()
+
+
+def _sanitize_multimodal_content(content: List[Any]) -> List[Any]:
+    sanitized: List[Any] = []
+    for part in content:
+        if not isinstance(part, dict):
+            sanitized.append(copy.deepcopy(part))
+            continue
+
+        clean_part = copy.deepcopy(part)
+        text_value = clean_part.get("text")
+        content_value = clean_part.get("content")
+        if isinstance(text_value, str):
+            clean_text = _sanitize_multimodal_text_part(text_value)
+            if clean_text is None:
+                continue
+            clean_part["text"] = clean_text
+        elif isinstance(content_value, str):
+            clean_text = _sanitize_multimodal_text_part(content_value)
+            if clean_text is None:
+                continue
+            clean_part["content"] = clean_text
+        sanitized.append(clean_part)
+    return sanitized
+
+
+def _sanitize_multimodal_text_part(text: str) -> str | None:
+    if "<runtime_context" in text:
+        cleaned = _RUNTIME_CONTEXT_RE.sub("", text)
+    else:
+        cleaned = text
+    cleaned = re.sub(r"</?user_request\b[^>]*>", "", cleaned, flags=re.IGNORECASE)
+    cleaned = cleaned.strip()
+    return cleaned if cleaned else None

--- a/sagents/agent/agent_base.py
+++ b/sagents/agent/agent_base.py
@@ -644,6 +644,31 @@ class AgentBase(ABC):
                 f"{self.__class__.__name__}: failed to persist frozen user inference: {exc}"
             )
 
+    def _save_runtime_context_snapshot(
+        self,
+        *,
+        session_id: str,
+        source_message: MessageChunk,
+        runtime_context: str,
+    ) -> None:
+        try:
+            session_context = self._get_live_session_context(session_id)
+            if session_context is None:
+                return
+            append_snapshot = getattr(
+                session_context, "append_runtime_context_snapshot", None
+            )
+            if not callable(append_snapshot):
+                return
+            append_snapshot(
+                message_id=source_message.message_id,
+                runtime_context=runtime_context,
+            )
+        except Exception as exc:
+            logger.debug(
+                f"{self.__class__.__name__}: failed to save runtime context snapshot: {exc}"
+            )
+
     def _find_frozen_user_inference_in_ledger(
         self, session_id: str, message: MessageChunk
     ) -> Optional[Dict[str, Any]]:
@@ -726,6 +751,11 @@ class AgentBase(ABC):
                     session_id=session_id,
                     source_message=messages[latest_user_idx],
                     frozen=frozen,
+                )
+                self._save_runtime_context_snapshot(
+                    session_id=session_id,
+                    source_message=messages[latest_user_idx],
+                    runtime_context=runtime_text,
                 )
                 injected[latest_user_idx] = latest_user
         return injected

--- a/sagents/context/session_context.py
+++ b/sagents/context/session_context.py
@@ -1,5 +1,6 @@
 # 负责管理会话的上下文，以及过程中产生的日志以及状态记录。
 import asyncio
+import hashlib
 import time
 import threading
 import uuid
@@ -25,7 +26,10 @@ import datetime
 from sagents.utils.sandbox import SandboxProviderFactory, SandboxConfig, SandboxType
 from sagents.utils.sandbox.config import VolumeMount
 from sagents.utils.common_utils import detect_machine_environment
-from common.utils.message_persistence import sanitize_messages_for_persistence
+from common.utils.message_persistence import (
+    extract_current_time_context_tag,
+    sanitize_messages_for_persistence,
+)
 
 _session_context_file_io_pool = ThreadPoolExecutor(
     max_workers=8, thread_name_prefix="session-context-io"
@@ -237,6 +241,9 @@ class SessionContext:
         self._current_request: Optional[Dict[str, Any]] = None
         self._request_lock = threading.Lock()
         self._llm_request_save_lock = threading.Lock()
+        self._runtime_context_snapshot_lock = threading.Lock()
+        self._runtime_context_snapshot_keys: set[str] = set()
+        self._runtime_context_snapshot_keys_loaded = False
         self._save_lock = threading.Lock()
         self._last_save_signature: Optional[tuple] = None
         self._last_save_time = 0.0
@@ -1147,6 +1154,78 @@ class SessionContext:
             with open(file_path, "w", encoding="utf-8") as f:
                 json.dump(serializable_request, f, ensure_ascii=False, indent=4)
             return file_path
+
+    def append_runtime_context_snapshot(
+        self,
+        *,
+        message_id: Optional[str],
+        runtime_context: str,
+    ) -> Optional[str]:
+        """Append one runtime-context audit snapshot outside conversation history."""
+        runtime_context = (runtime_context or "").strip()
+        if not runtime_context:
+            return None
+
+        snapshot_key = message_id or self._runtime_context_snapshot_hash(
+            runtime_context
+        )
+        with self._runtime_context_snapshot_lock:
+            self._load_runtime_context_snapshot_keys_locked()
+            if snapshot_key in self._runtime_context_snapshot_keys:
+                return None
+
+            file_path = os.path.join(
+                self.session_workspace,
+                "runtime_context_snapshots.jsonl",
+            )
+            os.makedirs(self.session_workspace, exist_ok=True)
+            snapshot = {
+                "snapshot_key": snapshot_key,
+                "session_id": self.session_id,
+                "message_id": message_id,
+                "timestamp": time.time(),
+                "current_time_context": extract_current_time_context_tag(
+                    runtime_context
+                ),
+                "runtime_context": runtime_context,
+            }
+            with open(file_path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(make_serializable(snapshot), ensure_ascii=False))
+                f.write("\n")
+            self._runtime_context_snapshot_keys.add(snapshot_key)
+            return file_path
+
+    @staticmethod
+    def _runtime_context_snapshot_hash(runtime_context: str) -> str:
+        digest = hashlib.sha256(runtime_context.encode("utf-8")).hexdigest()
+        return f"runtime:{digest}"
+
+    def _load_runtime_context_snapshot_keys_locked(self) -> None:
+        if self._runtime_context_snapshot_keys_loaded:
+            return
+        self._runtime_context_snapshot_keys_loaded = True
+        file_path = os.path.join(
+            self.session_workspace,
+            "runtime_context_snapshots.jsonl",
+        )
+        if not os.path.exists(file_path):
+            return
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    try:
+                        snapshot = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(snapshot, dict):
+                        continue
+                    key = snapshot.get("snapshot_key") or snapshot.get("message_id")
+                    if isinstance(key, str) and key:
+                        self._runtime_context_snapshot_keys.add(key)
+        except Exception as exc:
+            logger.warning(
+                f"SessionContext: Failed to load runtime context snapshot keys: {exc}"
+            )
 
     async def _cleanup_expired_todo_tasks(self):
         try:

--- a/sagents/context/session_context.py
+++ b/sagents/context/session_context.py
@@ -25,6 +25,7 @@ import datetime
 from sagents.utils.sandbox import SandboxProviderFactory, SandboxConfig, SandboxType
 from sagents.utils.sandbox.config import VolumeMount
 from sagents.utils.common_utils import detect_machine_environment
+from common.utils.message_persistence import sanitize_messages_for_persistence
 
 _session_context_file_io_pool = ThreadPoolExecutor(
     max_workers=8, thread_name_prefix="session-context-io"
@@ -1827,7 +1828,9 @@ class SessionContext:
                     encoding="utf-8",
                 ) as f:
                     serializable_messages = make_serializable(
-                        self.message_manager.messages
+                        sanitize_messages_for_persistence(
+                            self.message_manager.messages
+                        )
                     )
                     json.dump(serializable_messages, f, ensure_ascii=False, indent=4)
             except Exception as e:

--- a/tests/common/utils/test_message_persistence.py
+++ b/tests/common/utils/test_message_persistence.py
@@ -1,0 +1,93 @@
+from common.utils.message_persistence import sanitize_messages_for_persistence
+
+
+def test_sanitize_messages_removes_frozen_runtime_but_preserves_current_time():
+    messages = [
+        {
+            "role": "user",
+            "content": "hello",
+            "metadata": {
+                "keep": "value",
+                "frozen_user_inference": {
+                    "content": (
+                        "<runtime_context>\n"
+                        "<system_context>\n"
+                        "<current_time>2026-07-05 12:00:00</current_time>\n"
+                        "<private_workspace>/tmp/work</private_workspace>\n"
+                        "</system_context>\n"
+                        "</runtime_context>\n\n"
+                        "<user_request>\nhello\n</user_request>"
+                    ),
+                    "metadata": {"runtime_context_injected": True},
+                },
+                "runtime_context_injected": True,
+                "inference_view_only": True,
+                "frozen_user_inference_version": 3,
+            },
+        }
+    ]
+
+    clean = sanitize_messages_for_persistence(messages)
+
+    assert clean[0]["content"] == "hello"
+    assert clean[0]["metadata"] == {
+        "keep": "value",
+        "current_time_context": "<current_time>2026-07-05 12:00:00</current_time>",
+    }
+    assert "frozen_user_inference" in messages[0]["metadata"]
+
+
+def test_sanitize_messages_strips_runtime_context_from_user_content():
+    messages = [
+        {
+            "role": "user",
+            "content": (
+                "<runtime_context>\n"
+                "<system_context>\n"
+                "<current_time>now</current_time>\n"
+                "<workspace_files>files</workspace_files>\n"
+                "</system_context>\n"
+                "</runtime_context>\n\n"
+                "<user_request>\nreal request\n</user_request>"
+            ),
+        }
+    ]
+
+    clean = sanitize_messages_for_persistence(messages)
+
+    assert clean[0]["content"] == "real request"
+    assert clean[0]["metadata"] == {
+        "current_time_context": "<current_time>now</current_time>"
+    }
+
+
+def test_sanitize_messages_strips_multimodal_runtime_wrapper():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        "<runtime_context><system_context>"
+                        "<current_time>now</current_time>"
+                        "</system_context></runtime_context>\n\n"
+                        "<user_request>\n"
+                    ),
+                },
+                {"type": "text", "text": "describe this image"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,x"}},
+                {"type": "text", "text": "\n</user_request>"},
+            ],
+        }
+    ]
+
+    clean = sanitize_messages_for_persistence(messages)
+
+    assert clean[0]["content"] == [
+        {"type": "text", "text": "describe this image"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,x"}},
+    ]
+    assert clean[0]["metadata"] == {
+        "current_time_context": "<current_time>now</current_time>"
+    }

--- a/tests/sagents/agent/test_agent_base_system_request.py
+++ b/tests/sagents/agent/test_agent_base_system_request.py
@@ -422,7 +422,11 @@ async def test_prepare_llm_request_messages_persists_frozen_context_to_ledger_me
     view_user = MessageChunk.from_dict(ledger_user.to_dict())
     message_manager = MessageManager()
     message_manager.messages = [ledger_user]
-    session_context = SimpleNamespace(message_manager=message_manager)
+    snapshots = []
+    session_context = SimpleNamespace(
+        message_manager=message_manager,
+        append_runtime_context_snapshot=lambda **kwargs: snapshots.append(kwargs),
+    )
 
     async def fake_system_messages(**kwargs):
         return [_message(MessageRole.SYSTEM.value, "stable")]
@@ -446,6 +450,14 @@ async def test_prepare_llm_request_messages_persists_frozen_context_to_ledger_me
     assert "<todo_list>todo</todo_list>" in frozen["content"]
     assert frozen["metadata"]["inference_view_only"] is True
     assert "persist" not in frozen["metadata"]
+    assert snapshots == [
+        {
+            "message_id": ledger_user.message_id,
+            "runtime_context": (
+                "<runtime_context><system_context><todo_list>todo</todo_list></system_context></runtime_context>"
+            ),
+        }
+    ]
 
     stale_view_user = MessageChunk.from_dict(ledger_user.to_dict())
     stale_view_user.metadata = {}

--- a/tests/sagents/context/test_runtime_context_snapshots.py
+++ b/tests/sagents/context/test_runtime_context_snapshots.py
@@ -1,0 +1,97 @@
+import json
+import threading
+
+from sagents.context.session_context import SessionContext
+
+
+def _runtime_context() -> str:
+    return (
+        "<runtime_context>\n"
+        "<system_context>\n"
+        "<current_time>2026-07-05 12:00:00</current_time>\n"
+        "<private_workspace>/tmp/work</private_workspace>\n"
+        "</system_context>\n"
+        "</runtime_context>"
+    )
+
+
+def _bare_context(tmp_path):
+    context = object.__new__(SessionContext)
+    context.session_id = "sess"
+    context.session_workspace = str(tmp_path)
+    context._runtime_context_snapshot_lock = threading.Lock()
+    context._runtime_context_snapshot_keys = set()
+    context._runtime_context_snapshot_keys_loaded = False
+    return context
+
+
+def test_append_runtime_context_snapshot_writes_jsonl(tmp_path):
+    context = _bare_context(tmp_path)
+
+    path = context.append_runtime_context_snapshot(
+        message_id="msg-1",
+        runtime_context=_runtime_context(),
+    )
+
+    assert path == str(tmp_path / "runtime_context_snapshots.jsonl")
+    lines = (tmp_path / "runtime_context_snapshots.jsonl").read_text(
+        encoding="utf-8"
+    ).splitlines()
+    assert len(lines) == 1
+
+    snapshot = json.loads(lines[0])
+    assert snapshot["snapshot_key"] == "msg-1"
+    assert snapshot["session_id"] == "sess"
+    assert snapshot["message_id"] == "msg-1"
+    assert (
+        snapshot["current_time_context"]
+        == "<current_time>2026-07-05 12:00:00</current_time>"
+    )
+    assert "<runtime_context>" in snapshot["runtime_context"]
+    assert "<private_workspace>/tmp/work</private_workspace>" in snapshot[
+        "runtime_context"
+    ]
+
+
+def test_append_runtime_context_snapshot_deduplicates_message_id(tmp_path):
+    context = _bare_context(tmp_path)
+
+    first = context.append_runtime_context_snapshot(
+        message_id="msg-1",
+        runtime_context=_runtime_context(),
+    )
+    second = context.append_runtime_context_snapshot(
+        message_id="msg-1",
+        runtime_context=_runtime_context().replace("/tmp/work", "/tmp/other"),
+    )
+
+    assert first is not None
+    assert second is None
+    lines = (tmp_path / "runtime_context_snapshots.jsonl").read_text(
+        encoding="utf-8"
+    ).splitlines()
+    assert len(lines) == 1
+
+
+def test_append_runtime_context_snapshot_loads_existing_keys(tmp_path):
+    snapshot_file = tmp_path / "runtime_context_snapshots.jsonl"
+    snapshot_file.write_text(
+        json.dumps(
+            {
+                "snapshot_key": "msg-1",
+                "session_id": "sess",
+                "message_id": "msg-1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    context = _bare_context(tmp_path)
+
+    result = context.append_runtime_context_snapshot(
+        message_id="msg-1",
+        runtime_context=_runtime_context(),
+    )
+
+    assert result is None
+    assert len(snapshot_file.read_text(encoding="utf-8").splitlines()) == 1


### PR DESCRIPTION
## 背景

当前 Sage 会在 LLM inference view 中把 `<runtime_context>` 注入到最新 user message，并通过 `metadata.frozen_user_inference` 保存本轮冻结后的推理视图。

这对本轮多次 LLM 调用和工具循环是有用的，但不应该进入长期历史。否则 `messages.json` 或 `conversations.messages` 中会持久化运行态上下文，影响历史读取、导出、memory recall、rerun 等长期使用场景。

同时，完整 runtime context 对问题排查和审计仍然有价值，因此需要在不污染长期对话历史的前提下单独保存。

## 修改内容

- 新增统一的持久化清理工具 `sanitize_messages_for_persistence`
- 写入 `messages.json` 前，对消息 copy 做 runtime-only 清理
- 写入 `conversations.messages` 前，在 DAO 层增加兜底清理
- 直接写 session files 的路径也接入同一个清理逻辑
- 清理 `metadata.frozen_user_inference`、`runtime_context_injected`、`inference_view_only` 等运行态字段
- 保留 `<current_time>...</current_time>`，转存到 `metadata.current_time_context`
- 新增 `runtime_context_snapshots.jsonl`，单独保存每个 user turn 对应的完整 `<runtime_context>`
- snapshot 通过 `message_id` 和 `messages.json` 中的 user message 关联，不重复保存用户输入正文
- 对 snapshot 写入增加 `message_id` 去重，避免同一 user message 多次准备 LLM request 时重复落盘
- 增加 sanitizer 和 runtime context snapshot 单元测试

## 设计原则

- 不修改运行中的 `message_manager.messages` 原对象
- 不影响本轮 inference view 构造和 tool loop
- 只在落盘/落库前清理持久化 copy
- 长期历史保持干净，完整 runtime context 单独进入审计文件
- 多入口统一兜底，覆盖 server、desktop、CLI、rerun/edit 等写入路径