### PR TITLE
Add request-only continuation guidance for task judge

### DIFF
--- a/sagents/agent/simple_agent.py
+++ b/sagents/agent/simple_agent.py
@@ -23,6 +23,7 @@ from sagents.utils.llm_request_utils import redact_base64_data_urls_in_value
 import json
 import uuid
 from copy import deepcopy
+from dataclasses import dataclass
 import re
 import os
 from sagents.utils.repeat_pattern import (
@@ -35,6 +36,12 @@ from sagents.utils.repeat_pattern import (
 TASK_COMPLETE_TOOL_RESULT_PREVIEW_CHARS = 500
 DEFAULT_REPEAT_PATTERN_MAX_HITS = 3
 REPEAT_PATTERN_MAX_HITS_ENV = "SAGE_REPEAT_PATTERN_MAX_HITS"
+
+
+@dataclass(frozen=True)
+class TaskCompleteDecision:
+    task_interrupted: bool
+    reason: str = ""
 
 
 def _get_repeat_pattern_max_hits() -> int:
@@ -399,6 +406,18 @@ class SimpleAgent(AgentBase):
 
         return task_interrupted
 
+    @staticmethod
+    def _parse_task_interrupted_value(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized == "true":
+                return True
+            if normalized == "false":
+                return False
+        return False
+
     def _has_recent_assistant_summary(self, messages_input: List[MessageChunk]) -> bool:
         """判断 turn_status 之前是否存在用户可见的 assistant 收口文本。
 
@@ -687,13 +706,13 @@ class SimpleAgent(AgentBase):
 
         return False
 
-    async def _is_task_complete(
+    async def _get_task_complete_decision(
         self,
         messages_input: List[MessageChunk],
         session_id: str,
         tool_manager: Optional[ToolManager],
         session_context: SessionContext,
-    ) -> bool:
+    ) -> TaskCompleteDecision:
         """判断任务是否应该中断（完成/等待用户）
 
         两层策略：
@@ -702,7 +721,7 @@ class SimpleAgent(AgentBase):
         """
         # 第一层：确定性规则
         if await self._must_continue_by_rules(messages_input):
-            return False
+            return TaskCompleteDecision(task_interrupted=False)
 
         # 第二层：LLM 综合判断
         # 只提取最后一个 user 以及之后的 messages
@@ -761,8 +780,11 @@ class SimpleAgent(AgentBase):
         try:
             result_clean = MessageChunk.extract_json_from_markdown(all_content)
             result = json.loads(result_clean)
-            task_interrupted = bool(result.get("task_interrupted", False))
-            reason = str(result.get("reason", ""))
+            task_interrupted = self._parse_task_interrupted_value(
+                result.get("task_interrupted", False)
+            )
+            raw_reason = result.get("reason", "")
+            reason = raw_reason if isinstance(raw_reason, str) else ""
             normalized = self._normalize_task_interrupted_decision(
                 reason, task_interrupted
             )
@@ -774,12 +796,67 @@ class SimpleAgent(AgentBase):
             logger.info(
                 f"SimpleAgent: 任务完成 LLM 判断结果: {result}, normalized={normalized}"
             )
-            return normalized
+            return TaskCompleteDecision(task_interrupted=normalized, reason=reason)
         except json.JSONDecodeError:
             logger.warning(
                 "SimpleAgent: 解析任务完成判断响应时JSON解码错误，默认继续执行"
             )
-            return False
+            return TaskCompleteDecision(task_interrupted=False)
+
+    async def _is_task_complete(
+        self,
+        messages_input: List[MessageChunk],
+        session_id: str,
+        tool_manager: Optional[ToolManager],
+        session_context: SessionContext,
+    ) -> bool:
+        decision = await self._get_task_complete_decision(
+            messages_input, session_id, tool_manager, session_context
+        )
+        return decision.task_interrupted
+
+    @staticmethod
+    def _normalize_continuation_reason(reason: str) -> str:
+        normalized = re.sub(r"\s+", " ", str(reason or "")).strip()
+        if not normalized:
+            return ""
+        normalized = normalized[:240].replace("<", "[").replace(">", "]")
+        return normalized.strip()
+
+    @classmethod
+    def _continuation_reason_from_decision(
+        cls, decision: TaskCompleteDecision
+    ) -> Optional[str]:
+        if decision.task_interrupted:
+            return None
+        normalized_reason = cls._normalize_continuation_reason(decision.reason)
+        return normalized_reason or None
+
+    @classmethod
+    def _build_continuation_guidance_message(
+        cls, reason: str
+    ) -> Optional[MessageChunk]:
+        normalized_reason = cls._normalize_continuation_reason(reason)
+        if not normalized_reason:
+            return None
+        content = (
+            "<runtime_continuation_guidance>\n"
+            "Internal runtime note, not a user request. Do not mention it.\n"
+            f"Continue because: {normalized_reason}\n"
+            "Perform the next unfinished action. Do not repeat the last visible "
+            "update or already reported artifacts.\n"
+            "</runtime_continuation_guidance>"
+        )
+        return MessageChunk(
+            role=MessageRole.USER.value,
+            content=content,
+            type=MessageType.USER_INPUT.value,
+            message_type=MessageType.USER_INPUT.value,
+            metadata={
+                "inference_view_only": True,
+                "runtime_continuation_guidance": True,
+            },
+        )
 
     @classmethod
     def _format_task_complete_messages_for_prompt(
@@ -939,6 +1016,7 @@ class SimpleAgent(AgentBase):
         force_tool_choice_required_next = False
         turn_status_only_next = False
         consecutive_plain_text_direct_responses = 0
+        pending_continuation_reason: Optional[str] = None
         while True:
             if self._should_abort_due_to_session(session_context):
                 break
@@ -985,6 +1063,8 @@ class SimpleAgent(AgentBase):
             turn_status_only_next = False
             current_force_tool_choice_required = force_tool_choice_required_next
             force_tool_choice_required_next = False
+            current_continuation_reason = pending_continuation_reason
+            pending_continuation_reason = None
             if current_turn_status_only:
                 logger.info(
                     "SimpleAgent: 上一轮纯文本无工具调用，本轮仅开放 turn_status 并启用 tool_choice=required"
@@ -1031,6 +1111,7 @@ class SimpleAgent(AgentBase):
                 ),
                 force_tool_choice_auto=force_tool_choice_auto_next,
                 direct_response_state=direct_response_state,
+                continuation_reason=current_continuation_reason,
             ):
                 non_empty_chunks = [
                     c for c in chunks if (c.message_type != MessageType.EMPTY.value)
@@ -1196,20 +1277,27 @@ class SimpleAgent(AgentBase):
                             "SimpleAgent: 连续三轮 direct LLM 纯文本无工具调用，终止执行"
                         )
                         break
-                    if await self._is_task_complete(
+                    decision = await self._get_task_complete_decision(
                         messages_input, session_id, tool_manager, session_context
-                    ):
+                    )
+                    if decision.task_interrupted:
                         logger.info("SimpleAgent: 任务完成，终止执行")
                         break
+                    pending_continuation_reason = (
+                        self._continuation_reason_from_decision(decision)
+                    )
                     force_tool_choice_required_next = True
-                elif await self._is_task_complete(
-                    messages_input, session_id, tool_manager, session_context
-                ):
-                    consecutive_plain_text_direct_responses = 0
-                    logger.info("SimpleAgent: 任务完成，终止执行")
-                    break
                 else:
+                    decision = await self._get_task_complete_decision(
+                        messages_input, session_id, tool_manager, session_context
+                    )
                     consecutive_plain_text_direct_responses = 0
+                    if decision.task_interrupted:
+                        logger.info("SimpleAgent: 任务完成，终止执行")
+                        break
+                    pending_continuation_reason = (
+                        self._continuation_reason_from_decision(decision)
+                    )
 
     async def _call_llm_and_process_response(
         self,
@@ -1220,6 +1308,7 @@ class SimpleAgent(AgentBase):
         force_tool_choice_required: bool = False,
         force_tool_choice_auto: bool = False,
         direct_response_state: Optional[Dict[str, bool]] = None,
+        continuation_reason: Optional[str] = None,
     ) -> AsyncGenerator[tuple[List[MessageChunk], bool], None]:
         # 准备消息：提取可用消息 -> 检查压缩 -> 执行压缩
         # 通过生成器获取中间结果（tool_calls/tool result）和最终结果。
@@ -1250,6 +1339,11 @@ class SimpleAgent(AgentBase):
             custom_prefix=_get_system_prefix(tool_manager, language),
             language=language,
         )
+        continuation_guidance = self._build_continuation_guidance_message(
+            continuation_reason or ""
+        )
+        if continuation_guidance is not None:
+            prepared_messages = list(prepared_messages) + [continuation_guidance]
 
         clean_message_input = MessageManager.convert_messages_to_dict_for_request(
             prepared_messages

--- a/tests/sagents/agent/test_simple_agent_finish_summary.py
+++ b/tests/sagents/agent/test_simple_agent_finish_summary.py
@@ -11,6 +11,7 @@ from sagents.agent.simple_agent import (
     DEFAULT_REPEAT_PATTERN_MAX_HITS,
     REPEAT_PATTERN_MAX_HITS_ENV,
     SimpleAgent,
+    TaskCompleteDecision,
     _get_system_prefix,
 )
 from sagents.utils.prompt_manager import PromptManager
@@ -520,6 +521,191 @@ def test_committed_next_step_still_uses_llm_judge(monkeypatch):
         is False
     )
     assert captured["step_name"] == "task_complete_judge"
+
+
+def test_task_complete_decision_captures_continue_reason(monkeypatch):
+    agent = _agent()
+
+    async def _fake_llm_streaming(*args, **kwargs):
+        yield _llm_chunk(
+            content='{"task_interrupted": false, "reason": "more clips pending"}'
+        )
+
+    monkeypatch.setattr(agent, "_call_llm_streaming", _fake_llm_streaming)
+
+    msg_manager = SimpleNamespace(
+        context_budget_manager=SimpleNamespace(budget_info={"active_budget": 3000}),
+    )
+    session_context = SimpleNamespace(
+        message_manager=msg_manager,
+        get_language=lambda: "en",
+    )
+
+    decision = asyncio.run(
+        agent._get_task_complete_decision(
+            messages_input=_base_messages()
+            + [
+                MessageChunk(
+                    role=MessageRole.ASSISTANT.value,
+                    content="Progress update.",
+                    message_type=MessageType.DO_SUBTASK_RESULT.value,
+                )
+            ],
+            session_id="s-reason",
+            tool_manager=None,
+            session_context=session_context,  # pyright: ignore[reportArgumentType]
+        )
+    )
+
+    assert decision == TaskCompleteDecision(
+        task_interrupted=False, reason="more clips pending"
+    )
+    assert agent._continuation_reason_from_decision(decision) == "more clips pending"
+    assert (
+        agent._continuation_reason_from_decision(
+            TaskCompleteDecision(task_interrupted=False, reason="   ")
+        )
+        is None
+    )
+    assert (
+        agent._continuation_reason_from_decision(
+            TaskCompleteDecision(task_interrupted=True, reason="done")
+        )
+        is None
+    )
+    assert (
+        asyncio.run(
+            agent._is_task_complete(
+                messages_input=_base_messages(),
+                session_id="s-reason",
+                tool_manager=None,
+                session_context=session_context,  # pyright: ignore[reportArgumentType]
+            )
+        )
+        is False
+    )
+
+
+def test_task_complete_decision_ignores_non_string_reason(monkeypatch):
+    agent = _agent()
+
+    async def _fake_llm_streaming(*args, **kwargs):
+        yield _llm_chunk(content='{"task_interrupted": false, "reason": null}')
+
+    monkeypatch.setattr(agent, "_call_llm_streaming", _fake_llm_streaming)
+
+    msg_manager = SimpleNamespace(
+        context_budget_manager=SimpleNamespace(budget_info={"active_budget": 3000}),
+    )
+    session_context = SimpleNamespace(
+        message_manager=msg_manager,
+        get_language=lambda: "en",
+    )
+
+    decision = asyncio.run(
+        agent._get_task_complete_decision(
+            messages_input=_base_messages()
+            + [
+                MessageChunk(
+                    role=MessageRole.ASSISTANT.value,
+                    content="Progress update.",
+                    message_type=MessageType.DO_SUBTASK_RESULT.value,
+                )
+            ],
+            session_id="s-null-reason",
+            tool_manager=None,
+            session_context=session_context,  # pyright: ignore[reportArgumentType]
+        )
+    )
+
+    assert decision == TaskCompleteDecision(task_interrupted=False, reason="")
+    assert agent._continuation_reason_from_decision(decision) is None
+
+
+def test_task_complete_decision_parses_string_boolean(monkeypatch):
+    agent = _agent()
+
+    async def _fake_llm_streaming(*args, **kwargs):
+        yield _llm_chunk(
+            content='{"task_interrupted": "false", "reason": "more clips pending"}'
+        )
+
+    monkeypatch.setattr(agent, "_call_llm_streaming", _fake_llm_streaming)
+
+    msg_manager = SimpleNamespace(
+        context_budget_manager=SimpleNamespace(budget_info={"active_budget": 3000}),
+    )
+    session_context = SimpleNamespace(
+        message_manager=msg_manager,
+        get_language=lambda: "en",
+    )
+
+    decision = asyncio.run(
+        agent._get_task_complete_decision(
+            messages_input=_base_messages()
+            + [
+                MessageChunk(
+                    role=MessageRole.ASSISTANT.value,
+                    content="Progress update.",
+                    message_type=MessageType.DO_SUBTASK_RESULT.value,
+                )
+            ],
+            session_id="s-string-bool",
+            tool_manager=None,
+            session_context=session_context,  # pyright: ignore[reportArgumentType]
+        )
+    )
+
+    assert decision == TaskCompleteDecision(
+        task_interrupted=False, reason="more clips pending"
+    )
+    assert agent._parse_task_interrupted_value("true") is True
+    assert agent._parse_task_interrupted_value("false") is False
+    assert agent._parse_task_interrupted_value("yes") is False
+
+
+def test_direct_request_appends_continuation_guidance_request_only(monkeypatch):
+    agent = _agent()
+    captured = {}
+    original_messages = _base_messages()
+    prepared_messages = list(original_messages)
+    _patch_prepared_messages(monkeypatch, agent, prepared_messages)
+
+    async def _fake_prepare_llm_request_messages(**kwargs):
+        return list(kwargs["history_messages"])
+
+    async def _fake_llm_streaming(*args, **kwargs):
+        captured["messages"] = kwargs["messages"]
+        yield _llm_chunk(content="ok")
+
+    monkeypatch.setattr(
+        agent, "prepare_llm_request_messages", _fake_prepare_llm_request_messages
+    )
+    monkeypatch.setattr(agent, "_call_llm_streaming", _fake_llm_streaming)
+
+    chunks = asyncio.run(
+        _collect_llm_response(
+            agent,
+            messages_input=original_messages,
+            tools_json=[],
+            tool_manager=None,
+            session_id="s-guidance",
+            direct_response_state={},
+            continuation_reason="  more   <clips>   pending  ",
+        )
+    )
+
+    assert len(original_messages) == 2
+    assert len(prepared_messages) == 2
+    assert captured["messages"][:-1] == prepared_messages
+    guidance = captured["messages"][-1]
+    assert guidance.role == MessageRole.USER.value
+    assert "Continue because: more [clips] pending" in guidance.content
+    assert "Do not mention it" in guidance.content
+    assert all(
+        "runtime_continuation_guidance" not in (chunk.content or "")
+        for chunk in chunks
+    )
 
 
 class _ToolNameManager:
@@ -1253,15 +1439,17 @@ def test_llm_judge_skips_completion_check_after_direct_tool_activity(monkeypatch
             False,
         )
 
-    async def _fake_is_task_complete(*args, **kwargs):
+    async def _fake_get_task_complete_decision(*args, **kwargs):
         judge_calls.append((args, kwargs))
-        return True
+        return TaskCompleteDecision(task_interrupted=True)
 
     monkeypatch.setattr(agent, "_should_abort_due_to_session", lambda *args: False)
     monkeypatch.setattr(
         agent, "_call_llm_and_process_response", _fake_call_llm_and_process_response
     )
-    monkeypatch.setattr(agent, "_is_task_complete", _fake_is_task_complete)
+    monkeypatch.setattr(
+        agent, "_get_task_complete_decision", _fake_get_task_complete_decision
+    )
 
     async def _collect():
         chunks = []
@@ -1280,6 +1468,98 @@ def test_llm_judge_skips_completion_check_after_direct_tool_activity(monkeypatch
     assert len(direct_calls) == 2
     assert len(judge_calls) == 1
     assert chunks[-1].content == "已经完成。"
+
+
+def test_llm_judge_continuation_guidance_is_one_shot(monkeypatch):
+    monkeypatch.setenv("SAGE_TASK_COMPLETION_MODE", "llm_judge")
+    agent = _agent()
+    direct_calls = []
+    judge_calls = []
+
+    async def _fake_call_llm_and_process_response(**kwargs):
+        direct_calls.append(kwargs)
+        if len(direct_calls) == 1:
+            yield (
+                [
+                    MessageChunk(
+                        role=MessageRole.ASSISTANT.value,
+                        content="progress update",
+                        message_type=MessageType.DO_SUBTASK_RESULT.value,
+                    )
+                ],
+                False,
+            )
+            return
+        if len(direct_calls) == 2:
+            kwargs["direct_response_state"]["had_tool_calls"] = True
+            yield (
+                [
+                    MessageChunk(
+                        role=MessageRole.TOOL.value,
+                        content='{"ok": true}',
+                        tool_call_id="call_tool",
+                        message_type=MessageType.TOOL_CALL_RESULT.value,
+                    )
+                ],
+                False,
+            )
+            return
+        yield (
+            [
+                MessageChunk(
+                    role=MessageRole.ASSISTANT.value,
+                    content="done",
+                    message_type=MessageType.ASSISTANT_TEXT.value,
+                )
+            ],
+            False,
+        )
+
+    async def _fake_get_task_complete_decision(*args, **kwargs):
+        judge_calls.append((args, kwargs))
+        if len(judge_calls) == 1:
+            return TaskCompleteDecision(
+                task_interrupted=False,
+                reason="more clips pending",
+            )
+        return TaskCompleteDecision(
+            task_interrupted=True,
+            reason="done",
+        )
+
+    monkeypatch.setattr(agent, "_should_abort_due_to_session", lambda *args: False)
+    monkeypatch.setattr(
+        agent, "_call_llm_and_process_response", _fake_call_llm_and_process_response
+    )
+    monkeypatch.setattr(
+        agent, "_get_task_complete_decision", _fake_get_task_complete_decision
+    )
+
+    async def _collect():
+        chunks = []
+        async for yielded_chunks in agent._execute_loop(
+            messages_input=_base_messages(),
+            tools_json=[],
+            tool_manager=None,
+            session_id="s1",
+            session_context=_loop_session_context(),  # pyright: ignore[reportArgumentType]
+        ):
+            chunks.extend(yielded_chunks)
+        return chunks
+
+    chunks = asyncio.run(_collect())
+
+    assert len(direct_calls) == 3
+    assert [call["continuation_reason"] for call in direct_calls] == [
+        None,
+        "more clips pending",
+        None,
+    ]
+    assert [chunk.content for chunk in chunks if chunk.content] == [
+        "progress update",
+        '{"ok": true}',
+        "done",
+    ]
 
 
 def test_llm_judge_uses_direct_response_state_not_collected_chunks(monkeypatch):
@@ -1305,15 +1585,17 @@ def test_llm_judge_uses_direct_response_state_not_collected_chunks(monkeypatch):
             False,
         )
 
-    async def _fake_is_task_complete(*args, **kwargs):
+    async def _fake_get_task_complete_decision(*args, **kwargs):
         judge_calls.append((args, kwargs))
-        return True
+        return TaskCompleteDecision(task_interrupted=True)
 
     monkeypatch.setattr(agent, "_should_abort_due_to_session", lambda *args: False)
     monkeypatch.setattr(
         agent, "_call_llm_and_process_response", _fake_call_llm_and_process_response
     )
-    monkeypatch.setattr(agent, "_is_task_complete", _fake_is_task_complete)
+    monkeypatch.setattr(
+        agent, "_get_task_complete_decision", _fake_get_task_complete_decision
+    )
 
     async def _collect():
         chunks = []
@@ -1352,15 +1634,17 @@ def test_llm_judge_stops_after_three_plain_text_direct_responses(monkeypatch):
             False,
         )
 
-    async def _fake_is_task_complete(*args, **kwargs):
+    async def _fake_get_task_complete_decision(*args, **kwargs):
         judge_calls.append((args, kwargs))
-        return False
+        return TaskCompleteDecision(task_interrupted=False)
 
     monkeypatch.setattr(agent, "_should_abort_due_to_session", lambda *args: False)
     monkeypatch.setattr(
         agent, "_call_llm_and_process_response", _fake_call_llm_and_process_response
     )
-    monkeypatch.setattr(agent, "_is_task_complete", _fake_is_task_complete)
+    monkeypatch.setattr(
+        agent, "_get_task_complete_decision", _fake_get_task_complete_decision
+    )
 
     async def _collect():
         chunks = []
@@ -1421,15 +1705,17 @@ def test_llm_judge_forces_required_after_incomplete_plain_text(monkeypatch):
             False,
         )
 
-    async def _fake_is_task_complete(*args, **kwargs):
+    async def _fake_get_task_complete_decision(*args, **kwargs):
         judge_calls.append((args, kwargs))
-        return False
+        return TaskCompleteDecision(task_interrupted=False)
 
     monkeypatch.setattr(agent, "_should_abort_due_to_session", lambda *args: False)
     monkeypatch.setattr(
         agent, "_call_llm_and_process_response", _fake_call_llm_and_process_response
     )
-    monkeypatch.setattr(agent, "_is_task_complete", _fake_is_task_complete)
+    monkeypatch.setattr(
+        agent, "_get_task_complete_decision", _fake_get_task_complete_decision
+    )
 
     async def _collect():
         chunks = []
@@ -1476,15 +1762,17 @@ def test_llm_judge_completed_plain_text_does_not_force_required(monkeypatch):
             False,
         )
 
-    async def _fake_is_task_complete(*args, **kwargs):
+    async def _fake_get_task_complete_decision(*args, **kwargs):
         judge_calls.append((args, kwargs))
-        return True
+        return TaskCompleteDecision(task_interrupted=True)
 
     monkeypatch.setattr(agent, "_should_abort_due_to_session", lambda *args: False)
     monkeypatch.setattr(
         agent, "_call_llm_and_process_response", _fake_call_llm_and_process_response
     )
-    monkeypatch.setattr(agent, "_is_task_complete", _fake_is_task_complete)
+    monkeypatch.setattr(
+        agent, "_get_task_complete_decision", _fake_get_task_complete_decision
+    )
 
     async def _collect():
         chunks = []
@@ -1551,15 +1839,17 @@ def test_llm_judge_tool_activity_resets_required_after_plain_text(monkeypatch):
             False,
         )
 
-    async def _fake_is_task_complete(*args, **kwargs):
+    async def _fake_get_task_complete_decision(*args, **kwargs):
         judge_calls.append((args, kwargs))
-        return len(judge_calls) >= 2
+        return TaskCompleteDecision(task_interrupted=len(judge_calls) >= 2)
 
     monkeypatch.setattr(agent, "_should_abort_due_to_session", lambda *args: False)
     monkeypatch.setattr(
         agent, "_call_llm_and_process_response", _fake_call_llm_and_process_response
     )
-    monkeypatch.setattr(agent, "_is_task_complete", _fake_is_task_complete)
+    monkeypatch.setattr(
+        agent, "_get_task_complete_decision", _fake_get_task_complete_decision
+    )
 
     async def _collect():
         chunks = []


### PR DESCRIPTION
## Summary
- keep task_complete_judge schema unchanged while returning an internal TaskCompleteDecision
- inject a one-shot synthetic user guidance message only into the next direct_execution request when the judge says continue with a non-empty reason
- normalize and sanitize continuation reasons, including null/non-string reasons and string boolean task_interrupted values
- keep guidance out of messages_input/history/UI yields and avoid instance-level decision state

## Tests
- .venv/bin/pytest tests/sagents/agent/test_simple_agent_finish_summary.py tests/sagents/agent/test_agent_base_system_request.py tests/sagents/agent/test_simple_agent_task_complete.py -q
- git diff --check