### PR TITLE
Add direct model invocation API

### DIFF
--- a/app/server/routers/__init__.py
+++ b/app/server/routers/__init__.py
@@ -16,6 +16,7 @@ def register_routes(app):
     from .kdb import kdb_router
     from .llm_provider import router as llm_provider_router
     from .mcp import mcp_router
+    from .model import model_router
     from .observability import observability_router
     from .oauth2 import oauth2_router
     from .oss import oss_router
@@ -38,6 +39,7 @@ def register_routes(app):
     app.include_router(version_router)
     app.include_router(oss_router)
     app.include_router(chat_router)
+    app.include_router(model_router)
     app.include_router(skill_router)
     app.include_router(llm_provider_router)
     app.include_router(observability_router)

--- a/app/server/routers/model.py
+++ b/app/server/routers/model.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, Request
+from fastapi.responses import StreamingResponse
+
+from common.core.request_identity import get_request_user_id
+from common.schemas.model_invocation import DirectModelInvokeRequest
+from common.services import model_invocation_service
+
+model_router = APIRouter(prefix="/api/model", tags=["Model"])
+
+
+@model_router.post("/invoke")
+async def invoke_model(request: DirectModelInvokeRequest, http_request: Request):
+    user_id = get_request_user_id(http_request)
+    if request.stream:
+        return StreamingResponse(
+            model_invocation_service.stream_model(request, user_id=user_id),
+            media_type="text/event-stream",
+        )
+    return await model_invocation_service.invoke_model(request, user_id=user_id)
+
+
+@model_router.post("/invoke/stream")
+async def stream_model(request: DirectModelInvokeRequest, http_request: Request):
+    user_id = get_request_user_id(http_request)
+    request.stream = True
+    return StreamingResponse(
+        model_invocation_service.stream_model(request, user_id=user_id),
+        media_type="text/event-stream",
+    )

--- a/common/schemas/model_invocation.py
+++ b/common/schemas/model_invocation.py
@@ -1,0 +1,49 @@
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
+
+
+ReasoningLevel = Literal["minimal", "low", "medium", "high"]
+ModelType = Literal["standard", "fast"]
+ATTRIBUTION_METADATA_KEYS = (
+    "task",
+    "request_source",
+    "source",
+    "billing_key",
+    "purpose",
+)
+
+
+class DirectModelInvokeRequest(BaseModel):
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    agent_id: Optional[str] = None
+    provider_id: Optional[str] = None
+    model_type: ModelType = "standard"
+    task: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    messages: List[Dict[str, Any]] = Field(min_length=1)
+    response_format: Optional[Dict[str, Any]] = None
+    temperature: Optional[float] = None
+    max_tokens: Optional[int] = None
+    stream: bool = False
+    deep_thinking: Optional[bool] = None
+    thinking_level: Optional[ReasoningLevel] = Field(
+        default=None,
+        validation_alias=AliasChoices("thinking_level", "deep_thinking_level"),
+    )
+
+    @model_validator(mode="after")
+    def validate_audit_context(self) -> "DirectModelInvokeRequest":
+        task = str(self.task or "").strip()
+        has_metadata_attribution = any(
+            str(self.metadata.get(key) or "").strip()
+            for key in ATTRIBUTION_METADATA_KEYS
+        )
+        if not task and not has_metadata_attribution:
+            raise ValueError(
+                "task or metadata attribution "
+                "(task/request_source/source/billing_key/purpose) is required"
+            )
+        self.task = task or None
+        return self

--- a/common/services/model_invocation_service.py
+++ b/common/services/model_invocation_service.py
@@ -1,0 +1,524 @@
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from collections.abc import AsyncGenerator, Mapping
+from typing import Any, Dict, Optional
+
+from loguru import logger
+
+from common.core.exceptions import SageHTTPException
+from common.models.agent import Agent
+from common.models.llm_provider import LLMProvider, LLMProviderDao
+from common.schemas.model_invocation import (
+    ATTRIBUTION_METADATA_KEYS,
+    DirectModelInvokeRequest,
+)
+from common.services import agent_service, token_usage_service
+from common.services.chat_utils import create_model_client
+from sagents.llm.model_capabilities import (
+    is_openai_reasoning_model,
+    resolve_reasoning_effort,
+)
+from sagents.utils.llm_request_utils import (
+    create_chat_completion_with_fallback,
+    redact_base64_data_urls_in_value,
+)
+
+_INTERNAL_REQUEST_FIELDS = {
+    "agent_id",
+    "provider_id",
+    "model_type",
+    "task",
+    "metadata",
+    "messages",
+    "stream",
+    "deep_thinking",
+    "thinking_level",
+    "deep_thinking_level",
+}
+_PROVIDER_CONFIG_FIELDS = {
+    "api_key",
+    "api_keys",
+    "base_url",
+    "fast_api_key",
+    "fast_base_url",
+    "fast_model_name",
+    "maxTokens",
+    "max_model_len",
+    "model",
+}
+
+
+def _get_provider_api_key(provider: LLMProvider) -> str:
+    api_key = provider.api_key
+    if not api_key:
+        raise SageHTTPException(
+            status_code=400,
+            detail="Provider API key is missing",
+            error_detail=f"provider_id={provider.id}",
+        )
+    return api_key
+
+
+def _provider_to_model_config(provider: LLMProvider) -> Dict[str, Any]:
+    return {
+        "base_url": provider.base_url,
+        "api_key": _get_provider_api_key(provider),
+        "model": provider.model,
+        "max_tokens": provider.max_tokens,
+        "temperature": provider.temperature,
+        "top_p": provider.top_p,
+        "presence_penalty": provider.presence_penalty,
+        "max_model_len": provider.max_model_len,
+        "supports_multimodal": provider.supports_multimodal,
+        "supports_structured_output": provider.supports_structured_output,
+    }
+
+
+def _strip_none_values(data: Mapping[str, Any]) -> Dict[str, Any]:
+    return {key: value for key, value in data.items() if value is not None}
+
+
+def _ensure_provider_access(provider: LLMProvider, user_id: str) -> None:
+    if provider.user_id and provider.user_id != user_id:
+        raise SageHTTPException(
+            status_code=403,
+            detail="Permission denied",
+            error_detail=f"provider_id={provider.id}",
+        )
+
+
+async def _get_accessible_provider(provider_id: str, user_id: str) -> LLMProvider:
+    provider = await LLMProviderDao().get_by_id(provider_id)
+    if provider is None:
+        raise SageHTTPException(
+            status_code=404,
+            detail="Provider not found",
+            error_detail=f"provider_id={provider_id}",
+        )
+    _ensure_provider_access(provider, user_id)
+    return provider
+
+
+async def _get_default_provider(user_id: str) -> LLMProvider:
+    dao = LLMProviderDao()
+    provider = await dao.get_default(user_id=user_id) if user_id else None
+    if provider is None:
+        provider = await dao.get_default(user_id="")
+    if provider is None and not user_id:
+        provider = await dao.get_default()
+    if provider is None:
+        raise SageHTTPException(status_code=404, detail="Default provider not found")
+    _ensure_provider_access(provider, user_id)
+    return provider
+
+
+async def _resolve_agent(
+    request: DirectModelInvokeRequest, user_id: str
+) -> Optional[Agent]:
+    if not request.agent_id:
+        return None
+    return await agent_service.get_agent(request.agent_id, user_id)
+
+
+async def _resolve_provider(
+    request: DirectModelInvokeRequest, user_id: str, agent: Optional[Agent]
+) -> tuple[LLMProvider, Optional[LLMProvider]]:
+    if request.provider_id:
+        return await _get_accessible_provider(request.provider_id, user_id), None
+
+    if agent is not None:
+        provider_id = str(agent.config.get("llm_provider_id") or "").strip()
+        if not provider_id:
+            raise SageHTTPException(
+                status_code=400,
+                detail="Agent LLM provider is missing",
+                error_detail=f"agent_id={agent.agent_id}",
+            )
+        provider = await LLMProviderDao().get_by_id(provider_id)
+        if provider is None:
+            raise SageHTTPException(
+                status_code=404,
+                detail="Agent LLM provider not found",
+                error_detail=f"agent_id={agent.agent_id}, provider_id={provider_id}",
+            )
+
+        fast_provider = None
+        fast_provider_id = str(agent.config.get("fast_llm_provider_id") or "").strip()
+        if fast_provider_id:
+            fast_provider = await LLMProviderDao().get_by_id(fast_provider_id)
+            if fast_provider is None:
+                logger.warning(
+                    f"[DirectModelInvoke] Agent fast provider missing: agent_id={agent.agent_id}, "
+                    f"provider_id={fast_provider_id}"
+                )
+        return provider, fast_provider
+
+    return await _get_default_provider(user_id), None
+
+
+def _build_model_config(
+    provider: LLMProvider,
+    fast_provider: Optional[LLMProvider],
+    *,
+    model_type: str,
+) -> Dict[str, Any]:
+    model_config = _provider_to_model_config(provider)
+    if fast_provider is not None:
+        model_config["fast_api_key"] = _get_provider_api_key(fast_provider)
+        model_config["fast_base_url"] = fast_provider.base_url
+        model_config["fast_model_name"] = fast_provider.model
+    active_provider = (
+        fast_provider if model_type == "fast" and fast_provider is not None else provider
+    )
+    active_config = _provider_to_model_config(active_provider)
+    for key in (
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "presence_penalty",
+        "max_model_len",
+        "supports_multimodal",
+        "supports_structured_output",
+    ):
+        model_config[key] = active_config.get(key)
+    return _strip_none_values(model_config)
+
+
+def _build_openai_request_kwargs(
+    request: DirectModelInvokeRequest, model_config: Dict[str, Any]
+) -> Dict[str, Any]:
+    request_data = request.model_dump(exclude_none=True, by_alias=False)
+    kwargs: Dict[str, Any] = {}
+
+    for key, value in model_config.items():
+        if key not in _PROVIDER_CONFIG_FIELDS and not key.startswith("supports_"):
+            kwargs[key] = value
+
+    for key, value in request_data.items():
+        if key in _INTERNAL_REQUEST_FIELDS or key in _PROVIDER_CONFIG_FIELDS:
+            continue
+        kwargs[key] = value
+
+    extra = request.model_extra or {}
+    for key, value in extra.items():
+        if key in _INTERNAL_REQUEST_FIELDS or key in _PROVIDER_CONFIG_FIELDS:
+            continue
+        kwargs[key] = value
+
+    kwargs["model_type"] = request.model_type
+    if request.response_format is not None:
+        kwargs["response_format"] = request.response_format
+    return _strip_none_values(kwargs)
+
+
+def _build_thinking_extra_body(
+    *,
+    existing_extra_body: Any,
+    model: str,
+    task: Optional[str],
+    deep_thinking: Optional[bool],
+    thinking_level: Optional[str],
+) -> Dict[str, Any]:
+    extra_body = (
+        dict(existing_extra_body) if isinstance(existing_extra_body, dict) else {}
+    )
+    extra_body.setdefault("_step_name", task or "direct_model_invocation")
+
+    enable_thinking = bool(deep_thinking)
+    if thinking_level:
+        enable_thinking = True
+
+    if is_openai_reasoning_model(model):
+        if thinking_level:
+            extra_body["reasoning_effort"] = thinking_level
+        else:
+            extra_body["reasoning_effort"] = resolve_reasoning_effort(
+                enable_thinking=enable_thinking,
+                env_value=None,
+                default_off="low",
+            )
+        return extra_body
+
+    if deep_thinking is None and thinking_level is None:
+        return extra_body
+
+    extra_body["chat_template_kwargs"] = {"enable_thinking": enable_thinking}
+    extra_body["enable_thinking"] = enable_thinking
+    extra_body["thinking"] = {"type": "enabled" if enable_thinking else "disabled"}
+    return extra_body
+
+
+def _sanitize_for_log(value: Any, *, max_depth: int = 4, max_items: int = 12) -> Any:
+    if max_depth < 0:
+        return f"<{type(value).__name__}>"
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        redacted = redact_base64_data_urls_in_value(value)
+        if not isinstance(redacted, str):
+            return redacted
+        if len(redacted) <= 200:
+            return redacted
+        return redacted[:197] + "..."
+    if isinstance(value, Mapping):
+        result: Dict[str, Any] = {}
+        items = list(value.items())
+        for key, item in items[:max_items]:
+            key_str = str(key)
+            if any(
+                token in key_str.lower()
+                for token in ("key", "token", "secret", "password", "authorization")
+            ):
+                result[key_str] = "<redacted>"
+            else:
+                result[key_str] = _sanitize_for_log(
+                    item,
+                    max_depth=max_depth - 1,
+                    max_items=max_items,
+                )
+        if len(items) > max_items:
+            result["..."] = f"+{len(items) - max_items} more"
+        return result
+    if isinstance(value, (list, tuple)):
+        items = list(value)
+        result = [
+            _sanitize_for_log(item, max_depth=max_depth - 1, max_items=max_items)
+            for item in items[:max_items]
+        ]
+        if len(items) > max_items:
+            result.append(f"... +{len(items) - max_items} more")
+        return result
+    return f"<{type(value).__name__}>"
+
+
+def _truncate_attribution(value: str, limit: int = 128) -> str:
+    if len(value) <= limit:
+        return value
+    return value[:limit]
+
+
+def _resolve_attribution(request: DirectModelInvokeRequest) -> str:
+    task = str(request.task or "").strip()
+    if task:
+        return _truncate_attribution(task)
+    for key in ATTRIBUTION_METADATA_KEYS:
+        value = str(request.metadata.get(key) or "").strip()
+        if value:
+            return _truncate_attribution(value)
+    return "direct_model_invocation"
+
+
+def _to_jsonable(value: Any) -> Any:
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if hasattr(value, "dict"):
+        return value.dict()
+    if isinstance(value, Mapping):
+        return {key: _to_jsonable(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_to_jsonable(item) for item in value]
+    return value
+
+
+def _extract_usage(response: Any) -> Optional[Dict[str, Any]]:
+    usage = getattr(response, "usage", None)
+    if usage is None and isinstance(response, Mapping):
+        usage = response.get("usage")
+    if usage is None:
+        return None
+    data = _to_jsonable(usage)
+    return data if isinstance(data, dict) else None
+
+
+def _usage_payload(
+    *,
+    usage: Optional[Dict[str, Any]],
+    task: str,
+    model: str,
+) -> Optional[Dict[str, Any]]:
+    if not usage or not isinstance(usage.get("total_tokens"), int):
+        return None
+    return {
+        "total_info": usage,
+        "per_step_info": [
+            {
+                "step_name": task,
+                "model": model,
+                "usage": usage,
+            }
+        ],
+    }
+
+
+async def _record_usage(
+    *,
+    usage: Optional[Dict[str, Any]],
+    task: str,
+    model: str,
+    invocation_id: str,
+    user_id: str,
+    agent_id: Optional[str],
+    started_at: float,
+) -> None:
+    payload = _usage_payload(usage=usage, task=task, model=model)
+    if payload is None:
+        return
+    try:
+        await token_usage_service.record_execution_payload(
+            token_usage=payload,
+            request_source=task,
+            session_id=invocation_id,
+            user_id=user_id,
+            agent_id=agent_id,
+            started_at=started_at,
+            finished_at=time.time(),
+        )
+    except Exception as exc:
+        logger.warning(f"[DirectModelInvoke] Failed to record token usage: {exc}")
+
+
+def _model_for_request(model_config: Dict[str, Any], model_type: str) -> str:
+    if model_type == "fast" and model_config.get("fast_model_name"):
+        return str(model_config["fast_model_name"])
+    return str(model_config.get("model") or "gpt-3.5-turbo")
+
+
+async def invoke_model(
+    request: DirectModelInvokeRequest,
+    *,
+    user_id: str,
+) -> Dict[str, Any]:
+    started_at = time.time()
+    invocation_id = f"direct_model_{uuid.uuid4().hex}"
+    agent = await _resolve_agent(request, user_id)
+    provider, fast_provider = await _resolve_provider(request, user_id, agent)
+    model_config = _build_model_config(
+        provider,
+        fast_provider,
+        model_type=request.model_type,
+    )
+    model_name = _model_for_request(model_config, request.model_type)
+    attribution = _resolve_attribution(request)
+    kwargs = _build_openai_request_kwargs(request, model_config)
+    kwargs["extra_body"] = _build_thinking_extra_body(
+        existing_extra_body=kwargs.get("extra_body"),
+        model=model_name,
+        task=attribution,
+        deep_thinking=request.deep_thinking,
+        thinking_level=request.thinking_level,
+    )
+    kwargs["stream"] = False
+
+    client = create_model_client(model_config)
+    try:
+        logger.info(
+            "[DirectModelInvoke] invoke "
+            f"task={request.task}, user_id={user_id}, agent_id={request.agent_id}, "
+            f"provider_id={provider.id}, model_type={request.model_type}, model={model_name}, "
+            f"metadata={_sanitize_for_log(request.metadata)}"
+        )
+        response = await create_chat_completion_with_fallback(
+            client,
+            model=model_name,
+            messages=_to_jsonable(request.messages),
+            model_config=model_config,
+            response_format=kwargs.pop("response_format", None),
+            **kwargs,
+        )
+        result = _to_jsonable(response)
+        if isinstance(result, dict):
+            result["provider_id"] = provider.id
+            result["model_type"] = request.model_type
+            result["task"] = request.task
+            result["request_source"] = attribution
+            result["invocation_id"] = invocation_id
+        usage = _extract_usage(response)
+        await _record_usage(
+            usage=usage,
+            task=attribution,
+            model=model_name,
+            invocation_id=invocation_id,
+            user_id=user_id,
+            agent_id=request.agent_id,
+            started_at=started_at,
+        )
+        return result if isinstance(result, dict) else {"response": result}
+    finally:
+        close = getattr(client, "close", None)
+        if close is not None:
+            await close()
+
+
+async def stream_model(
+    request: DirectModelInvokeRequest,
+    *,
+    user_id: str,
+) -> AsyncGenerator[str, None]:
+    started_at = time.time()
+    invocation_id = f"direct_model_{uuid.uuid4().hex}"
+    agent = await _resolve_agent(request, user_id)
+    provider, fast_provider = await _resolve_provider(request, user_id, agent)
+    model_config = _build_model_config(
+        provider,
+        fast_provider,
+        model_type=request.model_type,
+    )
+    model_name = _model_for_request(model_config, request.model_type)
+    attribution = _resolve_attribution(request)
+    kwargs = _build_openai_request_kwargs(request, model_config)
+    kwargs["extra_body"] = _build_thinking_extra_body(
+        existing_extra_body=kwargs.get("extra_body"),
+        model=model_name,
+        task=attribution,
+        deep_thinking=request.deep_thinking,
+        thinking_level=request.thinking_level,
+    )
+    kwargs["stream"] = True
+    stream_options = dict(kwargs.get("stream_options") or {})
+    stream_options["include_usage"] = True
+    kwargs["stream_options"] = stream_options
+
+    client = create_model_client(model_config)
+    usage: Optional[Dict[str, Any]] = None
+    try:
+        logger.info(
+            "[DirectModelInvoke] stream "
+            f"task={request.task}, user_id={user_id}, agent_id={request.agent_id}, "
+            f"provider_id={provider.id}, model_type={request.model_type}, model={model_name}, "
+            f"metadata={_sanitize_for_log(request.metadata)}"
+        )
+        stream = await create_chat_completion_with_fallback(
+            client,
+            model=model_name,
+            messages=_to_jsonable(request.messages),
+            model_config=model_config,
+            response_format=kwargs.pop("response_format", None),
+            **kwargs,
+        )
+        async for chunk in stream:
+            chunk_data = _to_jsonable(chunk)
+            if isinstance(chunk_data, dict):
+                chunk_data["provider_id"] = provider.id
+                chunk_data["model_type"] = request.model_type
+                chunk_data["task"] = request.task
+                chunk_data["request_source"] = attribution
+                chunk_data["invocation_id"] = invocation_id
+            usage = _extract_usage(chunk) or usage
+            yield f"data: {json.dumps(chunk_data, ensure_ascii=False)}\n\n"
+        await _record_usage(
+            usage=usage,
+            task=attribution,
+            model=model_name,
+            invocation_id=invocation_id,
+            user_id=user_id,
+            agent_id=request.agent_id,
+            started_at=started_at,
+        )
+        yield "data: [DONE]\n\n"
+    finally:
+        close = getattr(client, "close", None)
+        if close is not None:
+            await close()

--- a/tests/common/services/test_model_invocation_service.py
+++ b/tests/common/services/test_model_invocation_service.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from common.core.exceptions import SageHTTPException
+from common.schemas.model_invocation import DirectModelInvokeRequest
+from common.services import model_invocation_service as service
+
+
+class FakeProvider:
+    def __init__(
+        self,
+        provider_id: str,
+        *,
+        model: str,
+        user_id: str = "user_1",
+        supports_multimodal: bool = True,
+        supports_structured_output: bool = True,
+    ) -> None:
+        self.id = provider_id
+        self.name = provider_id
+        self.base_url = f"https://example.com/{provider_id}"
+        self.api_keys = [f"key-{provider_id}"]
+        self.model = model
+        self.max_tokens = 1000
+        self.temperature = 0.7
+        self.top_p = None
+        self.presence_penalty = None
+        self.max_model_len = None
+        self.supports_multimodal = supports_multimodal
+        self.supports_structured_output = supports_structured_output
+        self.user_id = user_id
+
+    @property
+    def api_key(self) -> str:
+        return self.api_keys[0]
+
+
+class FakeDao:
+    def __init__(self, providers: dict[str, FakeProvider]) -> None:
+        self.providers = providers
+
+    async def get_by_id(self, provider_id: str):
+        return self.providers.get(provider_id)
+
+    async def get_default(self, user_id=None):
+        return self.providers.get("default")
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeUsage:
+    def model_dump(self, mode="json"):
+        return {
+            "prompt_tokens": 12,
+            "completion_tokens": 5,
+            "total_tokens": 17,
+        }
+
+
+class FakeCompletion:
+    usage = FakeUsage()
+
+    def model_dump(self, mode="json"):
+        return {
+            "id": "chatcmpl_test",
+            "object": "chat.completion",
+            "model": "fake-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": '{"ok":true}'},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": self.usage.model_dump(mode=mode),
+        }
+
+
+class FakeChunk:
+    def __init__(self, content: str = "", usage=None) -> None:
+        self.usage = usage
+        self._content = content
+
+    def model_dump(self, mode="json"):
+        data = {
+            "id": "chatcmpl_chunk",
+            "object": "chat.completion.chunk",
+            "model": "fake-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": self._content},
+                    "finish_reason": None,
+                }
+            ],
+        }
+        if self.usage is not None:
+            data["usage"] = self.usage.model_dump(mode=mode)
+        return data
+
+
+def _patch_common(monkeypatch, providers):
+    dao = FakeDao(providers)
+    captured: dict[str, object] = {}
+    fake_client = FakeClient()
+
+    monkeypatch.setattr(service, "LLMProviderDao", lambda: dao)
+    monkeypatch.setattr(service, "create_model_client", lambda config: fake_client)
+
+    async def fake_record_execution_payload(**kwargs):
+        captured["usage_record"] = kwargs
+        return True
+
+    monkeypatch.setattr(
+        service.token_usage_service,
+        "record_execution_payload",
+        fake_record_execution_payload,
+    )
+    return captured, fake_client
+
+
+@pytest.mark.asyncio
+async def test_provider_id_takes_priority_and_request_stays_openai_shaped(monkeypatch):
+    providers = {
+        "provider_1": FakeProvider("provider_1", model="gpt-5-mini"),
+        "agent_provider": FakeProvider("agent_provider", model="gpt-4o"),
+    }
+    captured, fake_client = _patch_common(monkeypatch, providers)
+
+    async def fake_get_agent(agent_id, user_id):
+        return SimpleNamespace(
+            agent_id=agent_id,
+            config={"llm_provider_id": "agent_provider"},
+        )
+
+    async def fake_completion(client, **kwargs):
+        captured["completion_kwargs"] = kwargs
+        return FakeCompletion()
+
+    monkeypatch.setattr(service.agent_service, "get_agent", fake_get_agent)
+    monkeypatch.setattr(
+        service, "create_chat_completion_with_fallback", fake_completion
+    )
+
+    request = DirectModelInvokeRequest(
+        agent_id="agent_1",
+        provider_id="provider_1",
+        task="ling_file_semantic_classification",
+        messages=[
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "noop", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "ok",
+            },
+            {"role": "user", "content": "hi", "name": "tester"},
+        ],
+        response_format={"type": "json_object"},
+        temperature=0.1,
+        max_tokens=50,
+        seed=7,
+        model="should-not-pass-through",
+        api_key="should-not-pass-through",
+    )
+
+    result = await service.invoke_model(request, user_id="user_1")
+
+    kwargs = captured["completion_kwargs"]
+    assert kwargs["model"] == "gpt-5-mini"
+    assert kwargs["response_format"] == {"type": "json_object"}
+    assert kwargs["temperature"] == 0.1
+    assert kwargs["max_tokens"] == 50
+    assert kwargs["seed"] == 7
+    assert kwargs["model_type"] == "standard"
+    assert kwargs["extra_body"]["reasoning_effort"] == "low"
+    assert kwargs["messages"][0]["tool_calls"][0]["id"] == "call_1"
+    assert kwargs["messages"][1]["tool_call_id"] == "call_1"
+    assert kwargs["messages"][2]["name"] == "tester"
+    assert "api_key" not in kwargs
+    assert "base_url" not in kwargs
+    assert result["object"] == "chat.completion"
+    assert result["provider_id"] == "provider_1"
+    assert captured["usage_record"]["request_source"] == (
+        "ling_file_semantic_classification"
+    )
+    assert fake_client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_agent_fast_model_uses_agent_fast_provider(monkeypatch):
+    providers = {
+        "standard": FakeProvider(
+            "standard",
+            model="gpt-4o",
+            supports_multimodal=True,
+            supports_structured_output=True,
+        ),
+        "fast": FakeProvider(
+            "fast",
+            model="gpt-4o-mini",
+            supports_multimodal=False,
+            supports_structured_output=False,
+        ),
+    }
+    captured, _ = _patch_common(monkeypatch, providers)
+
+    async def fake_get_agent(agent_id, user_id):
+        return SimpleNamespace(
+            agent_id=agent_id,
+            config={
+                "llm_provider_id": "standard",
+                "fast_llm_provider_id": "fast",
+            },
+        )
+
+    async def fake_completion(client, **kwargs):
+        captured["completion_kwargs"] = kwargs
+        return FakeCompletion()
+
+    monkeypatch.setattr(service.agent_service, "get_agent", fake_get_agent)
+    monkeypatch.setattr(
+        service, "create_chat_completion_with_fallback", fake_completion
+    )
+
+    request = DirectModelInvokeRequest(
+        agent_id="agent_1",
+        model_type="fast",
+        task="title_generation",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    await service.invoke_model(request, user_id="user_1")
+
+    assert captured["completion_kwargs"]["model"] == "gpt-4o-mini"
+    assert captured["completion_kwargs"]["model_type"] == "fast"
+    assert captured["completion_kwargs"]["model_config"]["supports_multimodal"] is False
+    assert (
+        captured["completion_kwargs"]["model_config"]["supports_structured_output"]
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_thinking_level_controls_reasoning_effort(monkeypatch):
+    providers = {"provider_1": FakeProvider("provider_1", model="gpt-5-mini")}
+    captured, _ = _patch_common(monkeypatch, providers)
+
+    async def fake_completion(client, **kwargs):
+        captured["completion_kwargs"] = kwargs
+        return FakeCompletion()
+
+    monkeypatch.setattr(
+        service, "create_chat_completion_with_fallback", fake_completion
+    )
+
+    request = DirectModelInvokeRequest(
+        provider_id="provider_1",
+        task="semantic_summary",
+        messages=[{"role": "user", "content": "hi"}],
+        deep_thinking=True,
+        thinking_level="high",
+    )
+
+    await service.invoke_model(request, user_id="user_1")
+
+    assert captured["completion_kwargs"]["extra_body"]["reasoning_effort"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_stream_model_emits_openai_style_sse_and_records_usage(monkeypatch):
+    providers = {"provider_1": FakeProvider("provider_1", model="gpt-4o")}
+    captured, _ = _patch_common(monkeypatch, providers)
+
+    async def fake_completion(client, **kwargs):
+        captured["completion_kwargs"] = kwargs
+
+        async def stream():
+            yield FakeChunk("he")
+            yield FakeChunk("llo", usage=FakeUsage())
+
+        return stream()
+
+    monkeypatch.setattr(
+        service, "create_chat_completion_with_fallback", fake_completion
+    )
+
+    request = DirectModelInvokeRequest(
+        provider_id="provider_1",
+        task="tag_extract",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+    )
+
+    events = [event async for event in service.stream_model(request, user_id="user_1")]
+
+    assert captured["completion_kwargs"]["stream"] is True
+    assert captured["completion_kwargs"]["stream_options"] == {"include_usage": True}
+    assert events[-1] == "data: [DONE]\n\n"
+    first_payload = json.loads(events[0].removeprefix("data: ").strip())
+    assert first_payload["object"] == "chat.completion.chunk"
+    assert first_payload["provider_id"] == "provider_1"
+    assert captured["usage_record"]["token_usage"]["total_info"]["total_tokens"] == 17
+
+
+def test_task_or_metadata_is_required():
+    with pytest.raises(ValueError):
+        DirectModelInvokeRequest(messages=[{"role": "user", "content": "hi"}])
+
+    with pytest.raises(ValueError):
+        DirectModelInvokeRequest(task="empty_messages", messages=[])
+
+    with pytest.raises(ValueError):
+        DirectModelInvokeRequest(
+            metadata={"opaque": "value"},
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_metadata_attribution_is_recorded_when_task_is_absent(monkeypatch):
+    providers = {"provider_1": FakeProvider("provider_1", model="gpt-4o")}
+    captured, _ = _patch_common(monkeypatch, providers)
+
+    async def fake_completion(client, **kwargs):
+        captured["completion_kwargs"] = kwargs
+        return FakeCompletion()
+
+    monkeypatch.setattr(
+        service, "create_chat_completion_with_fallback", fake_completion
+    )
+
+    request = DirectModelInvokeRequest(
+        provider_id="provider_1",
+        metadata={"request_source": "ling_tags"},
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    result = await service.invoke_model(request, user_id="user_1")
+
+    assert result["request_source"] == "ling_tags"
+    assert captured["usage_record"]["request_source"] == "ling_tags"
+    assert captured["completion_kwargs"]["extra_body"]["_step_name"] == "ling_tags"
+
+
+def test_metadata_log_sanitizer_redacts_sensitive_values():
+    sanitized = service._sanitize_for_log(
+        {
+            "request_source": "ling_tags",
+            "access_token": "secret-token",
+            "nested": {
+                "password": "secret-password",
+                "image": "data:image/png;base64,AAAA",
+            },
+        }
+    )
+
+    assert sanitized["request_source"] == "ling_tags"
+    assert sanitized["access_token"] == "<redacted>"
+    assert sanitized["nested"]["password"] == "<redacted>"
+    assert sanitized["nested"]["image"] == "<redacted data URL; base64_len=4>"
+
+
+@pytest.mark.asyncio
+async def test_provider_permission_is_enforced(monkeypatch):
+    providers = {
+        "provider_1": FakeProvider(
+            "provider_1",
+            model="gpt-4o",
+            user_id="other_user",
+        )
+    }
+    _patch_common(monkeypatch, providers)
+    request = DirectModelInvokeRequest(
+        provider_id="provider_1",
+        task="summary",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    with pytest.raises(SageHTTPException) as exc_info:
+        await service.invoke_model(request, user_id="user_1")
+
+    assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Summary

- add `POST /api/model/invoke` and `POST /api/model/invoke/stream` for direct model calls
- resolve model config through `provider_id`, `agent_id + model_type`, or the default provider without creating sessions or loading Agent runtime
- support OpenAI-style messages/parameters, streaming SSE, response_format fallback, multimodal downgrade, reasoning controls, metadata/task attribution, and token usage recording

## Impact

This is an additive API surface under `/api/model/*`. It does not change `/api/chat`, session creation, Agent prompt loading, tools, skills, memory, or task completion behavior.

## Validation

- `/Users/zhangzheng/zavixai/Sage/.venv/bin/pytest tests/common/services/test_model_invocation_service.py -q`
- `/Users/zhangzheng/zavixai/Sage/.venv/bin/python -m ruff check common/schemas/model_invocation.py common/services/model_invocation_service.py app/server/routers/model.py app/server/routers/__init__.py tests/common/services/test_model_invocation_service.py`
- `/Users/zhangzheng/zavixai/Sage/.venv/bin/python -m compileall common/schemas/model_invocation.py common/services/model_invocation_service.py app/server/routers/model.py app/server/routers/__init__.py`
