### PR TITLE
Unify runtime corrections and file-link validation

### DIFF
--- a/common/services/chat_service.py
+++ b/common/services/chat_service.py
@@ -15,6 +15,7 @@ from urllib.parse import unquote, urlparse
 
 from loguru import logger
 from sagents.context.session_context import get_session_run_lock
+from sagents.context.messages.message import is_message_client_visible
 from sagents.sagents import SAgent
 from sagents.session_runtime import get_global_session_manager
 from sagents.tool import get_tool_manager
@@ -1285,12 +1286,7 @@ class SageStreamService:
                         result = message.copy()
                     else:
                         result = message.to_dict()
-                    metadata = result.get("metadata")
-                    if isinstance(metadata, dict) and (
-                        metadata.get("hidden_from_chat") is True
-                        or metadata.get("hide_from_chat") is True
-                        or metadata.get("sse_visible") is False
-                    ):
+                    if not is_message_client_visible(result):
                         continue
                     result = ContentProcessor.clean_content(result)
                     approval_event = _sandbox_approval_event_from_tool_result(

--- a/common/services/conversation_service.py
+++ b/common/services/conversation_service.py
@@ -18,6 +18,7 @@ from sagents.session_runtime import (
     build_conversation_messages_view,
     get_global_session_manager,
 )
+from sagents.context.messages.message import is_message_client_visible
 
 from common.core import config
 from common.core.context import get_request_locale
@@ -638,11 +639,7 @@ def _load_session_raw_messages(session_id: str) -> List[Dict[str, Any]]:
 
 
 def _is_hidden_context_message(message: Dict[str, Any]) -> bool:
-    metadata = (message or {}).get("metadata")
-    return isinstance(metadata, dict) and (
-        metadata.get("hidden_from_chat") is True
-        or metadata.get("hide_from_chat") is True
-    )
+    return not is_message_client_visible(message)
 
 
 def _find_last_user_message_index(messages: List[Dict[str, Any]]) -> int:

--- a/sagents/agent/agent_base.py
+++ b/sagents/agent/agent_base.py
@@ -14,7 +14,12 @@ from sagents.tool.tool_progress import (
     emit_tool_progress_closed as _emit_tool_progress_closed,
 )
 from sagents.context.session_context import SessionContext
-from sagents.context.messages.message import MessageChunk, MessageRole, MessageType
+from sagents.context.messages.message import (
+    MessageChunk,
+    MessageRole,
+    MessageType,
+    is_message_client_visible,
+)
 from sagents.utils.prompt_manager import prompt_manager
 from sagents.context.messages.message_manager import MessageManager
 from sagents.llm.sage_openai import SageAsyncOpenAI
@@ -191,11 +196,7 @@ class AgentBase(ABC):
     @staticmethod
     def _visible_user_injections(chunks: List[MessageChunk]) -> List[MessageChunk]:
         """Return injected messages that should be emitted to clients."""
-        return [
-            chunk
-            for chunk in chunks
-            if (chunk.metadata or {}).get("sse_visible") is not False
-        ]
+        return [chunk for chunk in chunks if is_message_client_visible(chunk)]
 
     @staticmethod
     def _transient_user_injections(chunks: List[MessageChunk]) -> List[MessageChunk]:
@@ -216,13 +217,14 @@ class AgentBase(ABC):
         """Metadata for hidden audit messages consumed by one LLM request."""
 
         return {
+            **extra,
             "hidden_from_chat": True,
+            "hide_from_chat": True,
             "sse_visible": False,
             "llm_scope": "next_request",
             "llm_state": "pending",
             "llm_consumed_by": None,
             "llm_consumed_at": None,
-            **extra,
         }
 
     def _create_unavailable_tool_runtime_message(
@@ -2489,13 +2491,10 @@ class AgentBase(ABC):
             message_id=str(uuid.uuid4()),
             message_type=MessageType.AGENT_EXECUTION_ERROR.value,
             agent_name=self.agent_name,
-            metadata={
-                "hide_from_chat": True,
-                **self._next_request_runtime_metadata(
-                    runtime_diagnostic_source="tool_call_argument_parse",
-                    tool_name=tool_name,
-                ),
-            },
+            metadata=self._next_request_runtime_metadata(
+                runtime_diagnostic_source="tool_call_argument_parse",
+                tool_name=tool_name,
+            ),
         )
 
     def _create_tool_call_message(

--- a/sagents/agent/fibre/orchestrator.py
+++ b/sagents/agent/fibre/orchestrator.py
@@ -14,6 +14,7 @@ import random
 import string
 import traceback
 import uuid
+from dataclasses import dataclass
 from typing import List, Dict, Any, Optional, Union, AsyncGenerator, TYPE_CHECKING
 import copy
 
@@ -33,6 +34,17 @@ from sagents.utils.subtask_summary import summarize_subtask_history
 from sagents.utils.logger import logger
 
 StreamPayload = Union[MessageChunk, Dict[str, Any]]
+
+
+@dataclass
+class _OrderedStreamBatch:
+    """A main-container batch whose producer waits for downstream persistence."""
+
+    chunks: List[StreamPayload]
+    persisted: asyncio.Future[None]
+
+
+StreamQueueItem = Optional[Union[List[StreamPayload], _OrderedStreamBatch]]
 
 
 class FibreOrchestrator:
@@ -67,6 +79,53 @@ class FibreOrchestrator:
         self.backend_client = FibreBackendClient()
 
         self.output_queue: Optional[asyncio.Queue] = None
+
+    @staticmethod
+    async def _queue_container_stream_batch(
+        output_queue: asyncio.Queue[StreamQueueItem],
+        chunks: List[StreamPayload],
+    ) -> None:
+        """Queue a main-agent batch and wait until its consumer has persisted it."""
+
+        persisted = asyncio.get_running_loop().create_future()
+        batch = _OrderedStreamBatch(chunks=list(chunks), persisted=persisted)
+        await output_queue.put(batch)
+        try:
+            await persisted
+        except asyncio.CancelledError:
+            if not persisted.done():
+                persisted.cancel()
+            raise
+
+    @staticmethod
+    def _queued_stream_chunks(item: StreamQueueItem) -> List[StreamPayload]:
+        if isinstance(item, _OrderedStreamBatch):
+            return item.chunks
+        return item or []
+
+    @staticmethod
+    def _finish_queued_stream_item(
+        item: StreamQueueItem, *, cancelled: bool = False
+    ) -> None:
+        if not isinstance(item, _OrderedStreamBatch) or item.persisted.done():
+            return
+        if cancelled:
+            item.persisted.cancel()
+        else:
+            item.persisted.set_result(None)
+
+    async def _yield_queued_stream_item(
+        self, item: StreamQueueItem
+    ) -> AsyncGenerator[List[StreamPayload], None]:
+        """Yield one queue item and acknowledge it when downstream resumes."""
+
+        try:
+            yield self._queued_stream_chunks(item)
+        except BaseException:
+            self._finish_queued_stream_item(item, cancelled=True)
+            raise
+        else:
+            self._finish_queued_stream_item(item)
 
     @staticmethod
     def _payload_session_id(payload: StreamPayload) -> Optional[str]:
@@ -210,7 +269,7 @@ class FibreOrchestrator:
         Similar to the original run_loop but uses the new architecture.
         """
         # Initialize Output Queue for merging streams
-        output_queue: asyncio.Queue[Optional[List[StreamPayload]]] = asyncio.Queue()
+        output_queue: asyncio.Queue[StreamQueueItem] = asyncio.Queue()
         self.output_queue = output_queue
 
         # Initialize Main Session Context
@@ -461,7 +520,7 @@ class FibreOrchestrator:
                     async for chunks in container_agent.run_stream(
                         session_context=session_context,
                     ):
-                        await output_queue.put(chunks)
+                        await self._queue_container_stream_batch(output_queue, chunks)
                 except Exception as e:
                     logger.error(f"Error in container stream: {e}", exc_info=True)
                     raise
@@ -481,8 +540,8 @@ class FibreOrchestrator:
                         if not producer_task.done():
                             producer_task.cancel()
                         break
-                    chunks = await output_queue.get()
-                    if chunks is None:
+                    queued_item = await output_queue.get()
+                    if queued_item is None:
                         break
                     if main_session.should_interrupt():
                         logger.warning(
@@ -490,12 +549,16 @@ class FibreOrchestrator:
                         )
                         if not producer_task.done():
                             producer_task.cancel()
+                        self._finish_queued_stream_item(
+                            queued_item, cancelled=True
+                        )
                         break
-                    yield chunks
+                    async for chunks in self._yield_queued_stream_item(queued_item):
+                        yield chunks
 
-                # Wait for producer to finish cleanly
-                if not producer_task.done():
-                    await producer_task
+                # Always await the producer so an exception that happened before
+                # the sentinel was consumed is observed and propagated.
+                await producer_task
 
                 # 这里不要提前把 main_session 标记为 COMPLETED。
                 # Fibre 的外层 Flow 还可能继续执行 self_check / 其他后续节点，
@@ -521,6 +584,10 @@ class FibreOrchestrator:
                     producer_task.cancel()
                 raise
         finally:
+            if "producer_task" in locals() and not producer_task.done():
+                producer_task.cancel()
+                await asyncio.gather(producer_task, return_exceptions=True)
+            self.output_queue = None
             # Save session state
             try:
                 if main_session and hasattr(main_session, "save_state"):

--- a/sagents/agent/self_check_agent.py
+++ b/sagents/agent/self_check_agent.py
@@ -35,8 +35,22 @@ class FileReference:
     require_absolute: bool = True
 
 
-ARTIFACT_TAGS = ("movo-artifacts", "ling-artifacts", "sage-artifacts", "artifacts")
+@dataclass(frozen=True)
+class MarkdownFileLink:
+    markdown: str
+    target: str
+    in_code: bool = False
+
+
+ARTIFACT_TAGS = (
+    "yiii-artifacts",
+    "movo-artifacts",
+    "ling-artifacts",
+    "sage-artifacts",
+    "artifacts",
+)
 QUESTIONNAIRE_TAGS = (
+    "yiii-questionnaire",
     "movo-questionnaire",
     "ling-questionnaire",
     "sage-questionnaire",
@@ -89,16 +103,21 @@ class SelfCheckAgent(AgentBase):
         structured_tag_issues = self._validate_structured_tag_payloads(
             latest_assistant_content
         )
+        markdown_link_issues = self._validate_markdown_file_link_syntax(
+            latest_assistant_content
+        )
         referenced_file_refs = self._collect_recent_file_references(session_context)
         logger.info(
             "SelfCheckAgent: collected "
             f"{len(referenced_file_refs)} referenced files for validation, "
-            f"{len(structured_tag_issues)} structured-tag issues"
+            f"{len(structured_tag_issues)} structured-tag issues, "
+            f"{len(markdown_link_issues)} Markdown-link issues"
         )
 
         if (
             not referenced_file_refs
             and not structured_tag_issues
+            and not markdown_link_issues
             and not has_structured_tags
         ):
             self._mark_passed(
@@ -106,7 +125,7 @@ class SelfCheckAgent(AgentBase):
             )
             return
 
-        issues: List[str] = list(structured_tag_issues)
+        issues: List[str] = [*structured_tag_issues, *markdown_link_issues]
         checked_files: List[str] = []
 
         for file_ref in sorted(
@@ -169,14 +188,9 @@ class SelfCheckAgent(AgentBase):
                     message_id=str(uuid.uuid4()),
                     agent_name=self.agent_name,
                     metadata={
-                        "hidden_from_chat": True,
-                        "hide_from_chat": True,
-                        "sse_visible": False,
-                        "llm_scope": "next_request",
-                        "llm_state": "pending",
-                        "llm_consumed_by": None,
-                        "llm_consumed_at": None,
-                        "runtime_diagnostic_source": "sage_self_check",
+                        **self._next_request_runtime_metadata(
+                            runtime_diagnostic_source="sage_self_check"
+                        ),
                         "self_check_passed": False,
                         "checked_files": checked_files,
                     },
@@ -238,10 +252,11 @@ class SelfCheckAgent(AgentBase):
             return set()
 
         referenced_file_refs: Set[FileReference] = set()
-        markdown_link_pattern = re.compile(r"\[[^\]]+\]\(([^)\s]+)\)")
 
-        for raw_path in markdown_link_pattern.findall(content):  # pyright: ignore[reportArgumentType,reportCallIssue]
-            normalized_path = self._normalize_raw_file_reference(raw_path)
+        for link in self._iter_markdown_file_links(content):
+            if link.in_code:
+                continue
+            normalized_path = self._normalize_raw_file_reference(link.target)
             if self._looks_like_file_path(normalized_path):
                 referenced_file_refs.add(
                     FileReference(path=normalized_path, require_absolute=True)
@@ -255,6 +270,372 @@ class SelfCheckAgent(AgentBase):
                 )
 
         return self._dedupe_referenced_file_refs(referenced_file_refs)
+
+    def _validate_markdown_file_link_syntax(self, content: str) -> List[str]:
+        """Reject local file links hidden inside Markdown code regions."""
+        if not content:
+            return []
+
+        issues: List[str] = []
+        seen_markdown: Set[str] = set()
+        for link in self._iter_markdown_file_links(content):
+            normalized_target = self._normalize_raw_file_reference(link.target)
+            if (
+                not link.in_code
+                or not self._looks_like_file_path(normalized_target)
+                or link.markdown in seen_markdown
+            ):
+                continue
+            seen_markdown.add(link.markdown)
+            issues.append(
+                "真实文件引用不能放在反引号或代码块中，请移除代码标记并直接输出标准 "
+                f"Markdown 文件链接：{link.markdown}"
+            )
+        return issues
+
+    def _iter_markdown_file_links(self, content: str):
+        code_ranges = self._markdown_code_ranges(content)
+        range_index = 0
+        index = 0
+        while index < len(content or ""):
+            markdown_start = index
+            if content.startswith("![", index):
+                label_start = index + 1
+            elif content[index] == "[":
+                label_start = index
+            else:
+                index += 1
+                continue
+
+            label_end = self._find_matching_markdown_bracket(
+                content, label_start, "[", "]"
+            )
+            if label_end is None or label_end + 1 >= len(content):
+                index = label_start + 1
+                continue
+            if content[label_end + 1] != "(":
+                index = label_end + 1
+                continue
+
+            parsed = self._parse_markdown_link_destination(content, label_end + 1)
+            if parsed is None:
+                index = label_end + 1
+                continue
+            markdown_end, target = parsed
+
+            while (
+                range_index < len(code_ranges)
+                and code_ranges[range_index][1] <= markdown_start
+            ):
+                range_index += 1
+            in_code = bool(
+                range_index < len(code_ranges)
+                and code_ranges[range_index][0]
+                <= markdown_start
+                < code_ranges[range_index][1]
+            )
+            yield MarkdownFileLink(
+                markdown=content[markdown_start:markdown_end],
+                target=target,
+                in_code=in_code,
+            )
+            index = markdown_end
+
+    @staticmethod
+    def _find_matching_markdown_bracket(
+        content: str,
+        start: int,
+        opening: str,
+        closing: str,
+    ) -> Optional[int]:
+        depth = 0
+        index = start
+        while index < len(content):
+            char = content[index]
+            if char == "\\" and index + 1 < len(content):
+                index += 2
+                continue
+            if char == opening:
+                depth += 1
+            elif char == closing:
+                depth -= 1
+                if depth == 0:
+                    return index
+            index += 1
+        return None
+
+    def _parse_markdown_link_destination(
+        self, content: str, opening_paren: int
+    ) -> Optional[tuple[int, str]]:
+        """Parse one inline-link destination and return end offset plus target."""
+
+        cursor = opening_paren + 1
+        while cursor < len(content) and content[cursor].isspace():
+            cursor += 1
+        if cursor >= len(content):
+            return None
+
+        if content[cursor] == "<":
+            target_start = cursor
+            cursor += 1
+            while cursor < len(content):
+                if content[cursor] == "\\" and cursor + 1 < len(content):
+                    cursor += 2
+                    continue
+                if content[cursor] == ">":
+                    target = content[target_start : cursor + 1]
+                    return self._finish_markdown_link_destination(
+                        content, cursor + 1, target
+                    )
+                if content[cursor] in "\r\n":
+                    return None
+                cursor += 1
+            return None
+
+        target_start = cursor
+        nested_parens = 0
+        while cursor < len(content):
+            char = content[cursor]
+            if char == "\\" and cursor + 1 < len(content):
+                cursor += 2
+                continue
+            if char == "(":
+                nested_parens += 1
+                cursor += 1
+                continue
+            if char == ")":
+                if nested_parens == 0:
+                    return cursor + 1, content[target_start:cursor]
+                nested_parens -= 1
+                cursor += 1
+                continue
+            if char.isspace() and nested_parens == 0:
+                return self._finish_markdown_link_destination(
+                    content, cursor, content[target_start:cursor]
+                )
+            cursor += 1
+        return None
+
+    def _finish_markdown_link_destination(
+        self, content: str, cursor: int, target: str
+    ) -> Optional[tuple[int, str]]:
+        separator_start = cursor
+        while cursor < len(content) and content[cursor].isspace():
+            cursor += 1
+        if cursor >= len(content):
+            return None
+        if content[cursor] == ")":
+            return cursor + 1, target
+        if cursor == separator_start:
+            return None
+
+        title_opener = content[cursor]
+        title_closer = {"\"": "\"", "'": "'", "(": ")"}.get(title_opener)
+        if title_closer is None:
+            return None
+        cursor += 1
+        title_depth = 1
+        while cursor < len(content):
+            char = content[cursor]
+            if char == "\\" and cursor + 1 < len(content):
+                cursor += 2
+                continue
+            if title_opener == "(" and char == "(":
+                title_depth += 1
+            elif char == title_closer:
+                title_depth -= 1
+                if title_depth == 0:
+                    cursor += 1
+                    break
+            if char in "\r\n":
+                return None
+            cursor += 1
+        else:
+            return None
+
+        while cursor < len(content) and content[cursor].isspace():
+            cursor += 1
+        if cursor < len(content) and content[cursor] == ")":
+            return cursor + 1, target
+        return None
+
+    def _markdown_code_ranges(self, content: str) -> List[tuple[int, int]]:
+        """Return fenced-block and inline-code ranges using Markdown delimiters."""
+
+        if not content:
+            return []
+
+        fenced_ranges: List[tuple[int, int]] = []
+        open_fence: Optional[tuple[str, int, int, int, int]] = None
+        offset = 0
+        for line in content.splitlines(keepends=True):
+            body = line.rstrip("\r\n")
+            if open_fence is None:
+                opener = self._markdown_fence_opener(body)
+                if opener is not None:
+                    marker_char, marker_len, quote_depth, max_close_indent = opener
+                    open_fence = (
+                        marker_char,
+                        marker_len,
+                        offset,
+                        quote_depth,
+                        max_close_indent,
+                    )
+            else:
+                (
+                    marker_char,
+                    marker_len,
+                    start,
+                    quote_depth,
+                    max_close_indent,
+                ) = open_fence
+                if self._is_markdown_fence_closer(
+                    body,
+                    marker_char=marker_char,
+                    marker_len=marker_len,
+                    quote_depth=quote_depth,
+                    max_indent=max_close_indent,
+                ):
+                    fenced_ranges.append((start, offset + len(line)))
+                    open_fence = None
+            offset += len(line)
+        if open_fence is not None:
+            fenced_ranges.append((open_fence[2], len(content)))
+
+        inline_ranges: List[tuple[int, int]] = []
+        for start, end in self._markdown_inline_blocks(content, fenced_ranges):
+            inline_ranges.extend(self._markdown_inline_code_ranges(content, start, end))
+
+        return sorted([*fenced_ranges, *inline_ranges])
+
+    @staticmethod
+    def _strip_markdown_blockquote_prefix(body: str) -> tuple[int, str]:
+        quote_depth = 0
+        remaining = body
+        while True:
+            match = re.match(r" {0,3}>[ \t]?", remaining)
+            if match is None:
+                break
+            quote_depth += 1
+            remaining = remaining[match.end() :]
+        return quote_depth, remaining
+
+    def _markdown_fence_opener(
+        self, body: str
+    ) -> Optional[tuple[str, int, int, int]]:
+        quote_depth, remaining = self._strip_markdown_blockquote_prefix(body)
+        leading_spaces = len(remaining) - len(remaining.lstrip(" "))
+        if leading_spaces > 3:
+            return None
+
+        candidate = remaining[leading_spaces:]
+        list_match = re.match(r"(?:[-+*]|\d{1,9}[.)])[ \t]+", candidate)
+        if list_match is not None:
+            content_indent = leading_spaces + list_match.end()
+            candidate = candidate[list_match.end() :]
+            max_close_indent = content_indent + 3
+        else:
+            max_close_indent = 3
+
+        marker_match = re.match(r"(`{3,}|~{3,})(.*)$", candidate)
+        if marker_match is None:
+            return None
+        marker = marker_match.group(1)
+        info = marker_match.group(2)
+        if marker.startswith("`") and "`" in info:
+            return None
+        return marker[0], len(marker), quote_depth, max_close_indent
+
+    def _is_markdown_fence_closer(
+        self,
+        body: str,
+        *,
+        marker_char: str,
+        marker_len: int,
+        quote_depth: int,
+        max_indent: int,
+    ) -> bool:
+        actual_quote_depth, remaining = self._strip_markdown_blockquote_prefix(body)
+        if actual_quote_depth != quote_depth:
+            return False
+        leading_spaces = len(remaining) - len(remaining.lstrip(" "))
+        if leading_spaces > max_indent:
+            return False
+        candidate = remaining[leading_spaces:]
+        return bool(
+            re.fullmatch(
+                rf"{re.escape(marker_char)}{{{marker_len},}}[ \t]*",
+                candidate,
+            )
+        )
+
+    @staticmethod
+    def _markdown_inline_blocks(
+        content: str, fenced_ranges: List[tuple[int, int]]
+    ) -> List[tuple[int, int]]:
+        available_ranges: List[tuple[int, int]] = []
+        cursor = 0
+        for start, end in fenced_ranges:
+            if cursor < start:
+                available_ranges.append((cursor, start))
+            cursor = max(cursor, end)
+        if cursor < len(content):
+            available_ranges.append((cursor, len(content)))
+
+        blocks: List[tuple[int, int]] = []
+        for available_start, available_end in available_ranges:
+            block_start: Optional[int] = None
+            offset = available_start
+            for line in content[available_start:available_end].splitlines(
+                keepends=True
+            ):
+                line_end = offset + len(line)
+                if line.rstrip("\r\n").strip():
+                    if block_start is None:
+                        block_start = offset
+                elif block_start is not None:
+                    blocks.append((block_start, offset))
+                    block_start = None
+                offset = line_end
+            if block_start is not None:
+                blocks.append((block_start, available_end))
+        return blocks
+
+    @staticmethod
+    def _markdown_inline_code_ranges(
+        content: str, start: int, end: int
+    ) -> List[tuple[int, int]]:
+        ranges: List[tuple[int, int]] = []
+        index = start
+        while index < end:
+            if content[index] != "`":
+                index += 1
+                continue
+            opener_end = index + 1
+            while opener_end < end and content[opener_end] == "`":
+                opener_end += 1
+            delimiter_len = opener_end - index
+            search_at = opener_end
+            closing_end: Optional[int] = None
+            while search_at < end:
+                closing_start = content.find("`", search_at, end)
+                if closing_start < 0:
+                    break
+                candidate_end = closing_start + 1
+                while (
+                    candidate_end < end and content[candidate_end] == "`"
+                ):
+                    candidate_end += 1
+                if candidate_end - closing_start == delimiter_len:
+                    closing_end = candidate_end
+                    break
+                search_at = candidate_end
+            if closing_end is None:
+                index = opener_end
+                continue
+            ranges.append((index, closing_end))
+            index = closing_end
+        return ranges
 
     def _content_has_structured_tags(self, content: str) -> bool:
         for _tag_name, _raw_payload in self._iter_structured_tag_matches(content):
@@ -331,6 +712,11 @@ class SelfCheckAgent(AgentBase):
     def _validate_questionnaire_payload(
         self, tag_name: str, payload: Dict[str, Any]
     ) -> List[str]:
+        strict_yiii = tag_name == "yiii-questionnaire"
+        if strict_yiii:
+            title = payload.get("title")
+            if not isinstance(title, str) or not title.strip():
+                return [f"<{tag_name}> 缺少合法的 title 字段"]
         questions = payload.get("questions")
         if not isinstance(questions, list):
             return [f"<{tag_name}> 缺少合法的 questions 数组"]
@@ -343,11 +729,49 @@ class SelfCheckAgent(AgentBase):
             if not isinstance(text, str) or not text.strip():
                 return [f"<{tag_name}> questions[{index}] 缺少合法的 text 字段"]
             question_type = str(question.get("type") or "").strip().lower()
+            if strict_yiii and question_type not in {
+                "single_choice",
+                "multi_choice",
+                "free_text",
+            }:
+                return [
+                    f"<{tag_name}> questions[{index}] 的 type 不受支持: "
+                    f"{question_type or '空'}"
+                ]
             if question_type in {"single_choice", "multi_choice", "multiple_choice"}:
                 options = question.get("options")
-                if not isinstance(options, list) or not options:
+                if (
+                    not isinstance(options, list)
+                    or not options
+                    or any(
+                        not isinstance(option, str) or not option.strip()
+                        for option in options
+                    )
+                ):
                     return [
                         f"<{tag_name}> questions[{index}] 的选择题必须提供非空 options"
+                    ]
+            if strict_yiii:
+                if "default" not in question:
+                    return [
+                        f"<{tag_name}> questions[{index}] 缺少 default 字段"
+                    ]
+                default = question.get("default")
+                if question_type == "multi_choice":
+                    if not isinstance(default, list) or any(
+                        not isinstance(value, str) for value in default
+                    ):
+                        return [
+                            f"<{tag_name}> questions[{index}] 的 default 必须是字符串数组"
+                        ]
+                elif not isinstance(default, str):
+                    return [
+                        f"<{tag_name}> questions[{index}] 的 default 必须是字符串"
+                    ]
+                allow_other = question.get("allow_other")
+                if allow_other is not None and not isinstance(allow_other, bool):
+                    return [
+                        f"<{tag_name}> questions[{index}] 的 allow_other 必须是布尔值"
                     ]
         return []
 
@@ -446,6 +870,9 @@ class SelfCheckAgent(AgentBase):
         path = str(raw_path or "").strip().strip("`").strip("'\"")
         if not path:
             return path
+        if path.startswith("<") and path.endswith(">"):
+            path = path[1:-1].strip()
+        path = re.sub(r"\\([!\"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])", r"\1", path)
         if path.startswith("file://"):
             path = re.sub(r"^file:///?", "/", path)
         path = unquote(path)

--- a/sagents/agent/self_check_agent.py
+++ b/sagents/agent/self_check_agent.py
@@ -502,11 +502,15 @@ class SelfCheckAgent(AgentBase):
         if open_fence is not None:
             fenced_ranges.append((open_fence[2], len(content)))
 
+        indented_ranges = self._markdown_indented_code_ranges(
+            content, fenced_ranges
+        )
+        block_ranges = sorted([*fenced_ranges, *indented_ranges])
         inline_ranges: List[tuple[int, int]] = []
-        for start, end in self._markdown_inline_blocks(content, fenced_ranges):
+        for start, end in self._markdown_inline_blocks(content, block_ranges):
             inline_ranges.extend(self._markdown_inline_code_ranges(content, start, end))
 
-        return sorted([*fenced_ranges, *inline_ranges])
+        return sorted([*block_ranges, *inline_ranges])
 
     @staticmethod
     def _strip_markdown_blockquote_prefix(body: str) -> tuple[int, str]:
@@ -569,13 +573,96 @@ class SelfCheckAgent(AgentBase):
             )
         )
 
+    def _markdown_indented_code_ranges(
+        self,
+        content: str,
+        excluded_ranges: List[tuple[int, int]],
+    ) -> List[tuple[int, int]]:
+        """Return four-column indented code blocks outside fenced blocks."""
+
+        ranges: List[tuple[int, int]] = []
+        open_start: Optional[int] = None
+        open_end: Optional[int] = None
+        open_quote_depth: Optional[int] = None
+        previous_line_blank = True
+        excluded_index = 0
+        offset = 0
+
+        for line in content.splitlines(keepends=True):
+            line_end = offset + len(line)
+            while (
+                excluded_index < len(excluded_ranges)
+                and excluded_ranges[excluded_index][1] <= offset
+            ):
+                excluded_index += 1
+            is_excluded = bool(
+                excluded_index < len(excluded_ranges)
+                and excluded_ranges[excluded_index][0] < line_end
+                and offset < excluded_ranges[excluded_index][1]
+            )
+
+            body = line.rstrip("\r\n")
+            quote_depth, remaining = self._strip_markdown_blockquote_prefix(body)
+            is_blank = not remaining.strip()
+            is_indented = (
+                not is_blank and self._markdown_indentation_width(remaining) >= 4
+            )
+
+            if is_excluded:
+                if open_start is not None and open_end is not None:
+                    ranges.append((open_start, open_end))
+                    open_start = None
+                    open_end = None
+                    open_quote_depth = None
+                # A fenced block is already a block boundary, so an indented
+                # block may begin immediately after its closing line.
+                previous_line_blank = True
+                offset = line_end
+                continue
+
+            same_container = (
+                open_quote_depth is None or quote_depth == open_quote_depth
+            )
+            if open_start is not None and (is_blank or (is_indented and same_container)):
+                open_end = line_end
+            else:
+                if open_start is not None and open_end is not None:
+                    ranges.append((open_start, open_end))
+                    open_start = None
+                    open_end = None
+                    open_quote_depth = None
+
+                if is_indented and previous_line_blank:
+                    open_start = offset
+                    open_end = line_end
+                    open_quote_depth = quote_depth
+
+            previous_line_blank = is_blank
+            offset = line_end
+
+        if open_start is not None and open_end is not None:
+            ranges.append((open_start, open_end))
+        return ranges
+
+    @staticmethod
+    def _markdown_indentation_width(text: str) -> int:
+        width = 0
+        for char in text:
+            if char == " ":
+                width += 1
+            elif char == "\t":
+                width += 4 - (width % 4)
+            else:
+                break
+        return width
+
     @staticmethod
     def _markdown_inline_blocks(
-        content: str, fenced_ranges: List[tuple[int, int]]
+        content: str, code_block_ranges: List[tuple[int, int]]
     ) -> List[tuple[int, int]]:
         available_ranges: List[tuple[int, int]] = []
         cursor = 0
-        for start, end in fenced_ranges:
+        for start, end in code_block_ranges:
             if cursor < start:
                 available_ranges.append((cursor, start))
             cursor = max(cursor, end)
@@ -611,6 +698,9 @@ class SelfCheckAgent(AgentBase):
             if content[index] != "`":
                 index += 1
                 continue
+            if SelfCheckAgent._is_markdown_character_escaped(content, index, start):
+                index += 1
+                continue
             opener_end = index + 1
             while opener_end < end and content[opener_end] == "`":
                 opener_end += 1
@@ -636,6 +726,17 @@ class SelfCheckAgent(AgentBase):
             ranges.append((index, closing_end))
             index = closing_end
         return ranges
+
+    @staticmethod
+    def _is_markdown_character_escaped(
+        content: str, index: int, range_start: int = 0
+    ) -> bool:
+        backslash_count = 0
+        cursor = index - 1
+        while cursor >= range_start and content[cursor] == "\\":
+            backslash_count += 1
+            cursor -= 1
+        return backslash_count % 2 == 1
 
     def _content_has_structured_tags(self, content: str) -> bool:
         for _tag_name, _raw_payload in self._iter_structured_tag_matches(content):

--- a/sagents/agent/simple_agent.py
+++ b/sagents/agent/simple_agent.py
@@ -1242,6 +1242,8 @@ class SimpleAgent(AgentBase):
                     ),
                 )
                 all_new_response_chunks.append(correction_chunk)
+                # 内部有序 batch：由 FlowExecutor 先写入 ledger，再依据 metadata
+                # 从所有客户端出口过滤。Team/Fibre 会等待该 batch 的落盘确认。
                 yield [correction_chunk]
             else:
                 repeat_pattern_hits = 0

--- a/sagents/agent/team/orchestrator.py
+++ b/sagents/agent/team/orchestrator.py
@@ -47,7 +47,7 @@ class TeamOrchestrator(FibreOrchestrator):
         session_context: SessionContext,
         max_loop_count: int,
     ) -> AsyncGenerator[List[MessageChunk], None]:
-        output_queue: asyncio.Queue[Optional[List[Any]]] = asyncio.Queue()
+        output_queue: asyncio.Queue = asyncio.Queue()
         self.output_queue = output_queue
 
         session_context.orchestrator = self
@@ -89,7 +89,7 @@ class TeamOrchestrator(FibreOrchestrator):
                     async for chunks in container_agent.run_stream(
                         session_context=session_context,
                     ):
-                        await output_queue.put(chunks)
+                        await self._queue_container_stream_batch(output_queue, chunks)
                 except Exception as e:
                     logger.error(f"Error in team container stream: {e}", exc_info=True)
                     raise
@@ -107,17 +107,22 @@ class TeamOrchestrator(FibreOrchestrator):
                         if not producer_task.done():
                             producer_task.cancel()
                         break
-                    chunks = await output_queue.get()
-                    if chunks is None:
+                    queued_item = await output_queue.get()
+                    if queued_item is None:
                         break
                     if main_session.should_interrupt():
                         if not producer_task.done():
                             producer_task.cancel()
+                        self._finish_queued_stream_item(
+                            queued_item, cancelled=True
+                        )
                         break
-                    yield chunks
+                    async for chunks in self._yield_queued_stream_item(queued_item):
+                        yield chunks
 
-                if not producer_task.done():
-                    await producer_task
+                # Always await the producer so an exception that happened before
+                # the sentinel was consumed is observed and propagated.
+                await producer_task
 
                 if main_session.should_interrupt():
                     main_session.set_status(SessionStatus.INTERRUPTED, cascade=False)
@@ -133,6 +138,10 @@ class TeamOrchestrator(FibreOrchestrator):
                     producer_task.cancel()
                 raise
         finally:
+            if "producer_task" in locals() and not producer_task.done():
+                producer_task.cancel()
+                await asyncio.gather(producer_task, return_exceptions=True)
+            self.output_queue = None
             try:
                 if main_session and hasattr(main_session, "save_state"):
                     main_session.save_state()  # pyright: ignore[reportAttributeAccessIssue]

--- a/sagents/context/messages/message.py
+++ b/sagents/context/messages/message.py
@@ -368,3 +368,23 @@ class MessageChunk:
                 pass
         logger.debug("未找到有效JSON，返回原始内容")
         return content
+
+
+def is_message_client_visible(message: Any) -> bool:
+    """Return whether a message may cross a client-facing stream boundary.
+
+    Accept both ``MessageChunk`` instances and their serialized dictionaries so
+    every stream/history adapter applies exactly the same visibility contract.
+    """
+
+    if isinstance(message, dict):
+        metadata = message.get("metadata")
+    else:
+        metadata = getattr(message, "metadata", None)
+    if not isinstance(metadata, dict):
+        return True
+    return not (
+        metadata.get("hidden_from_chat") is True
+        or metadata.get("hide_from_chat") is True
+        or metadata.get("sse_visible") is False
+    )

--- a/sagents/flow/executor.py
+++ b/sagents/flow/executor.py
@@ -12,7 +12,7 @@ from sagents.flow.schema import (
 )
 from sagents.flow.conditions import ConditionRegistry
 from sagents.utils.logger import logger
-from sagents.context.messages.message import MessageChunk
+from sagents.context.messages.message import MessageChunk, is_message_client_visible
 from sagents.context.session_context import SessionStatus
 
 
@@ -51,23 +51,10 @@ def _message_manager_debug_id(ctx: Any) -> Optional[int]:
     return id(message_manager)
 
 
-def _should_suppress_chunk_from_flow_stream(chunk: MessageChunk) -> bool:
-    metadata = chunk.metadata if isinstance(chunk.metadata, dict) else {}
-    return (
-        metadata.get("sse_visible") is False
-        or metadata.get("hidden_from_chat") is True
-        or metadata.get("hide_from_chat") is True
-    )
-
-
 def _visible_chunks_for_flow_stream(
     message_chunks: List[MessageChunk],
 ) -> List[MessageChunk]:
-    return [
-        chunk
-        for chunk in message_chunks
-        if not _should_suppress_chunk_from_flow_stream(chunk)
-    ]
+    return [chunk for chunk in message_chunks if is_message_client_visible(chunk)]
 
 
 class _FlowExecutionTrace:

--- a/sagents/sagents.py
+++ b/sagents/sagents.py
@@ -5,7 +5,12 @@ import uuid
 from dataclasses import dataclass, field, replace
 from typing import Any, AsyncGenerator, Dict, FrozenSet, List, Optional, Tuple, Union
 
-from sagents.context.messages.message import MessageChunk, MessageRole, MessageType
+from sagents.context.messages.message import (
+    MessageChunk,
+    MessageRole,
+    MessageType,
+    is_message_client_visible,
+)
 from sagents.skill import SkillManager, SkillProxy
 from sagents.tool import ToolManager, ToolProxy
 from sagents.tool.impl import HIDDEN_FROM_STREAM_TOOL_NAMES
@@ -140,12 +145,7 @@ def _redact_hidden_tools_from_chunk(
 
 
 def _should_suppress_chunk_from_client_stream(chunk: MessageChunk) -> bool:
-    metadata = chunk.metadata if isinstance(chunk.metadata, dict) else {}
-    return (
-        metadata.get("sse_visible") is False
-        or metadata.get("hidden_from_chat") is True
-        or metadata.get("hide_from_chat") is True
-    )
+    return not is_message_client_visible(chunk)
 
 
 class SAgent:

--- a/sagents/session_runtime.py
+++ b/sagents/session_runtime.py
@@ -27,7 +27,12 @@ from sagents.agent import (
     PlanAgent,
     SelfCheckAgent,
 )
-from sagents.context.messages.message import MessageChunk, MessageRole, MessageType
+from sagents.context.messages.message import (
+    MessageChunk,
+    MessageRole,
+    MessageType,
+    is_message_client_visible,
+)
 from sagents.context.session_context import (
     SessionContext,
     SessionStatus,
@@ -1567,11 +1572,7 @@ def build_conversation_messages_view(session_id: str) -> Dict[str, Any]:
     seen_message_keys = set()
 
     def is_hidden_context_message(message_dict: Dict[str, Any]) -> bool:
-        metadata = message_dict.get("metadata")
-        return isinstance(metadata, dict) and (
-            metadata.get("hidden_from_chat") is True
-            or metadata.get("hide_from_chat") is True
-        )
+        return not is_message_client_visible(message_dict)
 
     def append_message(message_dict: Dict[str, Any]):
         if is_hidden_context_message(message_dict):

--- a/tests/sagents/agent/test_agent_base_parallel_tool_calls.py
+++ b/tests/sagents/agent/test_agent_base_parallel_tool_calls.py
@@ -68,6 +68,24 @@ class _FakeSessionContext:
         return self.language
 
 
+def test_next_request_runtime_metadata_keeps_visibility_and_lifecycle_fixed():
+    metadata = ParallelToolAgent._next_request_runtime_metadata(
+        hidden_from_chat=False,
+        hide_from_chat=False,
+        sse_visible=True,
+        llm_scope="durable",
+        llm_state="consumed",
+        runtime_notice="test_notice",
+    )
+
+    assert metadata["hidden_from_chat"] is True
+    assert metadata["hide_from_chat"] is True
+    assert metadata["sse_visible"] is False
+    assert metadata["llm_scope"] == "next_request"
+    assert metadata["llm_state"] == "pending"
+    assert metadata["runtime_notice"] == "test_notice"
+
+
 @pytest.mark.asyncio
 async def test_handle_tool_calls_runs_tools_concurrently_with_limit_10(monkeypatch):
     agent = ParallelToolAgent(expected_starts=3)
@@ -172,6 +190,8 @@ async def test_invalid_tool_call_arguments_become_hidden_localized_runtime_diagn
     assert message.metadata["sse_visible"] is False
     assert message.metadata["hidden_from_chat"] is True
     assert message.metadata["hide_from_chat"] is True
+    assert message.metadata["llm_scope"] == "next_request"
+    assert message.metadata["llm_state"] == "pending"
     assert message.metadata["runtime_diagnostic_source"] == "tool_call_argument_parse"
 
     request_messages = MessageManager.convert_messages_to_dict_for_request(

--- a/tests/sagents/agent/test_fibre_orchestrator.py
+++ b/tests/sagents/agent/test_fibre_orchestrator.py
@@ -2,11 +2,128 @@ import asyncio
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from sagents.agent.fibre.agent_definition import AgentDefinition
 from sagents.agent.fibre.orchestrator import FibreOrchestrator
 from sagents.context.messages.message import MessageChunk
 from sagents.context.session_context import SessionContext
 from sagents.tool import ToolManager
+
+
+def test_ordered_stream_batch_waits_until_downstream_resumes():
+    async def scenario():
+        orchestrator = FibreOrchestrator.__new__(FibreOrchestrator)
+        queue = asyncio.Queue()
+        chunks = [MessageChunk(role="assistant", content="first")]
+        producer = asyncio.create_task(
+            orchestrator._queue_container_stream_batch(queue, chunks)
+        )
+
+        queued_item = await queue.get()
+        await asyncio.sleep(0)
+        assert producer.done() is False
+
+        stream = orchestrator._yield_queued_stream_item(queued_item)
+        assert await anext(stream) == chunks
+        assert producer.done() is False
+
+        with pytest.raises(StopAsyncIteration):
+            await anext(stream)
+        await asyncio.wait_for(producer, timeout=1)
+
+    asyncio.run(scenario())
+
+
+def test_ordered_stream_batch_close_cancels_waiting_producer():
+    async def scenario():
+        orchestrator = FibreOrchestrator.__new__(FibreOrchestrator)
+        queue = asyncio.Queue()
+        chunks = [MessageChunk(role="assistant", content="first")]
+        producer = asyncio.create_task(
+            orchestrator._queue_container_stream_batch(queue, chunks)
+        )
+
+        queued_item = await queue.get()
+        stream = orchestrator._yield_queued_stream_item(queued_item)
+        assert await anext(stream) == chunks
+        await stream.aclose()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(producer, timeout=1)
+        assert queued_item.persisted.cancelled() is True
+
+    asyncio.run(scenario())
+
+
+def test_ordered_stream_batch_downstream_error_cancels_ack():
+    async def scenario():
+        orchestrator = FibreOrchestrator.__new__(FibreOrchestrator)
+        queue = asyncio.Queue()
+        chunks = [MessageChunk(role="assistant", content="first")]
+        producer = asyncio.create_task(
+            orchestrator._queue_container_stream_batch(queue, chunks)
+        )
+
+        queued_item = await queue.get()
+        stream = orchestrator._yield_queued_stream_item(queued_item)
+        assert await anext(stream) == chunks
+        with pytest.raises(RuntimeError, match="persistence failed"):
+            await stream.athrow(RuntimeError("persistence failed"))
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(producer, timeout=1)
+        assert queued_item.persisted.cancelled() is True
+
+    asyncio.run(scenario())
+
+
+def test_ordered_stream_batch_producer_cancellation_cancels_ack():
+    async def scenario():
+        orchestrator = FibreOrchestrator.__new__(FibreOrchestrator)
+        queue = asyncio.Queue()
+        producer = asyncio.create_task(
+            orchestrator._queue_container_stream_batch(
+                queue, [MessageChunk(role="assistant", content="first")]
+            )
+        )
+
+        queued_item = await queue.get()
+        producer.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await producer
+        assert queued_item.persisted.cancelled() is True
+
+    asyncio.run(scenario())
+
+
+def test_ordered_stream_ack_keeps_runtime_correction_after_previous_batch():
+    async def scenario():
+        orchestrator = FibreOrchestrator.__new__(FibreOrchestrator)
+        queue = asyncio.Queue()
+        ledger = []
+        previous = MessageChunk(role="tool", content="result", tool_call_id="call-1")
+        correction = MessageChunk(
+            role="assistant",
+            content="correct the next attempt",
+            metadata={"llm_scope": "next_request", "sse_visible": False},
+        )
+
+        async def producer():
+            await orchestrator._queue_container_stream_batch(queue, [previous])
+            ledger.append(correction)
+
+        producer_task = asyncio.create_task(producer())
+        queued_item = await queue.get()
+        stream = orchestrator._yield_queued_stream_item(queued_item)
+        yielded = await anext(stream)
+        ledger.extend(yielded)
+        assert ledger == [previous]
+
+        with pytest.raises(StopAsyncIteration):
+            await anext(stream)
+        await asyncio.wait_for(producer_task, timeout=1)
+        assert ledger == [previous, correction]
+
+    asyncio.run(scenario())
 
 
 class _FakeSessionManager:

--- a/tests/sagents/agent/test_simple_agent_finish_summary.py
+++ b/tests/sagents/agent/test_simple_agent_finish_summary.py
@@ -6,7 +6,12 @@
 import asyncio
 from types import SimpleNamespace
 
-from sagents.context.messages.message import MessageChunk, MessageRole, MessageType
+from sagents.context.messages.message import (
+    MessageChunk,
+    MessageRole,
+    MessageType,
+    is_message_client_visible,
+)
 from sagents.agent.simple_agent import (
     DEFAULT_REPEAT_PATTERN_MAX_HITS,
     REPEAT_PATTERN_MAX_HITS_ENV,
@@ -127,16 +132,24 @@ def _patch_tool_handler(monkeypatch, agent, seen_tool_calls):
 
 
 def _loop_session_context(max_loop_count=4):
+    stored_messages = []
     msg_manager = SimpleNamespace(
         get_recent_loop_signatures=lambda: [],
         add_loop_signature=lambda signature: None,
     )
-    return SimpleNamespace(
+    context = SimpleNamespace(
         agent_config={"max_loop_count": max_loop_count},
         audit_status={},
         message_manager=msg_manager,
         get_language=lambda: "zh",
+        stored_messages=stored_messages,
     )
+
+    def _add_messages(messages):
+        stored_messages.extend(messages if isinstance(messages, list) else [messages])
+
+    context.add_messages = _add_messages
+    return context
 
 
 def test_status_only_turn_status_response_suppresses_duplicate_text(monkeypatch):
@@ -2216,6 +2229,8 @@ def test_repeat_pattern_self_correction_is_internal_context(monkeypatch):
         agent, "_call_llm_and_process_response", _fake_call_llm_and_process_response
     )
 
+    session_context = _loop_session_context()
+
     async def _collect():
         chunks = []
         async for yielded_chunks in agent._execute_loop(
@@ -2223,8 +2238,9 @@ def test_repeat_pattern_self_correction_is_internal_context(monkeypatch):
             tools_json=[],
             tool_manager=None,
             session_id="s-repeat-internal",
-            session_context=_loop_session_context(),  # pyright: ignore[reportArgumentType]
+            session_context=session_context,  # pyright: ignore[reportArgumentType]
         ):
+            session_context.add_messages(yielded_chunks)
             chunks.extend(yielded_chunks)
         return chunks
 
@@ -2233,19 +2249,17 @@ def test_repeat_pattern_self_correction_is_internal_context(monkeypatch):
     assert len(direct_calls) == 3
     correction_chunks = [
         chunk
-        for chunk in chunks
+        for chunk in session_context.stored_messages
         if (chunk.metadata or {}).get("runtime_diagnostic_source")
         == "repeat_pattern_correction"
     ]
     assert len(correction_chunks) == 1
     assert correction_chunks[0].metadata["hidden_from_chat"] is True
+    assert correction_chunks[0].metadata["hide_from_chat"] is True
     assert correction_chunks[0].metadata["sse_visible"] is False
-    visible_chunks = [
-        chunk
-        for chunk in chunks
-        if (chunk.metadata or {}).get("hidden_from_chat") is not True
-        and (chunk.metadata or {}).get("sse_visible") is not False
-    ]
+    assert correction_chunks[0].metadata["llm_scope"] == "next_request"
+    assert correction_chunks[0].metadata["llm_state"] == "pending"
+    visible_chunks = [chunk for chunk in chunks if is_message_client_visible(chunk)]
     assert [chunk.content for chunk in visible_chunks] == [
         '{"ok": false, "reason": "same"}',
         '{"ok": false, "reason": "same"}',

--- a/tests/sagents/agent/test_tool_expansion_prepare.py
+++ b/tests/sagents/agent/test_tool_expansion_prepare.py
@@ -133,7 +133,10 @@ def test_task_executor_rejects_tool_not_in_current_llm_tools(monkeypatch):
     assert "beta_tool" in errors[0].content
     assert errors[0].metadata["runtime_notice"] == "unavailable_tool_rejected"
     assert errors[0].metadata["hidden_from_chat"] is True
+    assert errors[0].metadata["hide_from_chat"] is True
     assert errors[0].metadata["sse_visible"] is False
+    assert errors[0].metadata["llm_scope"] == "next_request"
+    assert errors[0].metadata["llm_state"] == "pending"
     rejected_results = [
         item
         for item in out

--- a/tests/sagents/messages/test_message_types.py
+++ b/tests/sagents/messages/test_message_types.py
@@ -3,6 +3,7 @@ from sagents.context.messages.message import (
     MessageRole,
     MessageType,
     is_execution_error_message_type,
+    is_message_client_visible,
 )
 from sagents.context.messages.message_manager import MessageManager
 
@@ -78,6 +79,20 @@ def test_next_request_message_is_included_only_while_pending():
     message.metadata["llm_state"] = "consumed"
     consumed = MessageManager.convert_messages_to_dict_for_request([message])
     assert consumed == []
+
+
+def test_client_visibility_contract_accepts_chunks_and_serialized_messages():
+    visible = MessageChunk(role=MessageRole.ASSISTANT.value, content="visible")
+    hidden = MessageChunk(
+        role=MessageRole.ASSISTANT.value,
+        content="internal",
+        metadata={"sse_visible": False},
+    )
+
+    assert is_message_client_visible(visible) is True
+    assert is_message_client_visible(visible.to_dict()) is True
+    assert is_message_client_visible(hidden) is False
+    assert is_message_client_visible(hidden.to_dict()) is False
 
 
 def test_hidden_durable_image_context_remains_in_llm_request():

--- a/tests/sagents/test_self_check_agent_paths.py
+++ b/tests/sagents/test_self_check_agent_paths.py
@@ -721,6 +721,50 @@ def test_markdown_code_regions_reject_local_file_links(monkeypatch):
         assert "真实文件引用不能放在反引号或代码块中" in issues[0]
 
 
+def test_markdown_indented_code_blocks_reject_local_file_links(monkeypatch):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+
+    samples = [
+        "    [report.md](file:///tmp/report.md)",
+        "\t[report.md](file:///tmp/report.md)",
+        ">     [report.md](file:///tmp/report.md)",
+        "结果如下：\n\n    [report.md](file:///tmp/report.md)",
+    ]
+
+    for content in samples:
+        issues = agent._validate_markdown_file_link_syntax(content)
+        assert len(issues) == 1, content
+        assert "真实文件引用不能放在反引号或代码块中" in issues[0]
+
+
+def test_indented_paragraph_continuation_keeps_file_link_clickable(monkeypatch):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+    content = "结果如下：\n    [report.md](file:///tmp/report.md)"
+
+    assert agent._validate_markdown_file_link_syntax(content) == []
+
+
+def test_escaped_backticks_do_not_hide_clickable_file_link(monkeypatch):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+    content = r"\`[report.md](file:///tmp/report.md)\`"
+    session_context = SimpleNamespace(
+        message_manager=SimpleNamespace(
+            messages=[
+                _make_message("user", "检查"),
+                _make_message("assistant", content),
+            ]
+        )
+    )
+
+    assert agent._validate_markdown_file_link_syntax(content) == []
+    assert agent._collect_recent_referenced_files(session_context) == {
+        "/tmp/report.md"
+    }
+
+
 def test_code_file_links_are_not_collected_as_clickable_artifacts(monkeypatch):
     self_check_agent = _load_self_check_agent(monkeypatch)
     agent = self_check_agent(model=None, model_config={})

--- a/tests/sagents/test_self_check_agent_paths.py
+++ b/tests/sagents/test_self_check_agent_paths.py
@@ -63,6 +63,19 @@ def _load_self_check_agent(monkeypatch):
         def _should_abort_due_to_session(self, session_context):
             return False
 
+        @staticmethod
+        def _next_request_runtime_metadata(**extra):
+            return {
+                "hidden_from_chat": True,
+                "hide_from_chat": True,
+                "sse_visible": False,
+                "llm_scope": "next_request",
+                "llm_state": "pending",
+                "llm_consumed_by": None,
+                "llm_consumed_at": None,
+                **extra,
+            }
+
     agent_base_module.AgentBase = AgentBase  # pyright: ignore[reportAttributeAccessIssue]
     monkeypatch.setitem(sys.modules, "sagents.agent.agent_base", agent_base_module)
 
@@ -90,7 +103,10 @@ def _make_message(role, content):
 def _assert_hidden_self_check_message(chunk):
     assert chunk.role == "user"
     assert chunk.metadata["hidden_from_chat"] is True
+    assert chunk.metadata["hide_from_chat"] is True
     assert chunk.metadata["sse_visible"] is False
+    assert chunk.metadata["llm_scope"] == "next_request"
+    assert chunk.metadata["llm_state"] == "pending"
     assert chunk.metadata["runtime_diagnostic_source"] == "sage_self_check"
 
 
@@ -529,6 +545,87 @@ def test_malformed_questionnaire_model_payload_triggers_execution_error(
     _assert_hidden_self_check_message(chunks[0])
 
 
+def test_malformed_yiii_questionnaire_from_session_triggers_execution_error(
+    monkeypatch, tmp_path
+):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    class DummySandbox:
+        async def file_exists(self, path):
+            return True
+
+    malformed_payload = (
+        '<yiii-questionnaire>{"title":"视频Brief确认","questions":'
+        '[{"type":"single_choice","text":"执行？",'
+        '"options":["执行生成视频计划","调整视频计划"],'
+        '"default":"执行生成视频计划"}]}></yiii-questionnaire>'
+    )
+    session_context = SimpleNamespace(
+        audit_status={},
+        sandbox=DummySandbox(),
+        sandbox_agent_workspace=str(workspace),
+        system_context={"private_workspace": str(workspace)},
+        message_manager=SimpleNamespace(
+            messages=[
+                _make_message("user", "请确认"),
+                _make_message("assistant", malformed_payload),
+            ]
+        ),
+    )
+
+    async def collect():
+        chunks = []
+        async for batch in agent.run_stream(session_context):
+            chunks.extend(batch)
+        return chunks
+
+    chunks = asyncio.run(collect())
+
+    assert session_context.audit_status["self_check_passed"] is False
+    assert "<yiii-questionnaire> 标签内容不是合法 JSON" in chunks[0].content
+    _assert_hidden_self_check_message(chunks[0])
+
+
+def test_valid_yiii_structured_aliases_are_accepted(monkeypatch):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+
+    content = (
+        '<yiii-artifacts>{"items":[{"path":"result.md"}]}</yiii-artifacts>'
+        '<yiii-questionnaire>{"title":"确认","questions":['
+        '{"type":"single_choice","text":"继续？","options":["是","否"],'
+        '"default":"是"}]}'
+        '</yiii-questionnaire>'
+        '<yiii-questionnaire-response>{"answers":[{"value":"是"}]}'
+        '</yiii-questionnaire-response>'
+    )
+
+    assert agent._content_has_structured_tags(content) is True
+    assert agent._validate_structured_tag_payloads(content) == []
+    assert agent._extract_artifact_paths(content) == {"result.md"}
+
+
+def test_invalid_yiii_questionnaire_field_structure_is_rejected(monkeypatch):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+
+    content = (
+        '<yiii-questionnaire>{"title":"确认","questions":['
+        '{"type":"single_choice","text":"继续？","options":["是","否"]}]}'
+        '</yiii-questionnaire>'
+    )
+
+    issues = agent._validate_structured_tag_payloads(content)
+
+    assert issues == [
+        "<yiii-questionnaire> questions[1] 缺少 default 字段"
+    ]
+
+
 def test_valid_questionnaire_without_files_passes_self_check(monkeypatch, tmp_path):
     self_check_agent = _load_self_check_agent(monkeypatch)
     agent = self_check_agent(model=None, model_config={})
@@ -550,7 +647,7 @@ def test_valid_questionnaire_without_files_passes_self_check(monkeypatch, tmp_pa
                 _make_message("user", "请确认"),
                 _make_message(
                     "assistant",
-                    '<movo-questionnaire>{"title":"确认","questions":[{"type":"single_choice","text":"画幅？","options":["9:16","16:9"]}]}</movo-questionnaire>',
+                    '<yiii-questionnaire>{"title":"确认","questions":[{"type":"single_choice","text":"画幅？","options":["9:16","16:9"],"default":"16:9"}]}</yiii-questionnaire>',
                 ),
             ]
         ),
@@ -567,6 +664,198 @@ def test_valid_questionnaire_without_files_passes_self_check(monkeypatch, tmp_pa
     assert chunks == []
     assert session_context.audit_status["self_check_passed"] is True
     assert session_context.audit_status["self_check_summary"] == "checked 0 files"
+
+
+def test_inline_code_wrapped_file_link_triggers_execution_error(monkeypatch):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+
+    class DummySandbox:
+        async def file_exists(self, path):
+            return True
+
+        async def read_file(self, path, encoding="utf-8"):
+            return ""
+
+    session_context = SimpleNamespace(
+        audit_status={},
+        sandbox=DummySandbox(),
+        message_manager=SimpleNamespace(
+            messages=[
+                _make_message("user", "请生成结果"),
+                _make_message(
+                    "assistant", "`[video_plan.md](file:///tmp/video_plan.md)`"
+                ),
+            ]
+        ),
+    )
+
+    async def collect():
+        chunks = []
+        async for batch in agent.run_stream(session_context):
+            chunks.extend(batch)
+        return chunks
+
+    chunks = asyncio.run(collect())
+
+    assert session_context.audit_status["self_check_passed"] is False
+    assert "真实文件引用不能放在反引号或代码块中" in chunks[0].content
+    _assert_hidden_self_check_message(chunks[0])
+
+
+def test_markdown_code_regions_reject_local_file_links(monkeypatch):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+
+    samples = [
+        "``[report.md](file:///tmp/report.md)``",
+        "```markdown\n[report.md](file:///tmp/report.md)\n```",
+        "~~~\n![preview](file:///tmp/preview.png)\n~~~",
+        "```\n[report.md](file:///tmp/report.md)",
+        "`[report](<file:///tmp/report with spaces.md>)`",
+    ]
+
+    for content in samples:
+        issues = agent._validate_markdown_file_link_syntax(content)
+        assert len(issues) == 1, content
+        assert "真实文件引用不能放在反引号或代码块中" in issues[0]
+
+
+def test_code_file_links_are_not_collected_as_clickable_artifacts(monkeypatch):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+    session_context = SimpleNamespace(
+        message_manager=SimpleNamespace(
+            messages=[
+                _make_message("user", "检查"),
+                _make_message(
+                    "assistant",
+                    "```\n[hidden.md](file:///tmp/hidden.md)\n```\n"
+                    "[visible.md](<file:///tmp/visible%20file.md>)",
+                ),
+            ]
+        )
+    )
+
+    referenced = agent._collect_recent_referenced_files(session_context)
+
+    assert referenced == {"/tmp/visible file.md"}
+
+
+def test_balanced_parentheses_in_markdown_file_targets_are_collected(monkeypatch):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+    session_context = SimpleNamespace(
+        message_manager=SimpleNamespace(
+            messages=[
+                _make_message("user", "检查"),
+                _make_message(
+                    "assistant",
+                    "[report](file:///tmp/report(1).md)\n"
+                    "![preview](file:///tmp/preview(2).png)",
+                ),
+            ]
+        )
+    )
+
+    referenced = agent._collect_recent_referenced_files(session_context)
+
+    assert referenced == {"/tmp/report(1).md", "/tmp/preview(2).png"}
+
+
+def test_list_fence_file_link_is_code_only(monkeypatch):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+    content = (
+        "- ```markdown\n"
+        "  [hidden.md](file:///tmp/hidden.md)\n"
+        "  ```"
+    )
+    session_context = SimpleNamespace(
+        message_manager=SimpleNamespace(
+            messages=[
+                _make_message("user", "检查"),
+                _make_message("assistant", content),
+            ]
+        )
+    )
+
+    issues = agent._validate_markdown_file_link_syntax(content)
+    referenced = agent._collect_recent_referenced_files(session_context)
+
+    assert len(issues) == 1
+    assert "真实文件引用不能放在反引号或代码块中" in issues[0]
+    assert referenced == set()
+
+
+def test_inline_code_span_does_not_cross_fenced_block(monkeypatch):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+    content = (
+        "`unmatched literal\n"
+        "```text\n"
+        "fenced\n"
+        "```\n"
+        "[visible.md](file:///tmp/visible.md) `"
+    )
+    session_context = SimpleNamespace(
+        message_manager=SimpleNamespace(
+            messages=[
+                _make_message("user", "检查"),
+                _make_message("assistant", content),
+            ]
+        )
+    )
+
+    assert agent._validate_markdown_file_link_syntax(content) == []
+    assert agent._collect_recent_referenced_files(session_context) == {
+        "/tmp/visible.md"
+    }
+
+
+def test_non_file_links_and_plain_code_do_not_trigger_file_link_issue(monkeypatch):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+
+    content = "```markdown\n[docs](https://example.com/docs)\n```\n`plain code`"
+
+    assert agent._validate_markdown_file_link_syntax(content) == []
+
+
+def test_standard_absolute_file_link_passes_self_check(monkeypatch):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+
+    class DummySandbox:
+        async def file_exists(self, path):
+            return True
+
+        async def read_file(self, path, encoding="utf-8"):
+            return ""
+
+    session_context = SimpleNamespace(
+        audit_status={},
+        sandbox=DummySandbox(),
+        message_manager=SimpleNamespace(
+            messages=[
+                _make_message("user", "请生成结果"),
+                _make_message(
+                    "assistant", "[video_plan.md](file:///tmp/video_plan.md)"
+                ),
+            ]
+        ),
+    )
+
+    async def collect():
+        chunks = []
+        async for batch in agent.run_stream(session_context):
+            chunks.extend(batch)
+        return chunks
+
+    chunks = asyncio.run(collect())
+
+    assert chunks == []
+    assert session_context.audit_status["self_check_passed"] is True
 
 
 def test_absolute_markdown_link_outside_workspace_is_execution_error(


### PR DESCRIPTION
## Summary

- unify one-shot runtime correction metadata and hide internal diagnostics at every public stream/history boundary
- preserve ledger ordering for SimpleAgent, Team, and Fibre with acknowledged main-agent batches
- replace regex-only Markdown file-link detection with balanced destination and code-region scanning
- support yiii structured artifact and questionnaire aliases already included in the branch changes

## Behavior

- runtime correction batches are persisted before the producer can start the next LLM request
- hidden corrections remain available to exactly one logical request and never reach the frontend
- abnormal consumer shutdown cancels the batch acknowledgement and producer
- local file links inside code regions report a syntax issue without duplicate artifact validation
- links with balanced parentheses, images, angle-bracket targets, spaces, list fences, blockquotes, and unclosed fences are handled

## Validation

- 482 related tests passed
- Ruff passed
- Python compileall passed
- git diff --check passed

## Notes

- SelfCheck corrections intentionally retain role=user for now
- yiii frontend tag compatibility is outside this runtime visibility change
