### PR TITLE
Add message journal recovery

### DIFF
--- a/sagents/context/session_context.py
+++ b/sagents/context/session_context.py
@@ -30,6 +30,9 @@ _session_context_file_io_pool = ThreadPoolExecutor(
     max_workers=8, thread_name_prefix="session-context-io"
 )
 
+MESSAGE_JOURNAL_SCHEMA_VERSION = 1
+MESSAGE_JOURNAL_FILE = "messages.journal.jsonl"
+
 
 class SessionStatus(Enum):
     """会话状态枚举"""
@@ -240,6 +243,10 @@ class SessionContext:
         self._mcp_calls_lock = threading.Lock()
         self._mcp_calls_save_lock = threading.Lock()
         self._save_lock = threading.Lock()
+        self._message_journal_lock = threading.RLock()
+        self._message_journal_seq = 0
+        self._message_journal_active_message_id: Optional[str] = None
+        self._message_journal_flushed_signatures: Dict[str, str] = {}
         self._last_save_signature: Optional[tuple] = None
         self._last_save_time = 0.0
         self.record_timing_event(
@@ -383,6 +390,226 @@ class SessionContext:
             "flow_node_timings": flow_node_timings,
         }
 
+    @staticmethod
+    def _message_journal_path_for_workspace(session_workspace: str) -> str:
+        return os.path.join(session_workspace, MESSAGE_JOURNAL_FILE)
+
+    def _message_journal_path(self) -> str:
+        session_workspace = getattr(self, "session_workspace", None)
+        if not session_workspace:
+            return ""
+        return self._message_journal_path_for_workspace(session_workspace)
+
+    @staticmethod
+    def _upsert_persisted_message(
+        messages: List[MessageChunk],
+        message: MessageChunk,
+    ) -> List[MessageChunk]:
+        if not message.message_id:
+            return [*messages, message]
+        for idx, existing in enumerate(messages):
+            if existing.message_id == message.message_id:
+                messages[idx] = message
+                return messages
+        messages.append(message)
+        return messages
+
+    @staticmethod
+    def load_persisted_message_ledger(
+        session_workspace: str,
+        session_id: Optional[str] = None,
+    ) -> tuple[List[MessageChunk], int, int]:
+        messages: List[MessageChunk] = []
+        max_journal_seq = 0
+        journal_records = 0
+
+        messages_path = os.path.join(session_workspace, "messages.json")
+        try:
+            if os.path.exists(messages_path):
+                with open(messages_path, "r", encoding="utf-8") as f:
+                    messages_data = json.load(f)
+                if isinstance(messages_data, list):
+                    messages = [
+                        MessageChunk.from_dict(msg)
+                        for msg in messages_data
+                        if isinstance(msg, dict)
+                    ]
+        except UnicodeDecodeError:
+            logger.warning(
+                "SessionContext: messages.json decode failed, file may be in legacy encoding, will start with empty messages"
+            )
+            messages = []
+        except Exception as e:
+            logger.warning(f"SessionContext: Failed to load messages.json: {e}")
+            messages = []
+
+        journal_path = SessionContext._message_journal_path_for_workspace(
+            session_workspace
+        )
+        if not os.path.exists(journal_path):
+            return messages, max_journal_seq, journal_records
+
+        try:
+            with open(journal_path, "r", encoding="utf-8") as f:
+                for line_number, line in enumerate(f, start=1):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError as exc:
+                        logger.warning(
+                            "SessionContext: skipped invalid message journal record "
+                            f"session_id={session_id} line={line_number}: {exc}"
+                        )
+                        continue
+                    if not isinstance(record, dict):
+                        continue
+                    if record.get("op") != "put_message":
+                        continue
+                    record_session_id = record.get("session_id")
+                    if (
+                        session_id
+                        and record_session_id
+                        and record_session_id != session_id
+                    ):
+                        continue
+                    seq = record.get("seq")
+                    if isinstance(seq, int):
+                        max_journal_seq = max(max_journal_seq, seq)
+                    message_data = record.get("message")
+                    if not isinstance(message_data, dict):
+                        continue
+                    try:
+                        message = MessageChunk.from_dict(message_data)
+                    except Exception as exc:
+                        logger.warning(
+                            "SessionContext: skipped invalid message journal message "
+                            f"session_id={session_id} line={line_number}: {exc}"
+                        )
+                        continue
+                    messages = SessionContext._upsert_persisted_message(
+                        messages, message
+                    )
+                    journal_records += 1
+        except Exception as e:
+            logger.warning(
+                f"SessionContext: Failed to replay {MESSAGE_JOURNAL_FILE}: {e}"
+            )
+
+        return messages, max_journal_seq, journal_records
+
+    def _get_message_by_id(self, message_id: Optional[str]) -> Optional[MessageChunk]:
+        if not message_id:
+            return None
+        for message in reversed(self.message_manager.messages):
+            if message.message_id == message_id:
+                return message
+        return None
+
+    def _append_message_to_journal(
+        self,
+        message_id: Optional[str],
+        *,
+        reason: str,
+    ) -> bool:
+        session_workspace = getattr(self, "session_workspace", None)
+        if not session_workspace:
+            return False
+        try:
+            os.makedirs(session_workspace, exist_ok=True)
+            with self._message_journal_lock:
+                message = self._get_message_by_id(message_id)
+                if message is None:
+                    return False
+                message_data = make_serializable(message)
+                message_signature = json.dumps(
+                    message_data,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+                if (
+                    message.message_id
+                    and self._message_journal_flushed_signatures.get(
+                        message.message_id
+                    )
+                    == message_signature
+                ):
+                    return False
+                self._message_journal_seq += 1
+                record = {
+                    "schema_version": MESSAGE_JOURNAL_SCHEMA_VERSION,
+                    "op": "put_message",
+                    "session_id": self.session_id,
+                    "message_id": message.message_id,
+                    "seq": self._message_journal_seq,
+                    "timestamp": time.time(),
+                    "reason": reason,
+                    "message": message_data,
+                }
+                with open(self._message_journal_path(), "a", encoding="utf-8") as f:
+                    f.write(json.dumps(record, ensure_ascii=False) + "\n")
+                    f.flush()
+                if message.message_id:
+                    self._message_journal_flushed_signatures[
+                        message.message_id
+                    ] = message_signature
+            return True
+        except Exception as e:
+            logger.warning(
+                "SessionContext: Failed to append message journal "
+                f"session_id={self.session_id} message_id={message_id} "
+                f"reason={reason}: {e}"
+            )
+            return False
+
+    def _track_message_journal_after_add(self, message_id: Optional[str]) -> None:
+        if not message_id:
+            return
+        if self._message_journal_active_message_id is None:
+            self._message_journal_active_message_id = message_id
+            return
+        if message_id == self._message_journal_active_message_id:
+            return
+        self._append_message_to_journal(
+            self._message_journal_active_message_id,
+            reason="message_id_switch",
+        )
+        self._message_journal_active_message_id = message_id
+
+    def flush_message_journal_current(self, *, reason: str) -> None:
+        self._append_message_to_journal(
+            self._message_journal_active_message_id,
+            reason=reason,
+        )
+
+    def _clear_message_journal_after_snapshot(self) -> None:
+        journal_path = self._message_journal_path()
+        if not journal_path:
+            return
+        if not os.path.exists(journal_path):
+            return
+        try:
+            with self._message_journal_lock:
+                if os.path.exists(journal_path):
+                    open(journal_path, "w", encoding="utf-8").close()
+            logger.info(
+                f"SessionContext: cleared {MESSAGE_JOURNAL_FILE} "
+                f"session_id={self.session_id}"
+            )
+        except Exception as e:
+            logger.warning(
+                f"SessionContext: Failed to clear {MESSAGE_JOURNAL_FILE} "
+                f"session_id={self.session_id}: {e}"
+            )
+
+    def _message_journal_has_records(self) -> bool:
+        try:
+            journal_path = self._message_journal_path()
+            return bool(journal_path) and os.path.getsize(journal_path) > 0
+        except OSError:
+            return False
+
     def add_messages(
         self, messages: Union[MessageChunk, List[MessageChunk], List[Dict[str, Any]]]
     ) -> None:
@@ -398,6 +625,7 @@ class SessionContext:
             messages_list = messages
 
         valid_messages = []
+        rejected_session_ids: List[str] = []
         for msg in messages_list:
             msg_session_id = None
             if isinstance(msg, MessageChunk):
@@ -407,16 +635,80 @@ class SessionContext:
 
             if msg_session_id is None or msg_session_id == self.session_id:
                 valid_messages.append(msg)
+            else:
+                rejected_session_ids.append(str(msg_session_id))
 
-        for msg in valid_messages:
-            if self._get_message_role(msg) == MessageRole.USER.value:
-                self._normalize_tool_call_pairs_before_user_message()
-            if self._get_message_role(msg) == MessageRole.TOOL.value:
-                if self._replace_synthetic_tool_result(msg):
-                    self._record_message_timing(msg)
-                    continue
-            self._record_message_timing(msg)
-            self.message_manager.add_messages(msg)
+        if rejected_session_ids:
+            logger.warning(
+                "SessionContext: rejected messages with mismatched session_id "
+                f"session_id={self.session_id} ctx_id={id(self)} "
+                f"manager_id={id(self.message_manager)} input_count={len(messages_list)} "
+                f"rejected_count={len(rejected_session_ids)} "
+                f"sample_rejected_session_ids={rejected_session_ids[:3]}"
+            )
+        if messages_list and not valid_messages:
+            logger.debug(
+                "SessionContext: add_messages had no valid messages "
+                f"session_id={self.session_id} ctx_id={id(self)} "
+                f"manager_id={id(self.message_manager)} input_count={len(messages_list)}"
+            )
+
+        with self._message_journal_lock:
+            for msg in valid_messages:
+                message_role = self._get_message_role(msg)
+                message_id = self._get_message_id(msg)
+                if message_role == MessageRole.USER.value:
+                    self.flush_message_journal_current(reason="before_user_message")
+                    self._normalize_tool_call_pairs_before_user_message()
+                if message_role == MessageRole.TOOL.value:
+                    if self._replace_synthetic_tool_result(msg):
+                        self._record_message_timing(msg)
+                        if self._get_message_by_id(message_id) is not None:
+                            self._track_message_journal_after_add(message_id)
+                            self._append_message_to_journal(
+                                message_id,
+                                reason="stable_message",
+                            )
+                        continue
+                self._record_message_timing(msg)
+                self.message_manager.add_messages(msg)
+                if self._get_message_by_id(message_id) is not None:
+                    self._track_message_journal_after_add(message_id)
+                    if (
+                        message_role
+                        in {MessageRole.USER.value, MessageRole.TOOL.value}
+                        or self._is_message_final(msg)
+                    ):
+                        self._append_message_to_journal(
+                            message_id,
+                            reason="stable_message",
+                        )
+
+    @staticmethod
+    def _debug_message_snapshot(message: Union[MessageChunk, Dict[str, Any]]) -> str:
+        if isinstance(message, MessageChunk):
+            role = message.role
+            message_type = message.message_type
+            message_id = message.message_id
+            content = message.content
+            tool_calls = message.tool_calls or []
+        elif isinstance(message, dict):
+            role = message.get("role")
+            message_type = message.get("message_type") or message.get("type")
+            message_id = message.get("message_id")
+            content = message.get("content")
+            tool_calls = message.get("tool_calls") or []
+        else:
+            return type(message).__name__
+        content_len = len(content) if isinstance(content, str) else 0
+        return (
+            f"{role}/{message_type}:{message_id}:"
+            f"content_len={content_len}:tool_calls={len(tool_calls)}"
+        )
+
+    def _debug_last_message_snapshots(self, limit: int = 5) -> List[str]:
+        messages = getattr(self.message_manager, "messages", []) or []
+        return [self._debug_message_snapshot(message) for message in messages[-limit:]]
 
     @staticmethod
     def _get_message_role(
@@ -428,6 +720,25 @@ class SessionContext:
             role = message.get("role")
             return role.value if hasattr(role, "value") else role
         return None
+
+    @staticmethod
+    def _get_message_id(
+        message: Union[MessageChunk, Dict[str, Any]],
+    ) -> Optional[str]:
+        if isinstance(message, MessageChunk):
+            return message.message_id
+        if isinstance(message, dict):
+            message_id = message.get("message_id")
+            return str(message_id) if message_id else None
+        return None
+
+    @staticmethod
+    def _is_message_final(message: Union[MessageChunk, Dict[str, Any]]) -> bool:
+        if isinstance(message, MessageChunk):
+            return bool(message.is_final)
+        if isinstance(message, dict):
+            return bool(message.get("is_final"))
+        return False
 
     @staticmethod
     def _get_tool_call_id_from_call(tool_call: Any) -> Optional[str]:
@@ -1091,27 +1402,22 @@ class SessionContext:
         """
         加载持久化的消息历史
         """
-        # 1. 尝试加载 messages.json
-        try:
-            messages_path = os.path.join(self.session_workspace, "messages.json")
-            if os.path.exists(messages_path):
-                with open(messages_path, "r", encoding="utf-8") as f:
-                    messages_data = json.load(f)
-                    if isinstance(messages_data, list):
-                        self.message_manager.messages = [
-                            MessageChunk.from_dict(msg) for msg in messages_data
-                        ]
-                        self.message_manager.refresh_compact_manifest()
-                        logger.debug(
-                            f"SessionContext: Loaded {len(self.message_manager.messages)} messages from messages.json"
-                        )
-                        return
-        except UnicodeDecodeError:
-            logger.warning(
-                "SessionContext: messages.json decode failed, file may be in legacy encoding, will start with empty messages"
-            )
-        except Exception as e:
-            logger.warning(f"SessionContext: Failed to load messages.json: {e}")
+        messages, max_journal_seq, journal_records = self.load_persisted_message_ledger(
+            self.session_workspace,
+            session_id=self.session_id,
+        )
+        self.message_manager.messages = messages
+        self.message_manager.stats["total_messages"] = len(messages)
+        self.message_manager.refresh_compact_manifest()
+        self._message_journal_seq = max_journal_seq
+        self._message_journal_active_message_id = (
+            messages[-1].message_id if messages else None
+        )
+        logger.debug(
+            "SessionContext: Loaded persisted messages "
+            f"session_id={self.session_id} messages={len(messages)} "
+            f"journal_records={journal_records}"
+        )
 
     def _prepare_llm_request_file_path(self, llm_request: Dict[str, Any]) -> str:
         llm_request_folder = os.path.join(self.session_workspace, "llm_request")
@@ -1876,26 +2182,70 @@ class SessionContext:
             if (
                 signature == self._last_save_signature
                 and now - self._last_save_time < 2.0
+                and not self._message_journal_has_records()
             ):
                 logger.debug(
                     f"SessionContext: 跳过重复保存 session_id={self.session_id}"
                 )
                 return
+            session_workspace = getattr(self, "session_workspace", None)
+            if not session_workspace:
+                logger.warning(
+                    "SessionContext: skip save because session_workspace is not set "
+                    f"session_id={self.session_id}"
+                )
+                self.record_timing_event(
+                    "session_end",
+                    status=status_value,
+                )
+                self._last_save_signature = signature
+                self._last_save_time = now
+                return
 
             # 1. 保存 messages 到 messages.json
             # 始终覆盖，保存完整历史
-            try:
-                with open(
-                    os.path.join(self.session_workspace, "messages.json"),
-                    "w",
-                    encoding="utf-8",
-                ) as f:
-                    serializable_messages = make_serializable(
-                        self.message_manager.messages
+            messages_saved = False
+            messages_path = os.path.join(session_workspace, "messages.json")
+            messages_tmp_path = f"{messages_path}.tmp"
+            with self._message_journal_lock:
+                self.flush_message_journal_current(reason="before_session_save")
+                logger.info(
+                    "SessionContext: saving messages.json "
+                    f"session_id={self.session_id} status={status_value} "
+                    f"ctx_id={id(self)} manager_id={id(self.message_manager)} "
+                    f"message_count={len(self.message_manager.messages)} "
+                    f"llm_request_count={len(self.llm_requests_logs)} "
+                    f"last_messages={self._debug_last_message_snapshots()}"
+                )
+                try:
+                    with open(messages_tmp_path, "w", encoding="utf-8") as f:
+                        serializable_messages = make_serializable(
+                            self.message_manager.messages
+                        )
+                        json.dump(
+                            serializable_messages,
+                            f,
+                            ensure_ascii=False,
+                            indent=4,
+                        )
+                    os.replace(messages_tmp_path, messages_path)
+                    messages_saved = True
+                    logger.info(
+                        "SessionContext: saved messages.json "
+                        f"session_id={self.session_id} "
+                        f"message_count={len(self.message_manager.messages)} "
+                        f"path={messages_path}"
                     )
-                    json.dump(serializable_messages, f, ensure_ascii=False, indent=4)
-            except Exception as e:
-                logger.error(f"SessionContext: Failed to save messages.json: {e}")
+                except Exception as e:
+                    logger.error(f"SessionContext: Failed to save messages.json: {e}")
+                    try:
+                        if os.path.exists(messages_tmp_path):
+                            os.remove(messages_tmp_path)
+                    except Exception:
+                        pass
+
+                if messages_saved:
+                    self._clear_message_journal_after_snapshot()
 
             # 2. 保存 compact_manifest.json（派生索引，仅用于审计/调试）
             try:

--- a/sagents/flow/executor.py
+++ b/sagents/flow/executor.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from typing import AsyncGenerator, List, Any, Optional
 from sagents.flow.schema import (
     FlowNode,
@@ -13,6 +14,41 @@ from sagents.flow.conditions import ConditionRegistry
 from sagents.utils.logger import logger
 from sagents.context.messages.message import MessageChunk
 from sagents.context.session_context import SessionStatus
+
+
+def _message_chunk_debug_summary(message_chunks: List[MessageChunk]) -> str:
+    if not message_chunks:
+        return "empty"
+    parts: List[str] = []
+    for chunk in message_chunks[-3:]:
+        role = getattr(chunk, "role", None)
+        message_type = getattr(chunk, "message_type", None) or getattr(
+            chunk, "type", None
+        )
+        message_id = getattr(chunk, "message_id", None)
+        content = getattr(chunk, "content", None)
+        content_len = len(content) if isinstance(content, str) else 0
+        tool_calls = getattr(chunk, "tool_calls", None) or []
+        parts.append(
+            f"{role}/{message_type}:{message_id}:"
+            f"content_len={content_len}:tool_calls={len(tool_calls)}"
+        )
+    return "; ".join(parts)
+
+
+def _message_ledger_count(ctx: Any) -> Optional[int]:
+    message_manager = getattr(ctx, "message_manager", None)
+    messages = getattr(message_manager, "messages", None)
+    if messages is None:
+        return None
+    return len(messages)
+
+
+def _message_manager_debug_id(ctx: Any) -> Optional[int]:
+    message_manager = getattr(ctx, "message_manager", None)
+    if message_manager is None:
+        return None
+    return id(message_manager)
 
 
 class _FlowExecutionTrace:
@@ -242,24 +278,49 @@ class FlowExecutor:
             # 如果有特殊配置，可能需要应用到 Agent (暂未实现完全覆盖，因 Agent 通常是单例或池化)
             # 这里直接执行
             phase_name = node.description or agent.agent_name
+            phase_started_at = time.time()
+            ledger_before = _message_ledger_count(ctx)
+            chunks_seen = 0
+            add_calls = 0
+            last_chunk_summary = "none"
 
-            async for message_chunks in self.runtime._execute_agent_phase(
-                session_id=self.session_id,
-                agent=agent,
-                phase_name=phase_name,
-                # override_config=node.override_config, # FlowNode definition does not have override_config yet
-            ):
-                if self._is_terminal_session_state(session):
-                    logger.info(
-                        f"FlowExecutor: session {self.session_id} reached terminal state "
-                        f"{session.get_status().value} while running agent '{agent_key}', stopping"
+            try:
+                async for message_chunks in self.runtime._execute_agent_phase(
+                    session_id=self.session_id,
+                    agent=agent,
+                    phase_name=phase_name,
+                    # override_config=node.override_config, # FlowNode definition does not have override_config yet
+                ):
+                    if self._is_terminal_session_state(session):
+                        logger.info(
+                            f"FlowExecutor: session {self.session_id} reached terminal state "
+                            f"{session.get_status().value} while running agent '{agent_key}', stopping"
+                        )
+                        return
+                    # 将消息添加到上下文 (这一步在 _execute_agent_phase 外部做还是内部做？)
+                    # 原逻辑是在外部做的: session_context.add_messages(message_chunks)
+                    # 所以这里我们也做
+                    ctx.add_messages(message_chunks)
+                    add_calls += 1
+                    chunks_seen += len(message_chunks or [])
+                    last_chunk_summary = _message_chunk_debug_summary(
+                        message_chunks or []
                     )
-                    return
-                # 将消息添加到上下文 (这一步在 _execute_agent_phase 外部做还是内部做？)
-                # 原逻辑是在外部做的: session_context.add_messages(message_chunks)
-                # 所以这里我们也做
-                ctx.add_messages(message_chunks)
-                yield message_chunks
+                    yield message_chunks
+            finally:
+                flush_journal = getattr(ctx, "flush_message_journal_current", None)
+                if callable(flush_journal):
+                    flush_journal(reason="agent_phase_end")
+                ledger_after = _message_ledger_count(ctx)
+                logger.info(
+                    "FlowExecutor: agent phase ledger summary "
+                    f"session_id={self.session_id} agent={agent_key} phase={phase_name} "
+                    f"ctx_id={id(ctx)} manager_id={_message_manager_debug_id(ctx)} "
+                    f"add_calls={add_calls} chunks_seen={chunks_seen} "
+                    f"ledger_before={ledger_before} ledger_after={ledger_after} "
+                    f"duration_ms={int((time.time() - phase_started_at) * 1000)} "
+                    f"last_chunks={last_chunk_summary}"
+                )
 
             if self._is_terminal_session_state(session):
                 logger.info(

--- a/sagents/session_runtime.py
+++ b/sagents/session_runtime.py
@@ -301,21 +301,11 @@ class Session:
         if not self.session_workspace:
             return []
 
-        messages_path = os.path.join(self.session_workspace, "messages.json")
-        if not os.path.exists(messages_path):
-            self._persisted_messages = []
-            return self._persisted_messages
-
         try:
-            raw_messages = _load_json_file_sync(messages_path)
-            if isinstance(raw_messages, list):
-                self._persisted_messages = [
-                    MessageChunk.from_dict(msg)
-                    for msg in raw_messages
-                    if isinstance(msg, dict)
-                ]
-            else:
-                self._persisted_messages = []
+            self._persisted_messages = SessionContext.load_persisted_message_ledger(
+                self.session_workspace,
+                session_id=self.session_id,
+            )[0]
         except Exception as exc:
             logger.debug(
                 f"SessionRuntime: 读取 session {self.session_id} messages 失败: {exc}"

--- a/tests/sagents/context/test_message_journal.py
+++ b/tests/sagents/context/test_message_journal.py
@@ -1,0 +1,326 @@
+import json
+import os
+import threading
+import time
+
+import sagents.context.session_context as session_context_module
+from sagents.context.messages.message import MessageChunk, MessageRole, MessageType
+from sagents.context.session_context import (
+    MESSAGE_JOURNAL_FILE,
+    SessionContext,
+)
+from sagents.session_runtime import Session
+
+
+def _make_session(tmp_path):
+    ctx = SessionContext(
+        session_id="sess_journal",
+        user_id="u1",
+        agent_id="a1",
+        session_root_space=str(tmp_path),
+    )
+    ctx.session_workspace = os.path.join(str(tmp_path), "sess_journal")
+    os.makedirs(ctx.session_workspace, exist_ok=True)
+    return ctx
+
+
+def _journal_path(ctx):
+    return os.path.join(ctx.session_workspace, MESSAGE_JOURNAL_FILE)
+
+
+def _read_journal(ctx):
+    path = _journal_path(ctx)
+    if not os.path.exists(path):
+        return []
+    with open(path, "r", encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def _assistant_chunk(message_id, content, is_final=False):
+    return MessageChunk(
+        role=MessageRole.ASSISTANT.value,
+        content=content,
+        message_id=message_id,
+        message_type=MessageType.DO_SUBTASK_RESULT.value,
+        is_final=is_final,
+    )
+
+
+def test_message_journal_writes_user_message_immediately(tmp_path):
+    ctx = _make_session(tmp_path)
+
+    ctx.add_messages(
+        MessageChunk(
+            role=MessageRole.USER.value,
+            content="please do this",
+            message_id="u1",
+        )
+    )
+
+    records = _read_journal(ctx)
+    assert len(records) == 1
+    assert records[0]["message_id"] == "u1"
+    assert records[0]["message"]["content"] == "please do this"
+
+
+def test_message_journal_writes_previous_message_on_id_switch(tmp_path):
+    ctx = _make_session(tmp_path)
+
+    ctx.add_messages(_assistant_chunk("m1", "hello"))
+    ctx.add_messages(_assistant_chunk("m1", " world"))
+    assert _read_journal(ctx) == []
+
+    ctx.add_messages(_assistant_chunk("m2", "next"))
+
+    records = _read_journal(ctx)
+    assert len(records) == 1
+    assert records[0]["op"] == "put_message"
+    assert records[0]["message_id"] == "m1"
+    assert records[0]["message"]["content"] == "hello world"
+
+
+def test_user_boundary_does_not_duplicate_previous_message_journal(tmp_path):
+    ctx = _make_session(tmp_path)
+
+    ctx.add_messages(_assistant_chunk("m1", "hello"))
+    ctx.add_messages(
+        MessageChunk(
+            role=MessageRole.USER.value,
+            content="next request",
+            message_id="u1",
+        )
+    )
+
+    records = _read_journal(ctx)
+    assert [record["message_id"] for record in records] == ["m1", "u1"]
+
+
+def test_save_flushes_current_message_and_clears_journal_after_snapshot(tmp_path):
+    ctx = _make_session(tmp_path)
+
+    ctx.add_messages(_assistant_chunk("m1", "hello"))
+    ctx.add_messages(_assistant_chunk("m2", "next"))
+    assert _read_journal(ctx)
+
+    ctx.save()
+
+    assert _read_journal(ctx) == []
+    messages_path = os.path.join(ctx.session_workspace, "messages.json")
+    with open(messages_path, "r", encoding="utf-8") as f:
+        messages = json.load(f)
+    assert [message["message_id"] for message in messages] == ["m1", "m2"]
+    assert messages[-1]["content"] == "next"
+
+
+def test_duplicate_save_with_message_still_skips_when_journal_is_clean(tmp_path):
+    ctx = _make_session(tmp_path)
+    ctx.add_messages(_assistant_chunk("m1", "hello"))
+
+    ctx.save()
+    ctx.save()
+
+    session_end_events = [
+        event
+        for event in ctx.execution_timeline_events
+        if event.get("event_type") == "session_end"
+    ]
+    assert len(session_end_events) == 1
+    assert _read_journal(ctx) == []
+
+
+def test_concurrent_add_after_snapshot_replace_survives_journal_clear(
+    tmp_path, monkeypatch
+):
+    ctx = _make_session(tmp_path)
+    ctx.add_messages(_assistant_chunk("m1", "hello"))
+
+    original_replace = session_context_module.os.replace
+    started = threading.Event()
+    finished = threading.Event()
+    worker_errors = []
+
+    def add_message_after_replace():
+        try:
+            started.set()
+            ctx.add_messages(_assistant_chunk("m2", "after save", is_final=True))
+        except Exception as exc:
+            worker_errors.append(exc)
+        finally:
+            finished.set()
+
+    def replace_and_start_concurrent_add(src, dst):
+        original_replace(src, dst)
+        worker = threading.Thread(target=add_message_after_replace)
+        worker.start()
+        assert started.wait(timeout=2)
+        time.sleep(0.05)
+
+    monkeypatch.setattr(
+        session_context_module.os,
+        "replace",
+        replace_and_start_concurrent_add,
+    )
+
+    ctx.save()
+
+    assert finished.wait(timeout=2)
+    assert worker_errors == []
+    records = _read_journal(ctx)
+    assert [record["message_id"] for record in records] == ["m2"]
+    assert records[0]["message"]["content"] == "after save"
+
+
+def test_load_persisted_message_ledger_replays_journal_and_upserts(tmp_path):
+    ctx = _make_session(tmp_path)
+    snapshot_message = _assistant_chunk("m1", "old").to_dict()
+    messages_path = os.path.join(ctx.session_workspace, "messages.json")
+    with open(messages_path, "w", encoding="utf-8") as f:
+        json.dump([snapshot_message], f)
+
+    journal_path = _journal_path(ctx)
+    records = [
+        {
+            "schema_version": 1,
+            "op": "put_message",
+            "session_id": ctx.session_id,
+            "message_id": "m1",
+            "seq": 1,
+            "timestamp": 1.0,
+            "message": _assistant_chunk("m1", "new").to_dict(),
+        },
+        {
+            "schema_version": 1,
+            "op": "put_message",
+            "session_id": ctx.session_id,
+            "message_id": "m2",
+            "seq": 2,
+            "timestamp": 2.0,
+            "message": _assistant_chunk("m2", "second").to_dict(),
+        },
+    ]
+    with open(journal_path, "w", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    messages, max_seq, journal_records = SessionContext.load_persisted_message_ledger(
+        ctx.session_workspace,
+        session_id=ctx.session_id,
+    )
+
+    assert max_seq == 2
+    assert journal_records == 2
+    assert [message.message_id for message in messages] == ["m1", "m2"]
+    assert [message.content for message in messages] == ["new", "second"]
+
+
+def test_load_persisted_message_ledger_handles_journal_without_snapshot(tmp_path):
+    ctx = _make_session(tmp_path)
+    journal_path = _journal_path(ctx)
+    record = {
+        "schema_version": 1,
+        "op": "put_message",
+        "session_id": ctx.session_id,
+        "message_id": "m1",
+        "seq": 1,
+        "timestamp": 1.0,
+        "message": _assistant_chunk("m1", "journal only").to_dict(),
+    }
+    with open(journal_path, "w", encoding="utf-8") as f:
+        f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    messages, max_seq, journal_records = SessionContext.load_persisted_message_ledger(
+        ctx.session_workspace,
+        session_id=ctx.session_id,
+    )
+
+    assert max_seq == 1
+    assert journal_records == 1
+    assert [message.content for message in messages] == ["journal only"]
+
+
+def test_load_persisted_message_ledger_skips_bad_and_other_session_records(tmp_path):
+    ctx = _make_session(tmp_path)
+    journal_path = _journal_path(ctx)
+    valid_record = {
+        "schema_version": 1,
+        "op": "put_message",
+        "session_id": ctx.session_id,
+        "message_id": "m1",
+        "seq": 3,
+        "timestamp": 3.0,
+        "message": _assistant_chunk("m1", "valid").to_dict(),
+    }
+    other_session_record = {
+        "schema_version": 1,
+        "op": "put_message",
+        "session_id": "other",
+        "message_id": "m2",
+        "seq": 2,
+        "timestamp": 2.0,
+        "message": _assistant_chunk("m2", "other").to_dict(),
+    }
+    with open(journal_path, "w", encoding="utf-8") as f:
+        f.write("{bad json\n")
+        f.write(json.dumps(other_session_record, ensure_ascii=False) + "\n")
+        f.write(json.dumps(valid_record, ensure_ascii=False) + "\n")
+
+    messages, max_seq, journal_records = SessionContext.load_persisted_message_ledger(
+        ctx.session_workspace,
+        session_id=ctx.session_id,
+    )
+
+    assert max_seq == 3
+    assert journal_records == 1
+    assert [message.message_id for message in messages] == ["m1"]
+    assert messages[0].content == "valid"
+
+
+def test_save_failure_keeps_journal_for_later_replay(tmp_path, monkeypatch):
+    ctx = _make_session(tmp_path)
+    ctx.add_messages(_assistant_chunk("m1", "hello"))
+    ctx.flush_message_journal_current(reason="test")
+
+    def fail_replace(src, dst):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(session_context_module.os, "replace", fail_replace)
+
+    ctx.save()
+
+    records = _read_journal(ctx)
+    assert records
+    assert records[-1]["message_id"] == "m1"
+    tmp_path = os.path.join(ctx.session_workspace, "messages.json.tmp")
+    assert not os.path.exists(tmp_path)
+
+
+def test_save_without_session_workspace_does_not_crash(tmp_path):
+    ctx = SessionContext(
+        session_id="no_workspace",
+        user_id="u1",
+        agent_id="a1",
+        session_root_space=str(tmp_path),
+    )
+
+    ctx.save()
+
+    session_end_events = [
+        event
+        for event in ctx.execution_timeline_events
+        if event.get("event_type") == "session_end"
+    ]
+    assert len(session_end_events) == 1
+
+
+def test_session_runtime_get_messages_replays_journal(tmp_path):
+    ctx = _make_session(tmp_path)
+    ctx.add_messages(_assistant_chunk("m1", "hello"))
+    ctx.flush_message_journal_current(reason="test")
+
+    session = Session(session_id=ctx.session_id, enable_obs=False)
+    session.set_workspace(ctx.session_workspace)
+
+    messages = session.get_messages()
+
+    assert [message.message_id for message in messages] == ["m1"]
+    assert messages[0].content == "hello"


### PR DESCRIPTION
## Summary
- add messages.journal.jsonl as an incremental recovery ledger for merged messages
- replay journal records after messages.json in SessionContext and Session runtime loading
- atomically replace messages.json before clearing the journal, with low-frequency save/phase diagnostics

## Tests
- .venv/bin/pytest tests/sagents/context/test_message_journal.py -q
- .venv/bin/pytest tests/sagents/context tests/sagents/messages tests/sagents/flow -q
- .venv/bin/pytest tests/sagents -q
- .venv/bin/python -c 'import opentelemetry.trace; import pytest; raise SystemExit(pytest.main(["tests/common/services/test_chat_stream_token_persistence.py", "tests/common/services/test_chat_service_provider_override.py", "tests/app/desktop/core/test_chat_router.py", "-q"]))'
- git diff --check

## Notes
- Full tests were also run with known unrelated ignores; one codebase_tool timeout reproduced as an isolated transient and passed on single-test rerun.