### PR TITLE
Set up Cloud dev environment (deps, docs, run verification)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Sage is a multi-agent platform. The primary dev target is the **Web product**: a
+FastAPI backend (`app/server/main.py`) plus a Vue 3 + Vite SPA (`app/server/web`).
+CLI/desktop/TUI/extension are alternate front-ends over the same Python kernel
+(`sagents/`, `common/`, `mcp_servers/`).
+
+Dependencies (Python `requirements.txt`, `app/server/web`, `app/desktop/ui`) are
+installed by the startup update script — do not reinstall them by hand.
+
+### Running the Web app (dev)
+- Backend: `python -m app.server.main` (needs a `.env`; create with
+  `cp .env.example.minimal .env` if missing). Health check: `GET /api/health`.
+- Frontend: `cd app/server/web && npm run dev` → http://localhost:5173
+- Logs from the helper script go to `logs/server.log`.
+
+### Non-obvious gotchas (important)
+- **Backend must run on port 30050 for the dev web UI.** `app/server/web/vite.config.js`
+  hardcodes its `/prod-api` proxy target to `http://127.0.0.1:30050`. The
+  `VITE_*` values that `scripts/dev-up.sh` writes into `.env.development` are NOT
+  read by this vite config. So set `SAGE_PORT=30050` in `.env` (the `sage` backend
+  otherwise defaults to 8080).
+- **`.env.example.minimal` has a broken DB setting.** It sets `SAGE_DB_TYPE=sqlite`
+  + `SAGE_SQLITE_PATH`, but the code only supports `file`, `memory`, `mysql`
+  (`common/core/client/db.py`). Use `SAGE_DB_TYPE=file` and `SAGE_DB_FILE=./data/sage.db`
+  instead, or the backend fails to start with "不支持的数据库类型".
+- **Agent chat needs an LLM provider.** Login and the whole UI work without it, but
+  a first-login modal ("完善配置信息") blocks the chat input until an LLM provider is
+  configured. Set `SAGE_DEFAULT_LLM_API_KEY` (+ `SAGE_DEFAULT_LLM_API_BASE_URL`,
+  `SAGE_DEFAULT_LLM_MODEL_NAME`) in `.env`, or add a provider via that modal with a
+  real key. There is no LLM key in the environment by default.
+- **Default login:** username `admin`, password `admin.1234` (from
+  `SAGE_BOOTSTRAP_ADMIN_*` in `.env`). Self-registration is disabled by default.
+- **pip user scripts are not on PATH.** `ruff`, `pytest`, etc. install to
+  `~/.local/bin`. Invoke via modules: `python3 -m ruff ...`, `python3 -m pytest ...`.
+
+### Lint / test / build (see CI in `.github/workflows/ci-tests.yml`)
+- Lint: `python3 -m ruff check .` and `python3 -m ruff format --check .`
+- Python tests — run each suite **separately** (as CI does):
+  `python3 -m pytest tests/app`, `... tests/common`, `... tests/sagents`.
+  Running all suites in one `pytest` invocation triggers a pre-existing
+  pandas/`pytz` import-order collection error; the separated runs pass.
+- Web: `cd app/server/web && npm run check:i18n && npm test -- --run`
+- Desktop UI i18n: `cd app/desktop/ui && npm run check:i18n`

--- a/change_log.md
+++ b/change_log.md
@@ -1,5 +1,7 @@
 # Change Log
 
+- **2026-07-05 14:10** 搭建云端开发环境：补齐缺失运行依赖（itsdangerous/APScheduler/Authlib），新增 AGENTS.md 记录端口 30050、DB 类型 file、LLM 配置等注意事项，验证后端/前端启动与 admin 登录通过。
+
 - **2026-07-03 14:55** 新增希腊酸奶问卷坏例回归测试，验证 SelfCheckAgent 可检出 options 内误嵌 default/allow_other 的非法 JSON。
 
 - **2026-07-03 14:50** SelfCheckAgent 为 Artifacts/Questionnaire 标签增加 JSON 语法与结构校验，失败时复用 runtime_diagnostic 重试流程，保留原有路径存在性校验。

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,8 @@ ruff==0.15.14
 fastapi>=0.104.0
 uvicorn[standard]>=0.38.0
 pydantic>=2.5.0
+itsdangerous>=2.0.0  # Required by starlette SessionMiddleware (login/session flow)
+Authlib>=1.6.0  # OAuth2/OIDC + session auth used by app.server
 
 ##############################
 # 多模型协同（MCP + 工具）
@@ -85,6 +87,7 @@ chromadb>=0.4.22
 # 任务 / 调度
 ##############################
 croniter>=2.0.0
+APScheduler>=3.10,<4.0
 
 ##############################
 # 应用类工具


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Sage development environment for Cursor Cloud agents and verifies the Web product runs end-to-end.

### Changes
- **`requirements.txt`**: add missing runtime dependencies needed to start the backend — `itsdangerous` (required by Starlette `SessionMiddleware` for the login/session flow), `APScheduler` (imported at startup by the task scheduler), and `Authlib` (auth, previously only resolved transitively).
- **`AGENTS.md`**: new `## Cursor Cloud specific instructions` documenting how to run/lint/test the Web app plus non-obvious gotchas (backend must run on `SAGE_PORT=30050` to match the hardcoded Vite `/prod-api` proxy target; `.env.example.minimal`'s `SAGE_DB_TYPE=sqlite` is unsupported — use `file`; agent chat requires an LLM key; per-suite pytest to avoid a pandas/pytz collection quirk).
- **`change_log.md`**: setup log entry.

### Verification
- Backend (`python -m app.server.main`) starts healthy on `:30050`; frontend Vite dev server on `:5173`.
- Logged in via the web UI with the bootstrap admin account (`admin` / `admin.1234`) — backend issues JWTs and the main chat/workbench UI loads.
- Agent chat itself is gated behind LLM provider config; no LLM API key is present in the environment, so that step is intentionally not exercised.

[sage_web_login_demo.mp4](https://cursor.com/agents/bc-681ce7cf-6e6c-4412-8f9d-5cfd44a41bc9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsage_web_login_demo.mp4)

[Sage login page](https://cursor.com/agents/bc-681ce7cf-6e6c-4412-8f9d-5cfd44a41bc9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsage_login_page.webp)
[Sage main interface after login](https://cursor.com/agents/bc-681ce7cf-6e6c-4412-8f9d-5cfd44a41bc9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsage_logged_in.webp)

### Checks run
- `python3 -m ruff check .` / `python3 -m ruff format --check .`
- `python3 -m pytest tests/app` (171), `tests/common` (107), `tests/sagents` (721)
- `app/server/web`: `npm run check:i18n`, `npm test -- --run` (42)
- `app/desktop/ui`: `npm run check:i18n`


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-681ce7cf-6e6c-4412-8f9d-5cfd44a41bc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-681ce7cf-6e6c-4412-8f9d-5cfd44a41bc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

