### PR TITLE
fix: limit historical user runtime context

### DIFF
--- a/sagents/agent/agent_base.py
+++ b/sagents/agent/agent_base.py
@@ -573,6 +573,32 @@ class AgentBase(ABC):
         return copied
 
     @classmethod
+    def _apply_frozen_historical_user_time_context(
+        cls,
+        message: MessageChunk,
+        frozen: Dict[str, Any],
+    ) -> MessageChunk:
+        current_time_context = cls._extract_current_time_context_tag(
+            frozen.get("content")
+        )
+        stripped = cls._strip_skill_tags_from_message(message)
+        if not current_time_context:
+            return stripped
+        runtime_context = f"<runtime_context>\n{current_time_context}\n</runtime_context>"
+        return cls._wrap_message_with_runtime_context(stripped, runtime_context)
+
+    @staticmethod
+    def _extract_current_time_context_tag(content: Any) -> Optional[str]:
+        if not isinstance(content, str):
+            return None
+        match = re.search(
+            r"<current_time\b[^>]*>.*?</current_time>",
+            content,
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        return match.group(0).strip() if match else None
+
+    @classmethod
     def _strip_skill_tags_from_text(cls, text: str) -> str:
         cleaned = re.sub(
             r"<skill>\s*[^<]*?\s*</skill>",
@@ -682,11 +708,15 @@ class AgentBase(ABC):
         for idx, message in enumerate(injected):
             if message.role != MessageRole.USER.value:
                 continue
+            if idx == latest_user_idx:
+                continue
             frozen = self._get_frozen_user_inference(message)
             if not frozen:
                 frozen = self._find_frozen_user_inference_in_ledger(session_id, message)
             if frozen:
-                injected[idx] = self._apply_frozen_user_inference(message, frozen)
+                injected[idx] = self._apply_frozen_historical_user_time_context(
+                    message, frozen
+                )
 
         latest_user = injected[latest_user_idx]
         latest_frozen = self._get_frozen_user_inference(messages[latest_user_idx])
@@ -694,7 +724,11 @@ class AgentBase(ABC):
             latest_frozen = self._find_frozen_user_inference_in_ledger(
                 session_id, messages[latest_user_idx]
             )
-        if latest_frozen is None:
+        if latest_frozen is not None:
+            injected[latest_user_idx] = self._apply_frozen_user_inference(
+                messages[latest_user_idx], latest_frozen
+            )
+        else:
             parts: List[str] = []
             try:
                 runtime_context = await self._build_runtime_context_text(

--- a/sagents/agent/agent_base.py
+++ b/sagents/agent/agent_base.py
@@ -589,11 +589,49 @@ class AgentBase(ABC):
 
     @staticmethod
     def _extract_current_time_context_tag(content: Any) -> Optional[str]:
-        if not isinstance(content, str):
+        text_parts: List[str] = []
+        if isinstance(content, str):
+            text_parts.append(content)
+        elif isinstance(content, list):
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                text = part.get("text")
+                if isinstance(text, str):
+                    text_parts.append(text)
+                    continue
+                part_content = part.get("content")
+                if isinstance(part_content, str):
+                    text_parts.append(part_content)
+
+        for text in text_parts:
+            current_time_context = AgentBase._extract_current_time_from_runtime_text(
+                text
+            )
+            if current_time_context:
+                return current_time_context
+        return None
+
+    @staticmethod
+    def _extract_current_time_from_runtime_text(text: str) -> Optional[str]:
+        runtime_match = re.search(
+            r"<runtime_context\b[^>]*>(.*?)</runtime_context>",
+            text,
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        if not runtime_match:
             return None
+
+        runtime_body = runtime_match.group(1)
+        system_match = re.search(
+            r"<system_context\b[^>]*>(.*?)</system_context>",
+            runtime_body,
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        trusted_body = system_match.group(1) if system_match else runtime_body
         match = re.search(
             r"<current_time\b[^>]*>.*?</current_time>",
-            content,
+            trusted_body,
             flags=re.IGNORECASE | re.DOTALL,
         )
         return match.group(0).strip() if match else None

--- a/tests/sagents/agent/test_agent_base_system_request.py
+++ b/tests/sagents/agent/test_agent_base_system_request.py
@@ -306,7 +306,7 @@ async def test_prepare_llm_request_messages_freezes_injected_context_for_user_tu
 
 
 @pytest.mark.asyncio
-async def test_prepare_llm_request_messages_keeps_historical_user_frozen(
+async def test_prepare_llm_request_messages_keeps_only_current_time_for_historical_user(
     monkeypatch,
 ):
     agent = CommonAgent(model=object(), model_config={})
@@ -324,6 +324,7 @@ async def test_prepare_llm_request_messages_keeps_historical_user_frozen(
         calls["runtime"] += 1
         return (
             "<runtime_context><system_context>"
+            f"<current_time>time-{calls['runtime']}</current_time>"
             f"<todo_list>todo-{calls['runtime']}</todo_list>"
             "</system_context></runtime_context>"
         )
@@ -349,7 +350,12 @@ async def test_prepare_llm_request_messages_keeps_historical_user_frozen(
 
     assert calls == {"runtime": 2}
     assert "<todo_list>todo-1</todo_list>" in first_request_messages[1].content
-    assert "<todo_list>todo-1</todo_list>" in second_request_messages[1].content
+    assert "<current_time>time-1</current_time>" in second_request_messages[1].content
+    assert "<todo_list>todo-1</todo_list>" not in second_request_messages[1].content
+    assert "<user_request>\nfirst request\n</user_request>" in second_request_messages[
+        1
+    ].content
+    assert "<current_time>time-2</current_time>" in second_request_messages[3].content
     assert "<todo_list>todo-2</todo_list>" in second_request_messages[3].content
 
     first_frozen = first_user.metadata["frozen_user_inference"]

--- a/tests/sagents/agent/test_agent_base_system_request.py
+++ b/tests/sagents/agent/test_agent_base_system_request.py
@@ -367,6 +367,114 @@ async def test_prepare_llm_request_messages_keeps_only_current_time_for_historic
 
 
 @pytest.mark.asyncio
+async def test_prepare_llm_request_messages_does_not_promote_user_current_time_tag(
+    monkeypatch,
+):
+    agent = CommonAgent(model=object(), model_config={})
+    first_user = _message(
+        MessageRole.USER.value,
+        "<current_time>user-time</current_time> first request",
+    )
+    second_user = _message(MessageRole.USER.value, "second request")
+    message_manager = MessageManager()
+    message_manager.messages = [first_user, second_user]
+    session_context = SimpleNamespace(message_manager=message_manager)
+
+    async def fake_system_messages(**kwargs):
+        return [_message(MessageRole.SYSTEM.value, "stable")]
+
+    async def fake_runtime(**kwargs):
+        return (
+            "<runtime_context><system_context>"
+            "<current_time>runtime-time</current_time>"
+            "</system_context></runtime_context>"
+        )
+
+    monkeypatch.setattr(
+        agent, "_get_live_session_context", lambda session_id: session_context
+    )
+    monkeypatch.setattr(agent, "prepare_unified_system_messages", fake_system_messages)
+    monkeypatch.setattr(agent, "_build_runtime_context_text", fake_runtime)
+
+    await agent.prepare_llm_request_messages(
+        session_id="sess",
+        history_messages=[first_user],
+    )
+    request_messages = await agent.prepare_llm_request_messages(
+        session_id="sess",
+        history_messages=[
+            first_user,
+            _message(MessageRole.ASSISTANT.value, "answer"),
+            second_user,
+        ],
+    )
+
+    historical_content = request_messages[1].content
+    assert "<current_time>runtime-time</current_time>" in historical_content
+    assert historical_content.index("runtime-time") < historical_content.index(
+        "<user_request>"
+    )
+    assert "<current_time>user-time</current_time>" in historical_content
+    assert historical_content.index("user-time") > historical_content.index(
+        "<user_request>"
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_llm_request_messages_extracts_current_time_from_multimodal_frozen(
+    monkeypatch,
+):
+    agent = CommonAgent(model=object(), model_config={})
+    first_user = MessageChunk(
+        role=MessageRole.USER.value,
+        content=[
+            {"type": "text", "text": "<current_time>user-time</current_time> 看图"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,x"}},
+        ],
+    )
+    second_user = _message(MessageRole.USER.value, "second request")
+    message_manager = MessageManager()
+    message_manager.messages = [first_user, second_user]
+    session_context = SimpleNamespace(message_manager=message_manager)
+
+    async def fake_system_messages(**kwargs):
+        return [_message(MessageRole.SYSTEM.value, "stable")]
+
+    async def fake_runtime(**kwargs):
+        return (
+            "<runtime_context><system_context>"
+            "<current_time>runtime-time</current_time>"
+            "</system_context></runtime_context>"
+        )
+
+    monkeypatch.setattr(
+        agent, "_get_live_session_context", lambda session_id: session_context
+    )
+    monkeypatch.setattr(agent, "prepare_unified_system_messages", fake_system_messages)
+    monkeypatch.setattr(agent, "_build_runtime_context_text", fake_runtime)
+
+    await agent.prepare_llm_request_messages(
+        session_id="sess",
+        history_messages=[first_user],
+    )
+    request_messages = await agent.prepare_llm_request_messages(
+        session_id="sess",
+        history_messages=[
+            first_user,
+            _message(MessageRole.ASSISTANT.value, "answer"),
+            second_user,
+        ],
+    )
+
+    historical_content = request_messages[1].content
+    assert isinstance(historical_content, list)
+    assert "<current_time>runtime-time</current_time>" in historical_content[0]["text"]
+    assert "user-time" not in historical_content[0]["text"]
+    assert historical_content[1]["text"] == "<current_time>user-time</current_time> 看图"
+    assert historical_content[2]["type"] == "image_url"
+
+
+@pytest.mark.asyncio
 async def test_prepare_llm_request_messages_refreshes_new_user_without_rewriting_old_frozen(
     monkeypatch,
 ):


### PR DESCRIPTION
## 背景

当前 Sage 会把 `<runtime_context>` 注入 user message 的 inference view，并通过 `frozen_user_inference` 固定同一轮 user 请求中的 runtime context。

原逻辑在构造后续模型请求时，会把历史 user 的完整 frozen runtime context 也恢复出来，导致多轮对话里每个历史 user 都携带完整 runtime context，增加上下文体积，也会让历史上下文包含过多过期运行态信息。

## 修改内容

- 调整 `AgentBase._inject_latest_user_runtime_context`
- 历史 user 如果存在 `frozen_user_inference`，只从中提取 `<current_time>...</current_time>`
- 历史 user 最终以最小 runtime 形式进入模型请求：
  ```xml
  <runtime_context>
  <current_time>...</current_time>
  </runtime_context>

  <user_request>
  ...
  </user_request>