### PR TITLE
Localize sagents return messages

### DIFF
--- a/common/services/chat_service.py
+++ b/common/services/chat_service.py
@@ -23,6 +23,7 @@ from sagents.utils.sandbox.policy import normalize_approval_mode
 from sagents.utils.user_input_optimizer import UserInputOptimizer
 
 from common.core import config
+from common.core.context import get_request_locale
 from common.core.exceptions import SageHTTPException
 from common.models.agent import AgentConfigDao
 from common.models.base import get_local_now
@@ -1176,6 +1177,12 @@ class SageStreamService:
                     mount_path=sandbox_agent_workspace,
                 )
             ]
+            if self.request.system_context is None:
+                self.request.system_context = {}
+            if not self.request.system_context.get("response_language"):
+                request_locale = get_request_locale()
+                if request_locale:
+                    self.request.system_context["response_language"] = request_locale
 
             run_kwargs: Dict[str, Any] = {
                 "session_id": session_id,

--- a/sagents/agent/agent_base.py
+++ b/sagents/agent/agent_base.py
@@ -409,7 +409,7 @@ class AgentBase(ABC):
             yield [
                 MessageChunk(
                     role=MessageRole.TOOL.value,
-                    content=f"压缩失败: {str(exc)}",
+                    content=f"Compression failed: {str(exc)}",
                     tool_call_id=tool_call_id,
                     type=MessageType.TOOL_CALL_RESULT.value,
                     metadata={
@@ -2581,7 +2581,7 @@ class AgentBase(ABC):
                     [
                         MessageChunk(
                             role=MessageRole.ASSISTANT.value,
-                            content="已经完成了满足用户的所有要求",
+                            content="All user requirements have been satisfied",
                             message_id=str(uuid.uuid4()),
                             message_type=MessageType.DO_SUBTASK_RESULT.value,
                         )

--- a/sagents/agent/common_agent.py
+++ b/sagents/agent/common_agent.py
@@ -246,7 +246,7 @@ class CommonAgent(AgentBase):
                 yield [
                     MessageChunk(
                         role=MessageRole.ASSISTANT.value,
-                        content="已经完成了满足用户的所有要求",
+                        content="All user requirements have been satisfied",
                         message_id=str(uuid.uuid4()),
                         message_type=MessageType.DO_SUBTASK_RESULT.value,
                     )

--- a/sagents/agent/fibre/backend_client.py
+++ b/sagents/agent/fibre/backend_client.py
@@ -562,7 +562,7 @@ class FibreBackendClient:
             async with aiohttp.ClientSession() as session:
                 async with session.post(
                     f"{self.base_url}/api/sessions/{session_id}/interrupt",
-                    json={"message": "用户请求中断"},
+                    json={"message": "User requested interruption"},
                     headers={"X-Sage-Internal-UserId": headers_user_id},
                     timeout=10,
                 ) as resp:

--- a/sagents/agent/simple_agent.py
+++ b/sagents/agent/simple_agent.py
@@ -931,7 +931,10 @@ class SimpleAgent(AgentBase):
                 yield [
                     MessageChunk(
                         role=MessageRole.ASSISTANT.value,
-                        content=f"Agent执行次数超过最大循环次数：{max_loop_count}, 任务暂停，是否需要继续执行？",
+                        content=(
+                            f"The agent exceeded the maximum loop count ({max_loop_count}). "
+                            "The task is paused. Do you want to continue?"
+                        ),
                         type=MessageType.ASSISTANT_TEXT.value,
                     )
                 ]

--- a/sagents/agent/task_completion_judge_agent.py
+++ b/sagents/agent/task_completion_judge_agent.py
@@ -112,7 +112,7 @@ class TaskCompletionJudgeAgent(AgentBase):
             yield [
                 MessageChunk(
                     role=MessageRole.ASSISTANT.value,
-                    content=f"任务完成判断失败: {str(e)}",
+                    content=f"Task completion judgment failed: {str(e)}",
                     message_id=str(uuid.uuid4()),
                     message_type=MessageType.OBSERVATION.value,
                 )

--- a/sagents/agent/task_decompose_agent.py
+++ b/sagents/agent/task_decompose_agent.py
@@ -209,7 +209,7 @@ class TaskDecomposeAgent(AgentBase):
                         yield [
                             MessageChunk(
                                 role=MessageRole.ASSISTANT.value,
-                                content=f"\n\n任务清单已生成：\n{chunk.content}",
+                                content=f"\n\nTask list generated:\n{chunk.content}",
                                 message_id=str(uuid.uuid4()),
                                 message_type=MessageType.TASK_DECOMPOSITION.value,
                             )

--- a/sagents/agent/workflow_select_agent.py
+++ b/sagents/agent/workflow_select_agent.py
@@ -133,7 +133,10 @@ class WorkflowSelectAgent(AgentBase):
             yield [
                 MessageChunk(
                     role=MessageRole.ASSISTANT.value,
-                    content=f"WorkflowSelector: 无法从LLM响应中提取JSON内容，原始响应: {all_content}",
+                    content=(
+                        "WorkflowSelector: failed to extract JSON content from the "
+                        f"LLM response. Raw response: {all_content}"
+                    ),
                     message_id=str(uuid.uuid4()),
                     message_type=MessageType.GUIDE.value,
                 )

--- a/sagents/context/messages/message.py
+++ b/sagents/context/messages/message.py
@@ -180,10 +180,10 @@ class MessageChunk:
 
         # 验证必需字段
         if role == MessageRole.TOOL.value and self.tool_call_id is None:
-            raise ValueError("tool角色的消息必须包含tool_call_id字段")
+            raise ValueError("Messages with role=tool must include tool_call_id")
 
         if self.content is None and self.tool_calls is None:
-            raise ValueError("消息必须包含content或tool_calls字段")
+            raise ValueError("Message must include content or tool_calls")
 
         if self.metadata is None:
             self.metadata = {}

--- a/sagents/context/session_context.py
+++ b/sagents/context/session_context.py
@@ -887,7 +887,7 @@ class SessionContext:
             str: 实际生效的 ``guidance_id``。
         """
         if not self._is_valid_user_injection_content(content):
-            raise ValueError("inject 内容不能为空")
+            raise ValueError("Injected content cannot be empty")
         gid = guidance_id or str(uuid.uuid4())
         for existing in self.pending_user_injections:
             md = existing.metadata or {}
@@ -1008,7 +1008,7 @@ class SessionContext:
         if not guidance_id:
             return False
         if not self._is_valid_user_injection_content(content):
-            raise ValueError("content 不能为空")
+            raise ValueError("content cannot be empty")
         for chunk in self.pending_user_injections:
             md = chunk.metadata or {}
             if md.get("guidance_id") == guidance_id:
@@ -1700,29 +1700,29 @@ class SessionContext:
 
     def set_status(self, status: SessionStatus, cascade: bool = True) -> None:
         raise RuntimeError(
-            f"SessionContext: set_status 已废弃，请通过 Session 操作，session_id={self.session_id}"
+            f"SessionContext: set_status is deprecated; use Session instead, session_id={self.session_id}"
         )
 
     def request_interrupt(
-        self, reason: str = "用户请求中断", cascade: bool = True
+        self, reason: str = "User requested interruption", cascade: bool = True
     ) -> None:
         raise RuntimeError(
-            f"SessionContext: request_interrupt 已废弃，请通过 Session 操作，session_id={self.session_id}"
+            f"SessionContext: request_interrupt is deprecated; use Session instead, session_id={self.session_id}"
         )
 
     def should_interrupt(self) -> bool:
         raise RuntimeError(
-            f"SessionContext: should_interrupt 已废弃，请通过 Session 操作，session_id={self.session_id}"
+            f"SessionContext: should_interrupt is deprecated; use Session instead, session_id={self.session_id}"
         )
 
     def add_child_session(self, child_session_id: str) -> None:
         raise RuntimeError(
-            f"SessionContext: add_child_session 已废弃，请通过 Session 操作，session_id={self.session_id}"
+            f"SessionContext: add_child_session is deprecated; use Session instead, session_id={self.session_id}"
         )
 
     def remove_child_session(self, child_session_id: str) -> None:
         raise RuntimeError(
-            f"SessionContext: remove_child_session 已废弃，请通过 Session 操作，session_id={self.session_id}"
+            f"SessionContext: remove_child_session is deprecated; use Session instead, session_id={self.session_id}"
         )
 
     def set_parent_session(self, parent_session_id: str) -> None:

--- a/sagents/context/user_memory/drivers/tool.py
+++ b/sagents/context/user_memory/drivers/tool.py
@@ -82,7 +82,7 @@ class ToolMemoryDriver(IMemoryDriver):
         session_id: Optional[str] = None,
     ) -> str:
         if not self._available:
-            return "记忆功能不可用"
+            return "Memory is unavailable"
 
         try:
             return await self.tool_manager.run_tool_async(  # pyright: ignore[reportOptionalMemberAccess]
@@ -96,13 +96,13 @@ class ToolMemoryDriver(IMemoryDriver):
             )
         except Exception as e:
             logger.error(f"记住记忆失败: {e}")
-            return f"记住记忆失败：{str(e)}"
+            return f"Failed to remember memory: {str(e)}"
 
     async def forget(
         self, user_id: str, memory_key: str, session_id: Optional[str] = None
     ) -> str:
         if not self._available:
-            return "记忆功能不可用"
+            return "Memory is unavailable"
 
         try:
             return await self.tool_manager.run_tool_async(  # pyright: ignore[reportOptionalMemberAccess]
@@ -113,7 +113,7 @@ class ToolMemoryDriver(IMemoryDriver):
             )
         except Exception as e:
             logger.error(f"忘记记忆失败: {e}")
-            return f"忘记记忆失败：{str(e)}"
+            return f"Failed to forget memory: {str(e)}"
 
     def _convert_memories_to_entries(
         self, memories_data: List[Dict]

--- a/sagents/context/user_memory/drivers/vector.py
+++ b/sagents/context/user_memory/drivers/vector.py
@@ -91,11 +91,11 @@ class VectorMemoryDriver(IMemoryDriver):
             # 这是一个简化示例，具体取决于 VectorStore 实现细节
             await self.vector_store.add_documents(self.collection_name, [document])
 
-            return f"已记住: {memory_key}"
+            return f"Remembered: {memory_key}"
 
         except Exception as e:
             logger.error(f"VectorMemoryDriver remember failed: {e}")
-            return f"记住记忆失败: {str(e)}"
+            return f"Failed to remember memory: {str(e)}"
 
     async def recall(
         self,
@@ -192,10 +192,10 @@ class VectorMemoryDriver(IMemoryDriver):
         try:
             doc_id = f"{user_id}_{memory_key}"
             await self.vector_store.delete_documents(self.collection_name, [doc_id])
-            return f"已忘记: {memory_key}"
+            return f"Forgotten: {memory_key}"
         except Exception as e:
             logger.error(f"VectorMemoryDriver forget failed: {e}")
-            return f"忘记记忆失败: {str(e)}"
+            return f"Failed to forget memory: {str(e)}"
 
     def _chunk_to_memory_entry(self, chunk: Chunk) -> Optional[MemoryEntry]:
         """将Chunk转换为MemoryEntry"""

--- a/sagents/context/user_memory/manager.py
+++ b/sagents/context/user_memory/manager.py
@@ -130,10 +130,10 @@ class UserMemoryManager:
             格式化的字符串，便于大模型理解和使用
         """
         if not memories:
-            return "没有找到相关记忆。"
+            return "No relevant memories found."
 
         formatted_lines = []
-        formatted_lines.append(f"找到 {len(memories)} 条相关记忆：")
+        formatted_lines.append(f"Found {len(memories)} relevant memories:")
         formatted_lines.append("")
 
         for i, memory in enumerate(memories, 1):
@@ -196,7 +196,7 @@ class UserMemoryManager:
 
         except Exception as e:
             logger.error(f"记住记忆失败: {e}")
-            return f"记住记忆失败：{str(e)}"
+            return f"Failed to remember memory: {str(e)}"
 
     async def recall(
         self,
@@ -222,7 +222,7 @@ class UserMemoryManager:
         """
         driver = self._get_active_driver()
         if not driver:
-            return "记忆功能已禁用：未配置记忆存储路径且无可用的MCP记忆服务"
+            return "Memory is disabled: no memory storage path or MCP memory service is available"
 
         try:
             # 通过驱动获取记忆对象列表
@@ -235,14 +235,14 @@ class UserMemoryManager:
             )
 
             if not memory_entries:
-                return f"未找到与 '{query}' 相关的记忆。"
+                return f"No memories found for '{query}'."
 
             # 格式化为大模型友好的字符串
             return self._format_memories_for_llm(memory_entries)
 
         except Exception as e:
             logger.error(f"回忆记忆失败: {e}")
-            return f"回忆记忆失败：{str(e)}"
+            return f"Failed to recall memory: {str(e)}"
 
     async def forget(
         self,
@@ -266,7 +266,7 @@ class UserMemoryManager:
         """
         driver = self._get_active_driver()
         if not driver:
-            return "记忆功能已禁用：未配置记忆存储路径且无可用的MCP记忆服务"
+            return "Memory is disabled: no memory storage path or MCP memory service is available"
 
         try:
             return await driver.forget(
@@ -278,7 +278,7 @@ class UserMemoryManager:
 
         except Exception as e:
             logger.error(f"忘记记忆失败: {e}")
-            return f"忘记记忆失败：{str(e)}"
+            return f"Failed to forget memory: {str(e)}"
 
     async def _fetch_single_memory_type(
         self,

--- a/sagents/context/workflows/workflow.py
+++ b/sagents/context/workflows/workflow.py
@@ -26,9 +26,9 @@ class WorkflowStep:
     def __post_init__(self):
         """初始化后的验证"""
         if not self.id:
-            raise ValueError("WorkflowStep: id不能为空")
+            raise ValueError("WorkflowStep: id is required")
         if not self.name:
-            raise ValueError("WorkflowStep: name不能为空")
+            raise ValueError("WorkflowStep: name is required")
 
     def to_dict(self) -> Dict[str, Any]:
         """转换为字典格式"""
@@ -47,7 +47,7 @@ class WorkflowStep:
     def from_dict(cls, data: Dict[str, Any]) -> "WorkflowStep":
         """从字典创建WorkflowStep实例"""
         if not isinstance(data, dict):
-            raise ValueError("WorkflowStep.from_dict: 输入数据必须是字典")
+            raise ValueError("WorkflowStep.from_dict: input data must be a dict")
 
         substeps = {}
         if "substeps" in data and data["substeps"]:
@@ -126,12 +126,12 @@ class Workflow:
     def __post_init__(self):
         """初始化后的验证"""
         if not self.name:
-            raise ValueError("Workflow: name不能为空")
+            raise ValueError("Workflow: name is required")
 
     def add_step(self, step: WorkflowStep) -> None:
         """添加步骤"""
         if not isinstance(step, WorkflowStep):
-            raise ValueError("Workflow.add_step: step必须是WorkflowStep实例")
+            raise ValueError("Workflow.add_step: step must be a WorkflowStep instance")
         self.steps[step.id] = step
         # logger.debug(f"Workflow '{self.name}': 添加步骤 '{step.id}', 步骤描述: {step.description}")
 
@@ -187,7 +187,7 @@ class Workflow:
     def from_dict(cls, data: Dict[str, Any]) -> "Workflow":
         """从字典创建Workflow实例"""
         if not isinstance(data, dict):
-            raise ValueError("Workflow.from_dict: 输入数据必须是字典")
+            raise ValueError("Workflow.from_dict: input data must be a dict")
 
         steps = {}
         if "steps" in data and data["steps"]:
@@ -219,7 +219,7 @@ class Workflow:
     ) -> "Workflow":
         """从旧格式（字符串列表）创建Workflow实例"""
         if not isinstance(steps, list):
-            raise ValueError("Workflow.from_legacy_format: steps必须是字符串列表")
+            raise ValueError("Workflow.from_legacy_format: steps must be a list of strings")
 
         workflow = cls(
             name=name, description=description, format_type=WorkflowFormat.LEGACY
@@ -260,7 +260,7 @@ class Workflow:
             return cls.from_dict(data)
         except json.JSONDecodeError as e:
             logger.error(f"Workflow.from_json: JSON解析错误: {str(e)}")
-            raise ValueError(f"无效的JSON格式: {str(e)}")
+            raise ValueError(f"Invalid JSON format: {str(e)}")
 
     def clone(self) -> "Workflow":
         """克隆工作流"""
@@ -278,28 +278,28 @@ class Workflow:
         errors = []
 
         if not self.name:
-            errors.append("工作流名称不能为空")
+            errors.append("Workflow name is required")
 
         if not self.steps:
-            errors.append("工作流必须包含至少一个步骤")
+            errors.append("Workflow must contain at least one step")
             return errors
 
         # 检查步骤ID重复
         step_ids = list(self.steps.keys())
         if len(step_ids) != len(set(step_ids)):
-            errors.append("存在重复的步骤ID")
+            errors.append("Duplicate step IDs exist")
 
         # 检查步骤order重复
         orders = [step.order for step in self.steps.values()]
         if len(orders) != len(set(orders)):
-            errors.append("存在重复的步骤顺序")
+            errors.append("Duplicate step order values exist")
 
         # 验证每个步骤
         for step_id, step in self.steps.items():
             if not step.id:
-                errors.append(f"步骤 '{step_id}' 的ID为空")
+                errors.append(f"Step '{step_id}' has an empty ID")
             if not step.name:
-                errors.append(f"步骤 '{step_id}' 的名称为空")
+                errors.append(f"Step '{step_id}' has an empty name")
 
         return errors
 

--- a/sagents/sagents.py
+++ b/sagents/sagents.py
@@ -260,11 +260,11 @@ class SAgent:
                 ...
         """
         if not model:
-            raise ValueError("run_stream 参数 model 不能为空")
+            raise ValueError("run_stream parameter model is required")
         if not isinstance(model_config, dict) or not model_config:
-            raise ValueError("run_stream 参数 model_config 必须是非空字典")
+            raise ValueError("run_stream parameter model_config must be a non-empty dict")
         if max_loop_count is None:
-            raise ValueError("run_stream 参数 max_loop_count 不能为空")
+            raise ValueError("run_stream parameter max_loop_count is required")
 
         # 确定沙箱类型（优先级：参数 > __init__ > 环境变量 > 默认）
         effective_sandbox_type = (
@@ -281,7 +281,9 @@ class SAgent:
         if effective_sandbox_type == "local":
             # local 模式必须有 sandbox_agent_workspace
             if not sandbox_agent_workspace:
-                raise ValueError("local 沙箱模式需要提供 sandbox_agent_workspace 参数")
+                raise ValueError(
+                    "local sandbox mode requires sandbox_agent_workspace"
+                )
 
         elif effective_sandbox_type == "remote":
             # remote 模式默认使用远程工作区根目录；sandbox_id 可选，不传时由 SessionContext 回退生成
@@ -661,7 +663,9 @@ class SAgent:
     def save_session(self, session_id: str) -> bool:
         return self.session_manager.save_session(session_id)
 
-    def interrupt_session(self, session_id: str, message: str = "用户请求中断") -> bool:
+    def interrupt_session(
+        self, session_id: str, message: str = "User requested interruption"
+    ) -> bool:
         return self.session_manager.interrupt_session(session_id, message=message)
 
     def get_tasks_status(self, session_id: str) -> Optional[Dict[str, Any]]:

--- a/sagents/session_runtime.py
+++ b/sagents/session_runtime.py
@@ -48,6 +48,7 @@ from sagents.flow.schema import AgentFlow
 from sagents.flow.executor import FlowExecutor
 from sagents.utils.sandbox.config import VolumeMount
 from sagents.utils.message_control_flags import extract_control_flags_from_messages
+from sagents.utils.i18n import normalize_language, t
 
 
 _session_id_var: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
@@ -448,7 +449,7 @@ class Session:
             return {"tasks": []}
 
     def request_interrupt(
-        self, message: str = "用户请求中断", cascade: bool = True
+        self, message: str = "User requested interruption", cascade: bool = True
     ) -> bool:
         if not self.session_context:
             return False
@@ -880,32 +881,60 @@ class Session:
         self, error: Exception
     ) -> AsyncGenerator[List[MessageChunk], None]:
         logger.error(f"SAgent: 处理工作流错误: {str(error)}\n{traceback.format_exc()}")
-        error_message = self._extract_friendly_error_message(error)
+        language = self._resolve_workflow_error_language()
+        error_message = self._extract_friendly_error_message(error, language=language)
         yield [
             MessageChunk(
                 role="assistant",
-                content=f"工作流执行失败: {error_message}",
+                content=t(
+                    "workflow.execution_failed",
+                    language=language,
+                    params={"message": error_message},
+                ),
                 type="final_answer",
             )
         ]
 
-    def _extract_friendly_error_message(self, error: Exception) -> str:
+    def _resolve_workflow_error_language(self) -> str:
+        session_context = self.session_context
+        if session_context:
+            get_language = getattr(session_context, "get_language", None)
+            if callable(get_language):
+                try:
+                    return normalize_language(str(get_language()))
+                except Exception as e:
+                    logger.debug(f"SAgent: 获取会话语言失败: {e}")
+
+            system_context = getattr(session_context, "system_context", None)
+            if isinstance(system_context, dict):
+                for key in ("response_language", "language", "locale"):
+                    value = system_context.get(key)
+                    if value:
+                        return normalize_language(str(value))
+
+        return normalize_language(None)
+
+    def _extract_friendly_error_message(
+        self, error: Exception, language: str | None = None
+    ) -> str:
         """从异常中提取友好的错误信息"""
         error_str = str(error)
 
         # 处理数据检查失败错误（内容审核）
         if "DataInspectionFailed" in error_str or "data_inspection_failed" in error_str:
             if "inappropriate content" in error_str or "inappropriate" in error_str:
-                return "输入内容可能包含不适当的内容，请修改后重试"
-            return "内容安全检查未通过，请修改输入后重试"
+                return t(
+                    "workflow.error.data_inspection_inappropriate", language=language
+                )
+            return t("workflow.error.data_inspection_failed", language=language)
 
         # 处理速率限制错误
         if "rate_limit" in error_str.lower() or "RateLimitError" in error_str:
-            return "请求过于频繁，请稍后再试"
+            return t("workflow.error.rate_limit", language=language)
 
         # 处理配额不足错误
         if "quota" in error_str.lower() or "insufficient_quota" in error_str.lower():
-            return "API 配额不足，请检查账户余额或配额设置"
+            return t("workflow.error.quota", language=language)
 
         # 处理认证错误
         if (
@@ -913,13 +942,13 @@ class Session:
             or "unauthorized" in error_str.lower()
             or "401" in error_str
         ):
-            return "API 认证失败，请检查 API Key 是否正确"
+            return t("workflow.error.authentication", language=language)
 
         # 处理模型不存在错误
         if "model" in error_str.lower() and (
             "not found" in error_str.lower() or "does not exist" in error_str.lower()
         ):
-            return "指定的模型不存在或不可用，请检查模型配置"
+            return t("workflow.error.model_not_found", language=language)
 
         # 处理上下文长度超限
         if (
@@ -927,7 +956,7 @@ class Session:
             or "token" in error_str.lower()
             and "exceed" in error_str.lower()
         ):
-            return "输入内容过长，请缩短后重试"
+            return t("workflow.error.context_length", language=language)
 
         # 处理连接错误
         if (
@@ -935,7 +964,7 @@ class Session:
             or "timeout" in error_str.lower()
             or "network" in error_str.lower()
         ):
-            return "网络连接失败，请检查网络设置或稍后重试"
+            return t("workflow.error.connection", language=language)
 
         # 处理服务不可用
         if (
@@ -943,7 +972,7 @@ class Session:
             or "503" in error_str
             or "502" in error_str
         ):
-            return "服务暂时不可用，请稍后再试"
+            return t("workflow.error.service_unavailable", language=language)
 
         # 默认返回原始错误信息（但截断过长的）
         if len(error_str) > 200:
@@ -960,7 +989,7 @@ class Session:
                 async for message_chunks in self.run_stream_with_flow(**kwargs):
                     yield message_chunks
             else:
-                raise ValueError("SAgent: run_stream_safe 必须提供 flow 参数")
+                raise ValueError("SAgent: run_stream_safe requires a flow parameter")
         except Exception as e:
             if self.observability_manager:
                 self.observability_manager.on_chain_error(
@@ -1083,15 +1112,15 @@ class Session:
         session_manager = get_global_session_manager()
         if not session_manager:
             raise RuntimeError(
-                f"SAgent: session_manager 未初始化，session_id={session_id}"
+                f"SAgent: session_manager is not initialized, session_id={session_id}"
             )
         session = session_manager.get_live_session(session_id)
         if session is None:
-            raise RuntimeError(f"SAgent: session 未绑定，session_id={session_id}")
+            raise RuntimeError(f"SAgent: session is not bound, session_id={session_id}")
         session_context = session.get_context()
         if session_context is None:
             raise RuntimeError(
-                f"SAgent: session_context 未绑定，session_id={session_id}"
+                f"SAgent: session_context is not bound, session_id={session_id}"
             )
 
         logger.info(f"SAgent: 使用 {agent.agent_description} 智能体，{phase_name}阶段")
@@ -1116,7 +1145,7 @@ class Session:
     ) -> List[MessageChunk]:
         for msg in input_messages:
             if not isinstance(msg, (dict, MessageChunk)):
-                raise ValueError("每个消息必须是字典或MessageChunk类型")
+                raise ValueError("Each message must be a dict or MessageChunk")
         return [
             MessageChunk.from_dict(msg) if isinstance(msg, dict) else msg
             for msg in input_messages
@@ -1419,7 +1448,9 @@ class SessionManager:
                 logger.warning(f"清理session {session_id} 日志资源时出错: {e}")
             session.close()
 
-    def interrupt_session(self, session_id: str, message: str = "用户请求中断") -> bool:
+    def interrupt_session(
+        self, session_id: str, message: str = "User requested interruption"
+    ) -> bool:
         """请求中断指定会话，并级联到已登记的子会话。"""
         session = self.get_live_session(session_id)
         if not session:

--- a/sagents/tool/impl/codebase_tool.py
+++ b/sagents/tool/impl/codebase_tool.py
@@ -472,17 +472,17 @@ class CodebaseTool:
         if not isinstance(pattern, str) or not pattern:
             return make_tool_error(
                 ToolErrorCode.INVALID_ARGUMENT,
-                "pattern 必须是非空字符串",
+                "pattern must be a non-empty string",
             )
         if output_mode not in {"content", "files_with_matches", "count"}:
             return make_tool_error(
                 ToolErrorCode.INVALID_ARGUMENT,
-                "output_mode 必须是 content/files_with_matches/count 之一",
+                "output_mode must be one of content/files_with_matches/count",
             )
         try:
             sandbox = self._get_sandbox(session_id)
         except Exception as exc:
-            return make_tool_error(ToolErrorCode.SANDBOX_ERROR, f"获取沙箱失败: {exc}")
+            return make_tool_error(ToolErrorCode.SANDBOX_ERROR, f"Failed to get sandbox: {exc}")
 
         try:
             if await self._has_command(sandbox, "rg"):
@@ -510,7 +510,7 @@ class CodebaseTool:
             )
         except Exception as exc:
             logger.error(f"CodebaseTool.grep: 运行失败: {exc}")
-            return make_tool_error(ToolErrorCode.INTERNAL_ERROR, f"grep 失败: {exc}")
+            return make_tool_error(ToolErrorCode.INTERNAL_ERROR, f"grep failed: {exc}")
 
     # ==================== glob ====================
 
@@ -640,12 +640,12 @@ class CodebaseTool:
         if not isinstance(pattern, str) or not pattern:
             return make_tool_error(
                 ToolErrorCode.INVALID_ARGUMENT,
-                "pattern 必须是非空字符串",
+                "pattern must be a non-empty string",
             )
         try:
             sandbox = self._get_sandbox(session_id)
         except Exception as exc:
-            return make_tool_error(ToolErrorCode.SANDBOX_ERROR, f"获取沙箱失败: {exc}")
+            return make_tool_error(ToolErrorCode.SANDBOX_ERROR, f"Failed to get sandbox: {exc}")
 
         root = path or sandbox.workspace_path
         try:
@@ -658,7 +658,7 @@ class CodebaseTool:
         except Exception as exc:
             logger.error(f"CodebaseTool.glob: walk 失败: {exc}")
             return make_tool_error(
-                ToolErrorCode.INTERNAL_ERROR, f"glob 遍历失败: {exc}"
+                ToolErrorCode.INTERNAL_ERROR, f"glob traversal failed: {exc}"
             )
 
         norm_pattern = self._to_pure_pattern(pattern)
@@ -737,7 +737,7 @@ class CodebaseTool:
         try:
             sandbox = self._get_sandbox(session_id)
         except Exception as exc:
-            return make_tool_error(ToolErrorCode.SANDBOX_ERROR, f"获取沙箱失败: {exc}")
+            return make_tool_error(ToolErrorCode.SANDBOX_ERROR, f"Failed to get sandbox: {exc}")
 
         root = path or sandbox.workspace_path
         try:
@@ -749,7 +749,7 @@ class CodebaseTool:
             )
         except Exception as exc:
             logger.error(f"CodebaseTool.list_dir: get_file_tree 失败: {exc}")
-            return make_tool_error(ToolErrorCode.INTERNAL_ERROR, f"列目录失败: {exc}")
+            return make_tool_error(ToolErrorCode.INTERNAL_ERROR, f"Failed to list directory: {exc}")
 
         return {
             "success": True,

--- a/sagents/tool/impl/compress_history_tool.py
+++ b/sagents/tool/impl/compress_history_tool.py
@@ -58,7 +58,7 @@ class CompressHistoryTool:
         session = get_live_session(session_id, log_prefix="CompressHistoryTool")
 
         if not session or not session.session_context:
-            raise CompressHistoryError(f"无效的 session_id={session_id}")
+            raise CompressHistoryError(f"Invalid session_id={session_id}")
 
         return session.session_context
 
@@ -99,13 +99,13 @@ class CompressHistoryTool:
         session = get_live_session(session_id, log_prefix="CompressHistoryTool")
 
         if not session:
-            raise CompressHistoryError(f"无法获取会话: {session_id}")
+            raise CompressHistoryError(f"Failed to get session: {session_id}")
 
         model = session.model
         model_config = session.model_config.copy()
 
         if not model:
-            raise CompressHistoryError("会话模型未初始化")
+            raise CompressHistoryError("Session model is not initialized")
 
         # 移除非标准参数和与显式参数冲突的参数
         model_config.pop("max_model_len", None)
@@ -203,7 +203,7 @@ class CompressHistoryTool:
 
         except Exception as e:
             logger.error(f"调用 LLM 压缩失败: {e}")
-            raise CompressHistoryError(f"LLM 压缩失败: {e}")
+            raise CompressHistoryError(f"LLM compression failed: {e}")
 
     @staticmethod
     def _bounded_list(
@@ -451,7 +451,7 @@ class CompressHistoryTool:
 
             if not to_compress:
                 content_payload = {
-                    "summary": "没有消息需要压缩",
+                    "summary": "No messages need compression",
                     "decisions": [],
                     "open_tasks": [],
                     "files_touched": [],
@@ -558,7 +558,7 @@ class CompressHistoryTool:
 
         except CompressHistoryError as e:
             logger.error(f"压缩历史消息失败: {e}")
-            return {"status": "error", "message": f"❌ 压缩失败: {str(e)}"}
+            return {"status": "error", "message": f"Compression failed: {str(e)}"}
         except Exception as e:
             logger.error(f"压缩历史消息时发生未知错误: {e}")
             import traceback
@@ -566,7 +566,7 @@ class CompressHistoryTool:
             logger.error(traceback.format_exc())
             return {
                 "status": "error",
-                "message": f"压缩失败: {str(e)}",
+                "message": f"Compression failed: {str(e)}",
                 "data": {
                     "compressed": False,
                     "summary": "",

--- a/sagents/tool/impl/execute_command_tool.py
+++ b/sagents/tool/impl/execute_command_tool.py
@@ -1024,7 +1024,7 @@ class ExecuteCommandTool:
             logger.error(f"ExecuteCommandTool: 启动后台命令失败: {exc}")
             return make_tool_error(
                 ToolErrorCode.SANDBOX_ERROR,
-                f"启动命令失败: {exc}",
+                f"Failed to start command: {exc}",
                 command=command,
             )
 

--- a/sagents/tool/impl/file_system_tool.py
+++ b/sagents/tool/impl/file_system_tool.py
@@ -37,13 +37,13 @@ class FileSystemTool:
         if normalized_start > normalized_end:
             return make_tool_error(
                 ToolErrorCode.INVALID_ARGUMENT,
-                "开始行号不能大于结束行号",
+                "start_line cannot be greater than end_line",
             )
 
         if total_lines == 0:
             return make_tool_error(
                 ToolErrorCode.PRECONDITION_FAILED,
-                "文件为空，无法执行按行替换",
+                "The file is empty, so line-based replacement cannot be applied",
             )
 
         normalized_end_exclusive = normalized_end + 1
@@ -393,21 +393,21 @@ class FileSystemTool:
             logger.error(f"FileSystemTool: 读取文件失败 {file_path}: {e}")
             return make_tool_error(
                 ToolErrorCode.NOT_FOUND,
-                f"读取文件失败: {str(e)}",
+                f"Failed to read file: {str(e)}",
                 file_path=file_path,
             )
         except PermissionError as e:
             logger.error(f"FileSystemTool: 读取文件失败 {file_path}: {e}")
             return make_tool_error(
                 ToolErrorCode.PERMISSION_DENIED,
-                f"读取文件失败: {str(e)}",
+                f"Failed to read file: {str(e)}",
                 file_path=file_path,
             )
         except Exception as e:
             logger.error(f"FileSystemTool: 读取文件失败 {file_path}: {e}")
             return make_tool_error(
                 ToolErrorCode.SANDBOX_ERROR,
-                f"读取文件失败: {str(e)}",
+                f"Failed to read file: {str(e)}",
                 file_path=file_path,
             )
 
@@ -522,9 +522,9 @@ class FileSystemTool:
             result: Dict[str, Any] = {
                 "status": "success",
                 "success": True,
-                "message": "文件写入成功"
+                "message": "File written successfully"
                 if validation.get("status") in {"passed", "skipped"}
-                else "文件写入成功，但校验发现问题",
+                else "File written successfully, but validation found issues",
                 "file_path": file_path,
                 "content_length": len(content),
                 "mode": mode,
@@ -538,14 +538,14 @@ class FileSystemTool:
             logger.error(f"FileSystemTool: 写入文件失败 {file_path}: {e}")
             return make_tool_error(
                 ToolErrorCode.PERMISSION_DENIED,
-                f"写入文件失败: {str(e)}",
+                f"Failed to write file: {str(e)}",
                 file_path=file_path,
             )
         except Exception as e:
             logger.error(f"FileSystemTool: 写入文件失败 {file_path}: {e}")
             return make_tool_error(
                 ToolErrorCode.SANDBOX_ERROR,
-                f"写入文件失败: {str(e)}",
+                f"Failed to write file: {str(e)}",
                 file_path=file_path,
             )
 
@@ -686,7 +686,7 @@ class FileSystemTool:
                 if mode_result["status"] == "error":
                     return make_tool_error(
                         mode_result.get("error_code", ToolErrorCode.INVALID_ARGUMENT),
-                        f"第 {index + 1} 个操作失败: {mode_result['message']}",
+                        f"Operation {index + 1} failed: {mode_result['message']}",
                         file_path=file_path,
                         failed_operation_index=index,
                     )
@@ -717,7 +717,7 @@ class FileSystemTool:
                 if step_result["status"] == "error":
                     return make_tool_error(
                         step_result.get("error_code", ToolErrorCode.INVALID_ARGUMENT),
-                        f"第 {index + 1} 个操作失败: {step_result['message']}",
+                        f"Operation {index + 1} failed: {step_result['message']}",
                         file_path=file_path,
                         failed_operation_index=index,
                     )
@@ -733,8 +733,10 @@ class FileSystemTool:
                     return make_tool_error(
                         ToolErrorCode.NO_MATCH,
                         (
-                            f"第 {index + 1} 个操作未替换任何行（start_line={requested_start}, end_line={requested_end}）。"
-                            "当前工具使用 0-based 且 start_line/end_line 都是包含边界；请检查行号是否有效。"
+                            f"Operation {index + 1} did not replace any lines "
+                            f"(start_line={requested_start}, end_line={requested_end}). "
+                            "This tool uses 0-based inclusive start_line/end_line values; "
+                            "check whether the line numbers are valid."
                         ),
                         file_path=file_path,
                         failed_operation_index=index,
@@ -769,7 +771,7 @@ class FileSystemTool:
                             extras[key] = step_result[key]
                     return make_tool_error(
                         step_result.get("error_code", ToolErrorCode.INVALID_ARGUMENT),
-                        f"第 {index + 1} 个操作失败: {step_result['message']}",
+                        f"Operation {index + 1} failed: {step_result['message']}",
                         hint=step_result.get("hint"),
                         **extras,
                     )
@@ -788,7 +790,7 @@ class FileSystemTool:
             if total_replacements == 0 and not line_range_ops:
                 return make_tool_error(
                     ToolErrorCode.NO_MATCH,
-                    "未找到匹配项，未进行任何替换",
+                    "No matches were found, so no replacements were made",
                     file_path=file_path,
                     replacements=0,
                 )
@@ -798,9 +800,9 @@ class FileSystemTool:
                 return {
                     "status": "success",
                     "message": (
-                        "已执行按行替换，但目标区间与替换内容一致，文件无变化"
+                        "Line-based replacement ran, but the target range already matched the replacement; the file was unchanged"
                         if validation.get("status") in {"passed", "skipped"}
-                        else "已执行按行替换，但目标区间与替换内容一致，文件无变化；校验发现问题"
+                        else "Line-based replacement ran, but the target range already matched the replacement; the file was unchanged and validation found issues"
                     ),
                     "replacements": 0,
                     "operations_applied": len(operation_summaries),
@@ -824,9 +826,9 @@ class FileSystemTool:
                 "status": "success",
                 "success": True,
                 "message": (
-                    f"成功执行 {len(operation_summaries)} 个更新操作，共替换 {total_replacements} 处内容"
+                    f"Successfully applied {len(operation_summaries)} update operations and made {total_replacements} replacements"
                     if validation.get("status") in {"passed", "skipped"}
-                    else f"成功执行 {len(operation_summaries)} 个更新操作，共替换 {total_replacements} 处内容；校验发现问题"
+                    else f"Successfully applied {len(operation_summaries)} update operations and made {total_replacements} replacements; validation found issues"
                 ),
                 "replacements": total_replacements,
                 "operations_applied": len(operation_summaries),
@@ -861,20 +863,20 @@ class FileSystemTool:
             logger.error(f"FileSystemTool: 文件更新失败 {file_path}: {e}")
             return make_tool_error(
                 ToolErrorCode.NOT_FOUND,
-                f"文件更新失败: {str(e)}",
+                f"Failed to update file: {str(e)}",
                 file_path=file_path,
             )
         except PermissionError as e:
             logger.error(f"FileSystemTool: 文件更新失败 {file_path}: {e}")
             return make_tool_error(
                 ToolErrorCode.PERMISSION_DENIED,
-                f"文件更新失败: {str(e)}",
+                f"Failed to update file: {str(e)}",
                 file_path=file_path,
             )
         except Exception as e:
             logger.error(f"FileSystemTool: 文件更新失败 {file_path}: {e}")
             return make_tool_error(
                 ToolErrorCode.SANDBOX_ERROR,
-                f"文件更新失败: {str(e)}",
+                f"Failed to update file: {str(e)}",
                 file_path=file_path,
             )

--- a/sagents/tool/impl/image_understanding_tool.py
+++ b/sagents/tool/impl/image_understanding_tool.py
@@ -78,7 +78,7 @@ class ImageUnderstandingTool:
             # 检查文件是否存在
             exists = await sandbox.file_exists(image_path)
             if not exists:
-                raise ImageUnderstandingError(f"图片文件不存在: {image_path}")
+                raise ImageUnderstandingError(f"Image file does not exist: {image_path}")
 
             # 使用 base64 命令读取图片
             # macOS 的 base64 语法不同，需要使用 -i 指定输入文件
@@ -102,12 +102,12 @@ class ImageUnderstandingTool:
             if not result.success:
                 out_len = len(result.stdout) if result.stdout else 0
                 raise ImageUnderstandingError(
-                    f"读取图片命令失败: return_code={result.return_code}, stderr={result.stderr}, stdout_bytes={out_len}"
+                    f"Image read command failed: return_code={result.return_code}, stderr={result.stderr}, stdout_bytes={out_len}"
                 )
 
             if not result.stdout or not result.stdout.strip():
                 raise ImageUnderstandingError(
-                    f"读取图片命令返回空数据: return_code={result.return_code}, stderr={result.stderr}"
+                    f"Image read command returned empty data: return_code={result.return_code}, stderr={result.stderr}"
                 )
 
             return result.stdout.strip()
@@ -118,7 +118,7 @@ class ImageUnderstandingTool:
             import traceback
 
             logger.error(f"从沙箱读取图片失败: {e}\n{traceback.format_exc()}")
-            raise ImageUnderstandingError(f"从沙箱读取图片失败: {e}")
+            raise ImageUnderstandingError(f"Failed to read image from sandbox: {e}")
 
     def _resize_image_if_needed(
         self, image_data: bytes, max_resolution: int = 1536
@@ -177,7 +177,9 @@ class ImageUnderstandingTool:
                 img = Image.open(io.BytesIO(body))
                 img.load()
             except Exception as e:
-                raise ImageUnderstandingError(f"下载内容不是有效图片: {e}") from e
+                raise ImageUnderstandingError(
+                    f"Downloaded content is not a valid image: {e}"
+                ) from e
             try:
                 compressed = self._resize_image_if_needed(body, max_resolution)
                 b64 = base64.b64encode(compressed).decode("utf-8")
@@ -260,16 +262,16 @@ class ImageUnderstandingTool:
                 response.raise_for_status()
         except httpx.HTTPStatusError as e:
             raise ImageUnderstandingError(
-                f"无法下载图片: HTTP {e.response.status_code}"
+                f"Failed to download image: HTTP {e.response.status_code}"
             ) from e
         except httpx.RequestError as e:
-            raise ImageUnderstandingError(f"无法下载图片: {e}") from e
+            raise ImageUnderstandingError(f"Failed to download image: {e}") from e
 
         body = response.content
         if len(body) > max_bytes:
-            raise ImageUnderstandingError("图片过大（超过 20MB）")
+            raise ImageUnderstandingError("Image is too large (over 20MB)")
         if not body:
-            raise ImageUnderstandingError("下载的图片为空")
+            raise ImageUnderstandingError("Downloaded image is empty")
 
         mime_hint = self._mime_from_url_or_headers(
             response.headers.get("content-type"), image_url
@@ -299,21 +301,21 @@ class ImageUnderstandingTool:
         # 获取当前 session_id
         current_session_id = session_id or get_current_session_id()
         if not current_session_id:
-            raise ImageUnderstandingError("无法获取当前会话 ID")
+            raise ImageUnderstandingError("Failed to get current session ID")
 
         # 获取 session manager 和 session
         session_manager = get_global_session_manager()
         session = session_manager.get(current_session_id)
 
         if not session:
-            raise ImageUnderstandingError(f"无法获取会话: {current_session_id}")
+            raise ImageUnderstandingError(f"Failed to get session: {current_session_id}")
 
         # 获取 session 的 model 和 model_config
         model = session.model
         model_config = session.model_config.copy()
 
         if not model:
-            raise ImageUnderstandingError("会话模型未初始化")
+            raise ImageUnderstandingError("Session model is not initialized")
 
         # 移除非标准参数
         model_config.pop("max_model_len", None)
@@ -350,7 +352,7 @@ class ImageUnderstandingTool:
                     "bad request",
                 ]
             ):
-                raise ImageUnderstandingError("当前模型不支持图片理解")
+                raise ImageUnderstandingError("The current model does not support image understanding")
             else:
                 raise e
 
@@ -463,7 +465,7 @@ class ImageUnderstandingTool:
 
                 return {
                     "status": "success",
-                    "message": "图片分析完成",
+                    "message": "Image analysis completed",
                     "data": {
                         "description": analysis_result,
                         "image_path": image_path,
@@ -474,9 +476,9 @@ class ImageUnderstandingTool:
             except ImageUnderstandingError:
                 return {
                     "status": "error",
-                    "message": "当前模型不支持图片理解，请使用多模态模型（如 GPT-4V、Claude 3、Qwen-VL 等）",
+                    "message": "The current model does not support image understanding. Use a multimodal model.",
                 }
 
         except Exception as e:
             logger.error(f"图片理解失败: {e}")
-            return {"status": "error", "message": f"图片理解失败: {str(e)}"}
+            return {"status": "error", "message": f"Image understanding failed: {str(e)}"}

--- a/sagents/tool/impl/lint_tool.py
+++ b/sagents/tool/impl/lint_tool.py
@@ -291,7 +291,7 @@ class LintTool:
         except Exception as exc:
             return make_tool_error(
                 ToolErrorCode.SANDBOX_ERROR,
-                f"获取沙箱失败: {exc}",
+                f"Failed to get sandbox: {exc}",
             )
         try:
             return await self._collect_for_paths(sandbox, paths, max_diagnostics)
@@ -299,5 +299,5 @@ class LintTool:
             logger.error(f"LintTool: 运行失败: {exc}")
             return make_tool_error(
                 ToolErrorCode.INTERNAL_ERROR,
-                f"运行 lint 失败: {exc}",
+                f"Failed to run lint: {exc}",
             )

--- a/sagents/tool/impl/questionnaire_tool.py
+++ b/sagents/tool/impl/questionnaire_tool.py
@@ -210,7 +210,7 @@ class QuestionnaireTool:
                 {
                     "success": True,
                     "status": "timeout",
-                    "message": "用户未在指定时间内提交，使用默认值",
+                    "message": "The user did not submit in time. Default values were used",
                     "answers": default_answers,
                     "questionnaire_kind": questionnaire_kind,
                 },
@@ -222,11 +222,11 @@ class QuestionnaireTool:
             f"QuestionnaireTool: 成功获取问卷答案. questionnaire_id={questionnaire_id}, is_auto_submit={result.get('is_auto_submit', False)}"
         )
         return json.dumps(
-            {
-                "success": True,
-                "status": "submitted",
-                "message": "用户已提交答案",
-                "answers": result.get("answers", {}),
+                {
+                    "success": True,
+                    "status": "submitted",
+                    "message": "The user submitted answers",
+                    "answers": result.get("answers", {}),
                 "questionnaire_id": result.get("questionnaire_id", questionnaire_id),
                 "submitted_at": result.get("submitted_at"),
                 "is_auto_submit": result.get("is_auto_submit", False),
@@ -239,31 +239,33 @@ class QuestionnaireTool:
     def _validate_questions(self, questions: List[Dict[str, Any]]):
         """验证问题格式"""
         if not questions:
-            raise ValueError("问题列表不能为空")
+            raise ValueError("Question list cannot be empty")
 
         for idx, q in enumerate(questions):
             if "id" not in q:
-                raise ValueError(f"第 {idx + 1} 个问题缺少 id 字段")
+                raise ValueError(f"Question {idx + 1} is missing the id field")
             if "type" not in q:
-                raise ValueError(f"第 {idx + 1} 个问题缺少 type 字段")
+                raise ValueError(f"Question {idx + 1} is missing the type field")
             if "title" not in q:
-                raise ValueError(f"第 {idx + 1} 个问题缺少 title 字段")
+                raise ValueError(f"Question {idx + 1} is missing the title field")
 
             qtype = q["type"]
             if qtype not in ["single_choice", "multiple_choice", "text"]:
-                raise ValueError(f"第 {idx + 1} 个问题类型无效: {qtype}")
+                raise ValueError(f"Question {idx + 1} has an invalid type: {qtype}")
 
             if qtype in ["single_choice", "multiple_choice"]:
                 if "options" not in q or not q["options"]:
-                    raise ValueError(f"第 {idx + 1} 个选择题缺少 options 字段")
+                    raise ValueError(
+                        f"Choice question {idx + 1} is missing the options field"
+                    )
                 for opt_idx, opt in enumerate(q["options"]):
                     if "label" not in opt:
                         raise ValueError(
-                            f"第 {idx + 1} 个问题第 {opt_idx + 1} 个选项缺少 label 字段"
+                            f"Question {idx + 1} option {opt_idx + 1} is missing the label field"
                         )
                     if "value" not in opt:
                         raise ValueError(
-                            f"第 {idx + 1} 个问题第 {opt_idx + 1} 个选项缺少 value 字段"
+                            f"Question {idx + 1} option {opt_idx + 1} is missing the value field"
                         )
 
     def _get_default_answers(self, questions: List[Dict[str, Any]]) -> Dict[str, Any]:

--- a/sagents/tool/impl/todo_tool.py
+++ b/sagents/tool/impl/todo_tool.py
@@ -497,7 +497,10 @@ class ToDoTool:
                         await self._sync_to_system_context([], session_id)
                         # 返回完整的任务列表（虽然文件已删除）
                         result = {
-                            "summary": f"所有任务已完成！任务清单已清理。\n新增: {added_count}, 更新: {updated_count}",
+                            "summary": (
+                                "All tasks are complete. The task list was cleared.\n"
+                                f"Added: {added_count}, Updated: {updated_count}"
+                            ),
                             "tasks": task_list,
                         }
                         return json.dumps(result, ensure_ascii=False, indent=2)
@@ -519,7 +522,11 @@ class ToDoTool:
 
             # 构建 JSON 返回结果（task_list 已在上面的代码中构建）
             result = {
-                "summary": f"成功更新任务清单。新增: {added_count}, 更新: {updated_count}。当前未完成任务数: {len(pending_tasks)}",
+                "summary": (
+                    "Task list updated successfully. "
+                    f"Added: {added_count}, Updated: {updated_count}. "
+                    f"Current pending task count: {len(pending_tasks)}"
+                ),
                 "tasks": task_list,
             }
             return json.dumps(result, ensure_ascii=False, indent=2)
@@ -528,7 +535,8 @@ class ToDoTool:
                 f"ToDoTool: Failed to save tasks to {file_path}", session_id=session_id
             )
             return json.dumps(
-                {"summary": "保存任务清单失败。", "tasks": []}, ensure_ascii=False
+                {"summary": "Failed to save the task list.", "tasks": []},
+                ensure_ascii=False,
             )
 
     async def clean_old_tasks(
@@ -631,15 +639,15 @@ class ToDoTool:
         ]
 
         if not unfinished:
-            return "当前没有未完成的任务。"
+            return "There are no unfinished tasks."
 
-        result = "当前未完成任务清单:\n"
+        result = "Current unfinished task list:\n"
         for t in unfinished:
             status = self._normalize_status(t.get("status"))
-            tag = "[进行中]" if status == "in_progress" else "[待办]"
+            tag = "[in progress]" if status == "in_progress" else "[todo]"
             result += f"- {tag} {t.get('content')} (ID: {t.get('id')})"
             if t.get("conclusion"):
-                result += f" [结论: {t.get('conclusion')}]"
+                result += f" [conclusion: {t.get('conclusion')}]"
             result += "\n"
 
         return result

--- a/sagents/tool/impl/web_fetcher_tool.py
+++ b/sagents/tool/impl/web_fetcher_tool.py
@@ -225,15 +225,16 @@ class WebFetcherTool:
 
         if success_count == len(urls):
             status = "success"
-            message = f"成功处理所有 {len(urls)} 个URL"
+            message = f"Successfully processed all {len(urls)} URLs"
         elif success_count > 0:
             status = "partial"
             message = (
-                f"成功处理 {success_count}/{len(urls)} 个URL，{error_count} 个失败"
+                f"Successfully processed {success_count}/{len(urls)} URLs; "
+                f"{error_count} failed"
             )
         else:
             status = "error"
-            message = f"所有 {len(urls)} 个URL处理失败"
+            message = f"Failed to process all {len(urls)} URLs"
 
         return {
             "status": status,
@@ -355,7 +356,7 @@ class WebFetcherTool:
                     "url": url,
                     "status": "success",
                     "type": "file",
-                    "content": f"文件已下载到: {save_path}",
+                    "content": f"File downloaded to: {save_path}",
                     "metadata": {
                         "filename": filename,
                         "save_path": save_path,
@@ -378,7 +379,7 @@ class WebFetcherTool:
         return {
             "url": url,
             "status": "error",
-            "error": f"下载失败，重试{retries + 1}次后仍失败: {last_error}",
+            "error": f"Download failed after {retries + 1} attempts: {last_error}",
             "content": None,
             "metadata": None,
         }
@@ -470,7 +471,7 @@ class WebFetcherTool:
                 if len(full_content) > max_return_length:
                     return_content = (
                         full_content[:max_return_length]
-                        + f"\n\n[内容已截断，完整内容已保存到文件: {save_path}]"
+                        + f"\n\n[Content truncated. Full content saved to: {save_path}]"
                     )
                 else:
                     return_content = full_content
@@ -511,7 +512,7 @@ class WebFetcherTool:
         return {
             "url": url,
             "status": "error",
-            "error": f"重试{retries + 1}次后仍失败: {last_error}",
+            "error": f"Failed after {retries + 1} attempts: {last_error}",
             "content": None,
             "metadata": None,
         }
@@ -540,7 +541,8 @@ class WebFetcherTool:
                 # 截断内容
                 if len(content) > max_length:
                     content = (
-                        content[:max_length] + "\n\n[内容已截断，超过最大长度限制]"
+                        content[:max_length]
+                        + "\n\n[Content truncated because it exceeds the maximum length]"
                     )
 
                 return {
@@ -575,7 +577,7 @@ class WebFetcherTool:
         return {
             "url": url,
             "status": "error",
-            "error": f"重试{retries + 1}次后仍失败: {last_error}",
+            "error": f"Failed after {retries + 1} attempts: {last_error}",
             "content": None,
             "metadata": None,
         }
@@ -749,8 +751,9 @@ class WebFetcherTool:
                 return None
 
         content = (
-            "# 小红书分享帖未返回正文\n\n"
-            "当前抓取到的是小红书的空状态、错误页或登录/安全验证页，页面 HTML 中没有可用的帖子正文和图片列表。"
+            "# Xiaohongshu share post did not return body content\n\n"
+            "The fetched page is an empty state, error page, login page, or security verification page. "
+            "The HTML does not contain usable post text or image lists."
         )
         return content, "xiaohongshu_unavailable", []
 

--- a/sagents/tool/tool_manager.py
+++ b/sagents/tool/tool_manager.py
@@ -131,7 +131,10 @@ def _truncate_result(result: str, max_tokens: int = MAX_TOOL_RESULT_TOKENS) -> s
     truncated = result[:max_chars]
 
     # 添加截断提示
-    truncation_notice = f"\n\n[结果已截断] 原始结果约 {estimated_tokens} tokens，超过最大限制 {max_tokens} tokens，仅显示前 {max_tokens} tokens。"
+    truncation_notice = (
+        f"\n\n[Result truncated] Original result is about {estimated_tokens} tokens, "
+        f"which exceeds the {max_tokens} token limit. Showing the first {max_tokens} tokens only."
+    )
 
     return truncated + truncation_notice
 
@@ -1436,7 +1439,7 @@ class ToolManager:
                     final_result = json.dumps(
                         {
                             "success": False,
-                            "error": f"缺少必填参数: {', '.join(missing_params)}",
+                            "error": f"Missing required parameters: {', '.join(missing_params)}",
                             "required_params": required_params,
                             "provided_params": list(kwargs.keys()),
                         },

--- a/sagents/tool/tool_proxy.py
+++ b/sagents/tool/tool_proxy.py
@@ -81,7 +81,7 @@ class ToolProxy:
             return
 
         if tool_name not in self._available_tools:
-            raise ValueError(f"工具 '{tool_name}' 不在可用工具列表中")
+            raise ValueError(f"Tool '{tool_name}' is not in the available tool list")
 
     def allow_tools(self, tool_names: List[str]) -> None:
         """
@@ -390,7 +390,8 @@ class ToolProxyFactory:
         """
         if tool_set_name not in self.PREDEFINED_TOOL_SETS:
             raise ValueError(
-                f"工具集 '{tool_set_name}' 不存在。可用工具集: {list(self.PREDEFINED_TOOL_SETS.keys())}"
+                f"Tool set '{tool_set_name}' does not exist. "
+                f"Available tool sets: {list(self.PREDEFINED_TOOL_SETS.keys())}"
             )
 
         tools = self.PREDEFINED_TOOL_SETS[tool_set_name]

--- a/sagents/utils/agent_abilities.py
+++ b/sagents/utils/agent_abilities.py
@@ -69,8 +69,8 @@ def _format_name_list(
 ) -> str:
     names = [str(v) for v in (values or []) if str(v).strip()]
     if not names:
-        return f"{label}：无"
-    display = "、".join(names[:max_count])
+        return f"{label}: none"
+    display = ", ".join(names[:max_count])
     if len(names) > max_count:
         display += " 等"
     return f"{label}：{display}"
@@ -135,7 +135,7 @@ async def generate_agent_abilities_from_config(
     """
 
     if not client:
-        raise AgentAbilitiesGenerationError("模型客户端未配置")
+        raise AgentAbilitiesGenerationError("Model client is not configured")
 
     agent_name = agent_config.get("name") or agent_config.get("id") or "Sage 助手"
     agent_description = (
@@ -233,14 +233,14 @@ async def generate_agent_abilities_from_config(
         )
     except Exception as e:  # pragma: no cover - 具体异常类型由底层 SDK 决定
         logger.error(f"生成 Agent 能力列表时调用模型失败: {e}")
-        raise AgentAbilitiesGenerationError("调用模型失败，请稍后重试") from e
+        raise AgentAbilitiesGenerationError("Model call failed. Try again later") from e
 
     # 解析模型返回的 JSON
     try:
         choice = response.choices[0].message
     except Exception as e:  # pragma: no cover
         logger.error(f"解析模型返回结果失败: {e}")
-        raise AgentAbilitiesGenerationError("模型返回结果格式不正确") from e
+        raise AgentAbilitiesGenerationError("Model response format is invalid") from e
 
     data_obj: Any
     parsed = getattr(choice, "parsed", None)
@@ -265,14 +265,20 @@ async def generate_agent_abilities_from_config(
                     e, content_text[:500]
                 )
             )
-            raise AgentAbilitiesGenerationError("解析模型返回的能力列表失败") from e
+            raise AgentAbilitiesGenerationError(
+                "Failed to parse the generated ability list"
+            ) from e
 
     if not isinstance(data_obj, dict) or "items" not in data_obj:
-        raise AgentAbilitiesGenerationError("能力列表结果缺少 items 字段")
+        raise AgentAbilitiesGenerationError(
+            "Ability list result is missing the items field"
+        )
 
     items_raw = data_obj.get("items") or []
     if not isinstance(items_raw, list):
-        raise AgentAbilitiesGenerationError("能力列表 items 字段格式不正确")
+        raise AgentAbilitiesGenerationError(
+            "Ability list items field has an invalid format"
+        )
 
     results: List[Dict[str, str]] = []
     seen_ids: set[str] = set()
@@ -314,7 +320,7 @@ async def generate_agent_abilities_from_config(
             break
 
     if not results:
-        raise AgentAbilitiesGenerationError("未生成任何有效的能力项")
+        raise AgentAbilitiesGenerationError("No valid ability items were generated")
 
     if len(results) < AGENT_ABILITIES_TARGET_COUNT:
         logger.warning(

--- a/sagents/utils/auto_gen_agent.py
+++ b/sagents/utils/auto_gen_agent.py
@@ -56,7 +56,7 @@ class AutoGenAgentFunc:
             logger.info(f"使用模型: {model}")
 
             if not llm_client:
-                raise ValueError("需要提供大模型客户端")
+                raise ValueError("A model client is required")
 
             # 获取所有可用工具信息
             available_tools = self._get_tools_info(tool_manager)
@@ -67,7 +67,7 @@ class AutoGenAgentFunc:
                 agent_description, available_tools, llm_client, model, language=language
             )
             if not basic_config:
-                raise Exception("生成基础配置失败")
+                raise Exception("Failed to generate basic configuration")
 
             # 根据tool_manager类型决定是否需要选择工具
             if isinstance(tool_manager, ToolProxy):
@@ -80,14 +80,14 @@ class AutoGenAgentFunc:
                     basic_config, available_tools, llm_client, model, language=language
                 )
                 if selected_tools is None:
-                    raise Exception("选择工具失败")
+                    raise Exception("Failed to select tools")
 
             # 生成工作流程
             workflows = await self._generate_workflows(
                 basic_config, selected_tools, llm_client, model, language=language
             )
             if workflows is None:
-                raise Exception("生成工作流程失败")
+                raise Exception("Failed to generate workflows")
 
             # 组装完整配置
             config = self._assemble_config(
@@ -187,7 +187,7 @@ class AutoGenAgentFunc:
                 required_fields = ["name", "description", "systemPrefix"]
                 for field in required_fields:
                     if field not in config:
-                        raise ValueError(f"缺少必需字段: {field}")
+                        raise ValueError(f"Missing required field: {field}")
 
                 logger.info(f"生成基础配置成功: {config['name']}")
                 return config
@@ -258,7 +258,7 @@ class AutoGenAgentFunc:
 
                 selected_tools = json.loads(json_str)
                 if not isinstance(selected_tools, list):
-                    raise ValueError("响应不是数组格式")
+                    raise ValueError("Response is not an array")
 
                 # 验证工具名称是否存在
                 available_tool_names = [tool["name"] for tool in available_tools]
@@ -331,7 +331,7 @@ class AutoGenAgentFunc:
 
                 workflows = json.loads(json_str)
                 if not isinstance(workflows, dict):
-                    raise ValueError("响应不是字典格式")
+                    raise ValueError("Response is not a dict")
 
                 logger.info(f"生成了 {len(workflows)} 个工作流程")
                 return workflows

--- a/sagents/utils/file_content_validator.py
+++ b/sagents/utils/file_content_validator.py
@@ -45,7 +45,7 @@ class FileContentValidator:
                 "status": "skipped",
                 "validator": None,
                 "file_extension": extension,
-                "message": "该文件后缀未启用内容校验",
+                "message": "Content validation is not enabled for this file extension",
                 "warnings": [],
                 "errors": [],
             }
@@ -68,7 +68,7 @@ class FileContentValidator:
             "status": "skipped",
             "validator": validator,
             "file_extension": extension,
-            "message": "未找到匹配的校验器",
+            "message": "No matching validator was found",
             "warnings": [],
             "errors": [],
         }
@@ -136,7 +136,7 @@ class FileContentValidator:
                 "status": "skipped",
                 "validator": "yaml",
                 "file_extension": extension,
-                "message": "PyYAML 未安装，已跳过 YAML 校验",
+                "message": "PyYAML is not installed; YAML validation was skipped",
                 "warnings": [],
                 "errors": [],
             }
@@ -144,19 +144,19 @@ class FileContentValidator:
             yaml.safe_load(content)
             return FileContentValidator._success(extension, "yaml")
         except yaml.YAMLError as exc:  # type: ignore[attr-defined]
-            message = f"YAML 语法错误: {exc}"
+            message = f"YAML syntax error: {exc}"
             mark = getattr(exc, "problem_mark", None)
             if mark is not None:
                 line = getattr(mark, "line", None)
                 column = getattr(mark, "column", None)
                 if line is not None and column is not None:
                     message = (
-                        f"YAML 语法错误: {exc} (line {line + 1}, column {column + 1})"
+                        f"YAML syntax error: {exc} (line {line + 1}, column {column + 1})"
                     )
             return FileContentValidator._error(extension, "yaml", message)
         except Exception as exc:
             return FileContentValidator._error(
-                extension, "yaml", f"YAML 校验失败: {exc}"
+                extension, "yaml", f"YAML validation failed: {exc}"
             )
 
     @staticmethod
@@ -167,11 +167,11 @@ class FileContentValidator:
         except SyntaxError as exc:
             line = exc.lineno or 0
             column = exc.offset or 0
-            message = f"Python 语法错误: {exc.msg} (line {line}, column {column})"
+            message = f"Python syntax error: {exc.msg} (line {line}, column {column})"
             return FileContentValidator._error(extension, "python", message)
         except Exception as exc:
             return FileContentValidator._error(
-                extension, "python", f"Python 校验失败: {exc}"
+                extension, "python", f"Python validation failed: {exc}"
             )
 
     @staticmethod
@@ -184,7 +184,7 @@ class FileContentValidator:
                 "status": "skipped",
                 "validator": "toml",
                 "file_extension": extension,
-                "message": "tomllib 不可用，已跳过 TOML 校验",
+                "message": "tomllib is unavailable; TOML validation was skipped",
                 "warnings": [],
                 "errors": [],
             }
@@ -192,15 +192,15 @@ class FileContentValidator:
             tomllib.loads(content)
             return FileContentValidator._success(extension, "toml")
         except tomllib.TOMLDecodeError as exc:  # type: ignore[attr-defined]
-            message = f"TOML 语法错误: {exc}"
+            message = f"TOML syntax error: {exc}"
             line = getattr(exc, "lineno", None)
             column = getattr(exc, "colno", None)
             if line is not None and column is not None:
-                message = f"TOML 语法错误: {exc} (line {line}, column {column})"
+                message = f"TOML syntax error: {exc} (line {line}, column {column})"
             return FileContentValidator._error(extension, "toml", message)
         except Exception as exc:
             return FileContentValidator._error(
-                extension, "toml", f"TOML 校验失败: {exc}"
+                extension, "toml", f"TOML validation failed: {exc}"
             )
 
     @staticmethod
@@ -214,7 +214,7 @@ class FileContentValidator:
                 "status": "skipped",
                 "validator": "javascript",
                 "file_extension": extension,
-                "message": "未找到 node，已跳过 JavaScript 语法校验",
+                "message": "node was not found; JavaScript syntax validation was skipped",
                 "warnings": [],
                 "errors": [],
             }
@@ -236,11 +236,11 @@ class FileContentValidator:
                 return FileContentValidator._success(extension, "javascript")
 
             stderr = (proc.stderr or proc.stdout or "").strip()
-            message = f"JavaScript 语法错误: {stderr or 'node --check failed'}"
+            message = f"JavaScript syntax error: {stderr or 'node --check failed'}"
             return FileContentValidator._error(extension, "javascript", message)
         except Exception as exc:
             return FileContentValidator._error(
-                extension, "javascript", f"JavaScript 校验失败: {exc}"
+                extension, "javascript", f"JavaScript validation failed: {exc}"
             )
         finally:
             try:

--- a/sagents/utils/file_parser/file_parser.py
+++ b/sagents/utils/file_parser/file_parser.py
@@ -118,7 +118,7 @@ class FileValidator:
                 # URL验证逻辑
                 parsed = urllib.parse.urlparse(file_path_or_url)
                 if not parsed.netloc:
-                    return {"valid": False, "error": "无效的URL格式"}
+                    return {"valid": False, "error": "Invalid URL format"}
 
                 # 从URL获取文件扩展名
                 path = parsed.path.lower()
@@ -137,10 +137,10 @@ class FileValidator:
                         if file_extension not in FileValidator.SUPPORTED_FORMATS:
                             return {
                                 "valid": False,
-                                "error": f"不支持的文件格式: {file_extension}",
+                                "error": f"Unsupported file format: {file_extension}",
                             }
                     else:
-                        return {"valid": False, "error": "无法从URL确定文件类型"}
+                        return {"valid": False, "error": "Cannot determine file type from URL"}
 
                 return {
                     "valid": True,
@@ -155,12 +155,12 @@ class FileValidator:
 
                 # 检查文件是否存在
                 if not file_path.exists():
-                    return {"valid": False, "error": f"文件不存在: {file_path_or_url}"}
+                    return {"valid": False, "error": f"File does not exist: {file_path_or_url}"}
 
                 if not file_path.is_file():
                     return {
                         "valid": False,
-                        "error": f"路径不是文件: {file_path_or_url}",
+                        "error": f"Path is not a file: {file_path_or_url}",
                     }
 
                 # 获取文件扩展名
@@ -168,7 +168,7 @@ class FileValidator:
                 if file_extension not in FileValidator.SUPPORTED_FORMATS:
                     return {
                         "valid": False,
-                        "error": f"不支持的文件格式: {file_extension}",
+                        "error": f"Unsupported file format: {file_extension}",
                     }
 
                 # 检查文件大小
@@ -177,7 +177,7 @@ class FileValidator:
                 if file_size_mb > max_size:
                     return {
                         "valid": False,
-                        "error": f"文件过大: {file_size_mb:.1f}MB，最大允许: {max_size}MB",
+                        "error": f"File is too large: {file_size_mb:.1f}MB, maximum allowed: {max_size}MB",
                     }
 
                 return {
@@ -190,7 +190,7 @@ class FileValidator:
                 }
 
         except Exception as e:
-            return {"valid": False, "error": f"文件验证失败: {str(e)}"}
+            return {"valid": False, "error": f"File validation failed: {str(e)}"}
 
 
 class FileHandler:
@@ -244,7 +244,7 @@ class FileHandler:
                 return file_path_or_url
 
         except Exception as e:
-            raise Exception(f"文件处理失败: {str(e)}")
+            raise Exception(f"File processing failed: {str(e)}")
 
 
 class TextProcessor:
@@ -613,7 +613,9 @@ class FileParser:
                 except Exception as e:
                     print(f"Pandoc解析失败: {e}")
                     traceback.print_exc()
-                    raise FileParserError(f"不支持的文件格式或解析失败: {str(e)}")
+                    raise FileParserError(
+                        f"Unsupported file format or parsing failed: {str(e)}"
+                    )
             else:
                 # 使用智能选择的解析器
                 try:
@@ -650,7 +652,9 @@ class FileParser:
                             )
                         except Exception as pypandoc_error:
                             raise FileParserError(
-                                f"所有解析器都失败了。解析器错误: {parse_result.error}, pypandoc错误: {str(pypandoc_error)}"
+                                "All parsers failed. "
+                                f"Parser error: {parse_result.error}, "
+                                f"pypandoc error: {str(pypandoc_error)}"
                             )
 
                     extracted_text = parse_result.text

--- a/sagents/utils/file_parser/parsers/docx_parser.py
+++ b/sagents/utils/file_parser/parsers/docx_parser.py
@@ -34,7 +34,7 @@ class DOCXParser(BaseFileParser):
             )
 
         if not skip_validation and not self.can_parse(file_path):
-            return self.create_error_result(f"不支持的文件类型: {file_path}", file_path)
+            return self.create_error_result(f"Unsupported file type: {file_path}", file_path)
 
         try:
             doc = Document(file_path)

--- a/sagents/utils/file_parser/parsers/eml_parser.py
+++ b/sagents/utils/file_parser/parsers/eml_parser.py
@@ -78,7 +78,7 @@ class EMLParser(BaseFileParser):
             )
 
         if not skip_validation and not self.can_parse(file_path):
-            return self.create_error_result(f"不支持的文件类型: {file_path}", file_path)
+            return self.create_error_result(f"Unsupported file type: {file_path}", file_path)
 
         try:
             # 使用参考实现的文件读取逻辑
@@ -1107,7 +1107,7 @@ class EMLParser(BaseFileParser):
             else:
                 # 非文本文件，返回基本信息
                 return {
-                    "content": f"[无法解析的{content_type}文件: {filename}]",
+                    "content": f"[Unable to parse {content_type} file: {filename}]",
                     "content_type_parsed": "unsupported",
                     "original_filename": filename,
                     "content_type": content_type,

--- a/sagents/utils/file_parser/parsers/excel_parser.py
+++ b/sagents/utils/file_parser/parsers/excel_parser.py
@@ -43,7 +43,7 @@ class ExcelParser(BaseFileParser):
             )
 
         if not skip_validation and not self.can_parse(file_path):
-            return self.create_error_result(f"不支持的文件类型: {file_path}", file_path)
+            return self.create_error_result(f"Unsupported file type: {file_path}", file_path)
 
         temp_xlsx_path = None
 
@@ -244,7 +244,7 @@ class ExcelParser(BaseFileParser):
                 ["libreoffice", "--version"], check=True, capture_output=True
             )
         except (FileNotFoundError, subprocess.CalledProcessError):
-            raise Exception("LibreOffice未安装或不在PATH中，无法转换XLS文件")
+            raise Exception("LibreOffice is not installed or not in PATH; cannot convert XLS files")
 
         logger.info(
             f"尝试使用LibreOffice将XLS转换为XLSX: {file_path} -> {xlsx_output_path}"
@@ -264,10 +264,10 @@ class ExcelParser(BaseFileParser):
 
         if result.returncode != 0:
             logger.error(f"LibreOffice转换错误: {result.stderr}")
-            raise Exception(f"LibreOffice转换失败: {result.stderr}")
+            raise Exception(f"LibreOffice conversion failed: {result.stderr}")
 
         if not os.path.exists(xlsx_output_path):
-            raise Exception(f"转换后的文件未找到: {xlsx_output_path}")
+            raise Exception(f"Converted file was not found: {xlsx_output_path}")
 
         return xlsx_output_path
 

--- a/sagents/utils/file_parser/parsers/html_parser.py
+++ b/sagents/utils/file_parser/parsers/html_parser.py
@@ -34,7 +34,7 @@ class HTMLParser(BaseFileParser):
             )
 
         if not skip_validation and not self.can_parse(file_path):
-            return self.create_error_result(f"不支持的文件类型: {file_path}", file_path)
+            return self.create_error_result(f"Unsupported file type: {file_path}", file_path)
 
         try:
             # 读取HTML文件

--- a/sagents/utils/file_parser/parsers/pdf_parser.py
+++ b/sagents/utils/file_parser/parsers/pdf_parser.py
@@ -33,7 +33,7 @@ class PDFParser(BaseFileParser):
             )
 
         if not skip_validation and not self.can_parse(file_path):
-            return self.create_error_result(f"不支持的文件类型: {file_path}", file_path)
+            return self.create_error_result(f"Unsupported file type: {file_path}", file_path)
 
         try:
             text_parts = []

--- a/sagents/utils/file_parser/parsers/pptx_parser.py
+++ b/sagents/utils/file_parser/parsers/pptx_parser.py
@@ -38,7 +38,7 @@ class PPTXParser(BaseFileParser):
             )
 
         if not skip_validation and not self.can_parse(file_path):
-            return self.create_error_result(f"不支持的文件类型: {file_path}", file_path)
+            return self.create_error_result(f"Unsupported file type: {file_path}", file_path)
 
         temp_pptx_path = None
 
@@ -52,7 +52,7 @@ class PPTXParser(BaseFileParser):
                     temp_pptx_path = self._convert_ppt_to_pptx(file_path)
                     target_path = temp_pptx_path
                 except Exception as e:
-                    return self.create_error_result(f"PPT转换失败: {str(e)}", file_path)
+                    return self.create_error_result(f"PPT conversion failed: {str(e)}", file_path)
             else:
                 target_path = file_path
 
@@ -141,7 +141,7 @@ class PPTXParser(BaseFileParser):
                 ["libreoffice", "--version"], check=True, capture_output=True
             )
         except (FileNotFoundError, subprocess.CalledProcessError):
-            raise Exception("LibreOffice未安装或不在PATH中，无法转换PPT文件")
+            raise Exception("LibreOffice is not installed or not in PATH; cannot convert PPT files")
 
         logger.info(
             f"尝试使用LibreOffice将PPT转换为PPTX: {file_path} -> {pptx_output_path}"
@@ -161,12 +161,12 @@ class PPTXParser(BaseFileParser):
 
         if result.returncode != 0:
             logger.error(f"LibreOffice转换错误: {result.stderr}")
-            raise Exception(f"LibreOffice转换失败: {result.stderr}")
+            raise Exception(f"LibreOffice conversion failed: {result.stderr}")
 
         if not os.path.exists(pptx_output_path):
             # 有时候输出文件名可能不同，尝试根据文件名猜测
             # 这里简单处理，假设如果上面的check通过，文件应该存在
-            raise Exception(f"转换后的文件未找到: {pptx_output_path}")
+            raise Exception(f"Converted file was not found: {pptx_output_path}")
 
         return pptx_output_path
 

--- a/sagents/utils/file_parser/parsers/text_parser.py
+++ b/sagents/utils/file_parser/parsers/text_parser.py
@@ -83,7 +83,7 @@ class TextParser(BaseFileParser):
             )
 
         if not skip_validation and not self.can_parse(file_path):
-            return self.create_error_result(f"不支持的文件类型: {file_path}", file_path)
+            return self.create_error_result(f"Unsupported file type: {file_path}", file_path)
 
         return self._do_parse(file_path)
 

--- a/sagents/utils/file_system_utils.py
+++ b/sagents/utils/file_system_utils.py
@@ -46,31 +46,31 @@ class SecurityValidator:
     def validate_path(file_path: str, allow_dangerous: bool = False) -> Dict[str, Any]:
         try:
             if ".." in file_path:
-                return {"valid": False, "error": "路径包含危险的遍历字符"}
+                return {"valid": False, "error": "Path contains dangerous traversal characters"}
 
             path = Path(file_path).resolve()
 
             if not path.is_absolute():
-                return {"valid": False, "error": "必须提供绝对路径"}
+                return {"valid": False, "error": "An absolute path is required"}
 
             path_str = str(path)
             for protected in SecurityValidator.PROTECTED_PATHS:
                 if path_str.startswith(protected):
                     return {
                         "valid": False,
-                        "error": f"禁止访问系统保护目录: {protected}",
+                        "error": f"Access to protected system directory is forbidden: {protected}",
                     }
 
             if (
                 not allow_dangerous
                 and path.suffix.lower() in SecurityValidator.DANGEROUS_EXTENSIONS
             ):
-                return {"valid": False, "error": f"危险的文件类型: {path.suffix}"}
+                return {"valid": False, "error": f"Dangerous file type: {path.suffix}"}
 
             return {"valid": True, "resolved_path": str(path)}
 
         except Exception as e:
-            return {"valid": False, "error": f"路径验证失败: {str(e)}"}
+            return {"valid": False, "error": f"Path validation failed: {str(e)}"}
 
 
 class FileMetadata:
@@ -161,18 +161,18 @@ async def file_read_core(
 
         file_info = await asyncio.to_thread(FileMetadata.get_file_info, file_path)
         if not file_info["exists"]:
-            return {"status": "error", "message": "文件不存在"}
+            return {"status": "error", "message": "File does not exist"}
 
         if not file_info["is_file"]:
-            return {"status": "error", "message": "指定路径不是文件"}
+            return {"status": "error", "message": "The specified path is not a file"}
 
         if not file_info["permissions"]["readable"]:
-            return {"status": "error", "message": "文件无读取权限"}
+            return {"status": "error", "message": "File is not readable"}
 
         if file_info["size_mb"] > max_size_mb:
             return {
                 "status": "error",
-                "message": f"文件过大: {file_info['size_mb']:.2f}MB > {max_size_mb}MB",
+                "message": f"File is too large: {file_info['size_mb']:.2f}MB > {max_size_mb}MB",
             }
 
         if encoding == "auto":
@@ -200,7 +200,7 @@ async def file_read_core(
 
         return {
             "status": "success",
-            "message": f"成功读取文件 (行 {start_line}-{end_line})",
+            "message": f"File read successfully (lines {start_line}-{end_line})",
             "content": content,
             "file_info": {
                 "path": file_path,
@@ -217,8 +217,8 @@ async def file_read_core(
     except UnicodeDecodeError as e:
         return {
             "status": "error",
-            "message": f"文件编码错误: {str(e)}，请尝试指定正确的编码",
+            "message": f"File encoding error: {str(e)}. Try specifying the correct encoding",
         }
     except Exception as e:
         logger.error(f"💥 读取文件异常 [{operation_id}] - 错误: {str(e)}")
-        return {"status": "error", "message": f"读取文件失败: {str(e)}"}
+        return {"status": "error", "message": f"Failed to read file: {str(e)}"}

--- a/sagents/utils/i18n.py
+++ b/sagents/utils/i18n.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+DEFAULT_LANGUAGE = "zh"
+
+MESSAGES: dict[str, dict[str, str]] = {
+    "zh": {
+        "workflow.execution_failed": "工作流执行失败: {message}",
+        "workflow.error.data_inspection_inappropriate": "输入内容可能包含不适当的内容，请修改后重试",
+        "workflow.error.data_inspection_failed": "内容安全检查未通过，请修改输入后重试",
+        "workflow.error.rate_limit": "请求过于频繁，请稍后再试",
+        "workflow.error.quota": "API 配额不足，请检查账户余额或配额设置",
+        "workflow.error.authentication": "API 认证失败，请检查 API Key 是否正确",
+        "workflow.error.model_not_found": "指定的模型不存在或不可用，请检查模型配置",
+        "workflow.error.context_length": "输入内容过长，请缩短后重试",
+        "workflow.error.connection": "网络连接失败，请检查网络设置或稍后重试",
+        "workflow.error.service_unavailable": "服务暂时不可用，请稍后再试",
+    },
+    "en": {
+        "workflow.execution_failed": "Workflow execution failed: {message}",
+        "workflow.error.data_inspection_inappropriate": (
+            "The input may contain inappropriate content. Edit it and try again"
+        ),
+        "workflow.error.data_inspection_failed": (
+            "Content safety check failed. Edit the input and try again"
+        ),
+        "workflow.error.rate_limit": "Too many requests. Try again later",
+        "workflow.error.quota": (
+            "API quota is insufficient. Check the account balance or quota settings"
+        ),
+        "workflow.error.authentication": (
+            "API authentication failed. Check whether the API key is correct"
+        ),
+        "workflow.error.model_not_found": (
+            "The selected model does not exist or is unavailable. "
+            "Check the model configuration"
+        ),
+        "workflow.error.context_length": "The input is too long. Shorten it and try again",
+        "workflow.error.connection": (
+            "Network connection failed. Check the network settings or try again later"
+        ),
+        "workflow.error.service_unavailable": (
+            "The service is temporarily unavailable. Try again later"
+        ),
+    },
+    "pt": {
+        "workflow.execution_failed": "Falha ao executar o fluxo de trabalho: {message}",
+        "workflow.error.data_inspection_inappropriate": (
+            "A entrada pode conter conteudo inadequado. Edite e tente novamente"
+        ),
+        "workflow.error.data_inspection_failed": (
+            "A verificacao de seguranca do conteudo falhou. "
+            "Edite a entrada e tente novamente"
+        ),
+        "workflow.error.rate_limit": "Muitas solicitacoes. Tente novamente mais tarde",
+        "workflow.error.quota": (
+            "A cota da API e insuficiente. "
+            "Verifique o saldo da conta ou as configuracoes de cota"
+        ),
+        "workflow.error.authentication": (
+            "A autenticacao da API falhou. Verifique se a chave de API esta correta"
+        ),
+        "workflow.error.model_not_found": (
+            "O modelo selecionado nao existe ou esta indisponivel. "
+            "Verifique a configuracao do modelo"
+        ),
+        "workflow.error.context_length": "A entrada e longa demais. Reduza o texto e tente novamente",
+        "workflow.error.connection": (
+            "Falha na conexao de rede. "
+            "Verifique as configuracoes de rede ou tente novamente mais tarde"
+        ),
+        "workflow.error.service_unavailable": (
+            "O servico esta temporariamente indisponivel. Tente novamente mais tarde"
+        ),
+    },
+}
+
+
+def normalize_language(language: str | None) -> str:
+    value = str(language or "").strip().replace("_", "-").lower()
+    if not value:
+        return DEFAULT_LANGUAGE
+    if "zh" in value or "中文" in value:
+        return "zh"
+    if "pt" in value or "portugu" in value:
+        return "pt"
+    if "en" in value or "english" in value:
+        return "en"
+    return DEFAULT_LANGUAGE
+
+
+def t(
+    key: str,
+    language: str | None = None,
+    params: Mapping[str, Any] | None = None,
+    default: str | None = None,
+) -> str:
+    resolved_language = normalize_language(language)
+    template = MESSAGES.get(resolved_language, {}).get(key)
+    if template is None:
+        template = MESSAGES[DEFAULT_LANGUAGE].get(key)
+    if template is None:
+        return default if default is not None else key
+    if params:
+        return template.format(**params)
+    return template

--- a/sagents/utils/prompt_manager.py
+++ b/sagents/utils/prompt_manager.py
@@ -342,7 +342,7 @@ class PromptManager:
             if default is not None:
                 return default
             raise ValueError(
-                "无法自动获取调用者类名，请使用get_agent_prompt方法并手动指定agent参数"
+                "Could not infer the caller class name. Use get_agent_prompt and pass agent explicitly"
             )
 
         return self.get_prompt(key, default=default, agent=agent, language=language)

--- a/sagents/utils/sandbox/_bg_runner.py
+++ b/sagents/utils/sandbox/_bg_runner.py
@@ -75,7 +75,7 @@ class HostBackgroundRunner:
                 log_fh.close()
             except Exception:
                 pass
-            raise FileNotFoundError(f"workdir 不存在: {cwd}")
+            raise FileNotFoundError(f"workdir does not exist: {cwd}")
 
         try:
             if _IS_WINDOWS:

--- a/sagents/utils/sandbox/interface.py
+++ b/sagents/utils/sandbox/interface.py
@@ -179,7 +179,9 @@ class ISandboxHandle(ABC):
 
     async def kill_background(self, task_id: str, force: bool = False) -> bool:
         """终止后台任务；force=True 表示直接 SIGKILL/TerminateProcess。"""
-        raise NotImplementedError(f"{self.__class__.__name__} 不支持 kill_background")
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support kill_background"
+        )
 
     async def cleanup_background(self, task_id: str) -> None:
         """从注册表中移除任务（关闭日志句柄等）；默认 no-op。"""

--- a/sagents/utils/sandbox/providers/local/filesystem.py
+++ b/sagents/utils/sandbox/providers/local/filesystem.py
@@ -20,7 +20,7 @@ class SandboxFileSystem:
             volume_mounts: 卷挂载配置列表，第一个作为主映射
         """
         if not volume_mounts:
-            raise ValueError("volume_mounts 不能为空")
+            raise ValueError("volume_mounts cannot be empty")
 
         self._volume_mounts = volume_mounts
 

--- a/sagents/utils/sandbox/providers/local/isolation/subprocess.py
+++ b/sagents/utils/sandbox/providers/local/isolation/subprocess.py
@@ -221,7 +221,10 @@ def main():
                 )
                 result = {
                     "success": True,
-                    "output": f"[后台任务已启动]\\n命令: {cmd}\\n进程ID: {proc.pid}\\n日志文件: {log_file}",
+                    "output": (
+                        "[Background task started]"
+                        f"\\nCommand: {cmd}\\nProcess ID: {proc.pid}\\nLog file: {log_file}"
+                    ),
                     "process_id": f"bg_{proc.pid}",
                     "is_background": True,
                     "log_file": log_file,

--- a/sagents/utils/sandbox/providers/local/local.py
+++ b/sagents/utils/sandbox/providers/local/local.py
@@ -302,7 +302,7 @@ class LocalSandboxProvider(ISandboxHandle):
     async def _ensure_venv(self):
         """确保 venv 存在"""
         if not self._venv_dir:
-            raise RuntimeError("venv 目录未初始化")
+            raise RuntimeError("venv directory is not initialized")
         if os.path.exists(self._venv_dir):
             return
 
@@ -318,7 +318,7 @@ class LocalSandboxProvider(ISandboxHandle):
             # 获取正确的 Python 解释器路径（处理 PyInstaller 打包环境）
             system_python = get_system_python_path()
             if not system_python:
-                raise RuntimeError("无法找到系统 Python 解释器")
+                raise RuntimeError("System Python interpreter was not found")
 
             # 使用 subprocess 调用 python -m venv 创建虚拟环境
             logger.info(
@@ -331,7 +331,9 @@ class LocalSandboxProvider(ISandboxHandle):
                 text=True,
             )
             if result.returncode != 0:
-                raise RuntimeError(f"创建虚拟环境失败: {result.stderr}")
+                raise RuntimeError(
+                    f"Failed to create virtual environment: {result.stderr}"
+                )
 
             # 确保 venv 中同时存在 python 和 python3 命令
             self._ensure_python3_link()

--- a/sagents/utils/sandbox/providers/local/sandbox.py
+++ b/sagents/utils/sandbox/providers/local/sandbox.py
@@ -327,7 +327,7 @@ class Sandbox:
 
         # 如果没有 tool_func，返回错误
         if tool_func is None:
-            raise SandboxError("未提供 tool_func")
+            raise SandboxError("tool_func was not provided")
 
         # 检查是否是 bound method
         if hasattr(tool_func, "__self__"):

--- a/sagents/utils/sandbox/providers/local/venv.py
+++ b/sagents/utils/sandbox/providers/local/venv.py
@@ -34,7 +34,7 @@ class VenvManager:
             system_python = get_system_python_path()
             if not system_python:
                 logger.error("[VenvManager] 无法找到系统 Python 解释器")
-                raise RuntimeError("无法找到系统 Python 解释器")
+                raise RuntimeError("System Python interpreter was not found")
 
             logger.info(f"[VenvManager] 使用 Python 解释器: {system_python}")
 

--- a/sagents/utils/system_prompt_optimizer.py
+++ b/sagents/utils/system_prompt_optimizer.py
@@ -133,7 +133,7 @@ class SystemPromptOptimizer:
             return {
                 "success": False,
                 "error": str(e),
-                "message": "系统指令优化失败",
+                "message": "System prompt optimization failed",
                 "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             }
 
@@ -257,7 +257,10 @@ class SystemPromptOptimizer:
                 return normalized_sections
             else:
                 logger.error("JSON解析失败，无法生成优化内容")
-                raise ValueError("JSON解析失败，可能是生成内容过长或格式不正确")
+                raise ValueError(
+                    "JSON parsing failed, possibly because the generated content "
+                    "is too long or malformed"
+                )
 
         except Exception as e:
             logger.error(f"生成优化部分时发生错误: {str(e)}")
@@ -821,11 +824,11 @@ class SystemPromptOptimizer:
                 f.write(result["optimized_prompt"])
 
             logger.info(f"优化结果已保存到: {file_path}")
-            return f"成功保存到 {file_path}"
+            return f"Saved to {file_path}"
 
         except Exception as e:
             logger.error(f"保存文件时发生错误: {str(e)}")
-            return f"保存失败: {str(e)}"
+            return f"Save failed: {str(e)}"
 
 
 if __name__ == "__main__":

--- a/tests/sagents/context/test_session_runtime_stream.py
+++ b/tests/sagents/context/test_session_runtime_stream.py
@@ -1,6 +1,7 @@
 import pytest
 
 from sagents.context.messages.message import MessageChunk, MessageRole, MessageType
+from sagents.context.session_context import SessionContext
 from sagents.flow.schema import AgentFlow, AgentNode
 from sagents.session_runtime import Session, initialize_global_session_manager
 
@@ -55,3 +56,39 @@ async def test_run_stream_with_flow_fills_missing_session_id(monkeypatch, tmp_pa
 
     assert chunks[0].session_id == "child-session"
     assert chunks[1]["session_id"] == "child-session"
+
+
+@pytest.mark.parametrize(
+    ("response_language", "expected"),
+    [
+        ("zh-CN", "工作流执行失败: 请求过于频繁，请稍后再试"),
+        ("en-US", "Workflow execution failed: Too many requests. Try again later"),
+        (
+            "pt-BR",
+            "Falha ao executar o fluxo de trabalho: "
+            "Muitas solicitacoes. Tente novamente mais tarde",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_handle_workflow_error_uses_session_language_for_rate_limit(
+    tmp_path, response_language, expected
+):
+    session = Session(session_id="error-session", enable_obs=False)
+    session.session_context = SessionContext(
+        session_id="error-session",
+        user_id="user-1",
+        agent_id="agent-1",
+        session_root_space=str(tmp_path),
+        system_context={"response_language": response_language},
+    )
+
+    chunks = []
+    async for emitted in session._handle_workflow_error(
+        Exception("RateLimitError: rate_limit")
+    ):
+        chunks.extend(emitted)
+
+    assert len(chunks) == 1
+    assert chunks[0].content == expected
+    assert chunks[0].type == "final_answer"

--- a/tests/sagents/messages/test_compress_history_tool.py
+++ b/tests/sagents/messages/test_compress_history_tool.py
@@ -169,7 +169,7 @@ class TestCompressHistoryTool:
         )
 
         assert result["status"] == "success"
-        assert "没有消息需要压缩" in result["message"]
+        assert "No messages need compression" in result["message"]
         print("OK: compress_conversation_history empty messages")
 
     def test_compress_conversation_history_compresses_caller_input(self):

--- a/tests/sagents/tool/impl/test_web_fetcher_tool.py
+++ b/tests/sagents/tool/impl/test_web_fetcher_tool.py
@@ -215,7 +215,7 @@ def test_fetch_html_with_save_truncates_markdown_and_saves_full_content(
         )
     )
 
-    assert "[内容已截断，完整内容已保存到文件:" in result["content"]
+    assert "[Content truncated. Full content saved to:" in result["content"]
     assert result["metadata"]["full_content_saved"] is True
     saved_content = tmp_path.joinpath(result["metadata"]["filename"]).read_text()
     assert "![A](https://domain.test/posts/images/a.png)" in saved_content
@@ -426,6 +426,6 @@ def test_xiaohongshu_unavailable_page_does_not_fallback_to_shell_markdown(
 
     assert result["status"] == "success"
     assert result["metadata"]["selector"] == "xiaohongshu_unavailable"
-    assert "小红书分享帖未返回正文" in result["content"]
+    assert "Xiaohongshu share post did not return body content" in result["content"]
     assert "data:image" not in result["content"]
     assert result["metadata"]["image_count"] == 0

--- a/tests/sagents/utils/test_file_content_validator.py
+++ b/tests/sagents/utils/test_file_content_validator.py
@@ -34,7 +34,7 @@ def test_yaml_validation_reports_error_for_invalid_yaml():
 
     assert result["status"] == "error"
     assert result["passed"] is False
-    assert "YAML 语法错误" in result["message"]
+    assert "YAML syntax error" in result["message"]
 
 
 def test_python_validation_passes_for_valid_python():
@@ -54,7 +54,7 @@ def test_python_validation_reports_error_for_invalid_python():
 
     assert result["status"] == "error"
     assert result["passed"] is False
-    assert "Python 语法错误" in result["message"]
+    assert "Python syntax error" in result["message"]
 
 
 def test_toml_validation_passes_for_valid_toml():


### PR DESCRIPTION
## Summary
- add sagents-local i18n for workflow execution errors, independent of backend request context
- bridge backend request locale into sagents system_context.response_language when missing
- replace sagents user/model-visible return, success, error, and exception text with localized workflow messages or English fallback
- update tests for the new English/localized return text

## Tests
- .venv/bin/pytest tests/sagents -q
- python -m compileall -q sagents common/services/chat_service.py tests/sagents/context/test_session_runtime_stream.py tests/sagents/messages/test_compress_history_tool.py tests/sagents/tool/impl/test_web_fetcher_tool.py tests/sagents/utils/test_file_content_validator.py