### PR TITLE
Fix conversation history and SelfCheck repair flow

### DIFF
--- a/common/services/conversation_service.py
+++ b/common/services/conversation_service.py
@@ -430,43 +430,61 @@ async def get_conversation_messages(
 ) -> Dict[str, Any]:
     dao = ConversationDao()
     conversation = await dao.get_by_session_id(session_id)
-    if not conversation:
+    session_manager = get_global_session_manager()
+    session = session_manager.get(session_id) if session_manager else None
+    if not session:
         raise SageHTTPException(
-            **_conversation_error_kwargs(
-                message_key="conversation.not_found",
-                message_params={"session_id": session_id},
-                error_detail=f"Conversation '{session_id}' not found",
-            )
+            **{
+                **_conversation_error_kwargs(
+                    message_key="conversation.not_found",
+                    message_params={"session_id": session_id},
+                    error_detail=f"Conversation '{session_id}' not found",
+                ),
+                "status_code": 404,
+            }
         )
-
-    stream_manager_module = (
-        "app.desktop.core.services.chat.stream_manager"
-        if _is_desktop_mode()
-        else "app.server.services.chat.stream_manager"
-    )
-    stream_manager = __import__(
-        stream_manager_module, fromlist=["StreamManager"]
-    ).StreamManager
 
     view = build_conversation_messages_view(session_id)
     messages: List[Dict[str, Any]] = []
     for message in view["messages"]:
         messages.append(ContentProcessor.clean_content(message))
 
-    next_stream_index = stream_manager.get_instance().get_history_length(session_id)
-    return {
-        "conversation_id": session_id,
-        "messages": messages,
-        "message_count": len(messages),
-        "next_stream_index": next_stream_index,
-        "conversation_info": {
+    next_stream_index = _get_stream_manager().get_history_length(session_id)
+    if conversation:
+        conversation_info = {
             "session_id": conversation.session_id,
             "agent_id": conversation.agent_id,
             "agent_name": conversation.agent_name,
             "title": conversation.title,
             "created_at": conversation.created_at,
             "updated_at": conversation.updated_at,
-        },
+        }
+    else:
+        session_context = session.get_context() if session else None
+        session_created_at = session.get_start_time() if session else None
+        agent_config = (
+            getattr(session_context, "agent_config", None) or {}
+            if session_context
+            else {}
+        )
+        conversation_info = {
+            "session_id": session_id,
+            "agent_id": str(
+                agent_config.get("agent_id")
+                or getattr(session_context, "agent_id", "")
+                or ""
+            ),
+            "agent_name": str(agent_config.get("name") or ""),
+            "title": "",
+            "created_at": session_created_at or "",
+            "updated_at": getattr(session, "end_time", None) or "",
+        }
+    return {
+        "conversation_id": session_id,
+        "messages": messages,
+        "message_count": len(messages),
+        "next_stream_index": next_stream_index,
+        "conversation_info": conversation_info,
     }
 
 

--- a/sagents/agent/agent_base.py
+++ b/sagents/agent/agent_base.py
@@ -1185,6 +1185,31 @@ class AgentBase(ABC):
             return
         yield (final_view, True)
 
+    @staticmethod
+    def _chunks_contain_tool_calls(chunks: List[Any]) -> bool:
+        for chunk in chunks:
+            choices = (
+                chunk.get("choices", [])
+                if isinstance(chunk, dict)
+                else getattr(chunk, "choices", [])
+            ) or []
+            for choice in choices:
+                if isinstance(choice, dict):
+                    finish_reason = choice.get("finish_reason")
+                    delta = choice.get("delta") or {}
+                    tool_calls = (
+                        delta.get("tool_calls")
+                        if isinstance(delta, dict)
+                        else getattr(delta, "tool_calls", None)
+                    )
+                else:
+                    finish_reason = getattr(choice, "finish_reason", None)
+                    delta = getattr(choice, "delta", None)
+                    tool_calls = getattr(delta, "tool_calls", None)
+                if finish_reason == "tool_calls" or tool_calls:
+                    return True
+        return False
+
     async def _call_llm_streaming(
         self,
         messages: List[Union[MessageChunk, Dict[str, Any]]],
@@ -1266,7 +1291,7 @@ class AgentBase(ABC):
             )
         messages = MessageManager.filter_messages_for_llm_scope(messages)  # pyright: ignore[reportAssignmentType]
         pending_next_request_message_ids: List[str] = []
-        llm_scope_consumed = False
+        llm_scope_finalized = False
 
         # A logical request owns one immutable provider payload. Network retries
         # reuse this snapshot; only the explicit structured-output fallback may
@@ -1538,15 +1563,6 @@ class AgentBase(ABC):
                 )
                 async for chunk in stream:
                     # print(chunk)
-                    if not llm_scope_consumed:
-                        if session_id and pending_next_request_message_ids:
-                            session_context = self._get_live_session_context(session_id)
-                            if session_context is not None:
-                                session_context.mark_llm_messages_consumed(
-                                    pending_next_request_message_ids,
-                                    logical_request_id,
-                                )
-                        llm_scope_consumed = True
                     # 记录首token时间
                     if first_token_time is None:
                         first_token_time = time.time()
@@ -1560,6 +1576,28 @@ class AgentBase(ABC):
 
                 # 成功完成，跳出重试循环
                 all_chunks = attempt_chunks
+                if session_id and pending_next_request_message_ids:
+                    session_context = self._get_live_session_context(session_id)
+                    if session_context is not None:
+                        if attempt_chunks and not self._chunks_contain_tool_calls(
+                            attempt_chunks
+                        ):
+                            session_context.mark_llm_messages_consumed(
+                                pending_next_request_message_ids,
+                                logical_request_id,
+                            )
+                        else:
+                            release_claims = getattr(
+                                session_context,
+                                "release_llm_message_claims",
+                                None,
+                            )
+                            if callable(release_claims):
+                                release_claims(
+                                    pending_next_request_message_ids,
+                                    logical_request_id,
+                                )
+                    llm_scope_finalized = True
                 stream_succeeded = True
                 break
 
@@ -1780,21 +1818,28 @@ class AgentBase(ABC):
             finally:
                 if (
                     pending_next_request_message_ids
-                    and not llm_scope_consumed
+                    and not llm_scope_finalized
                     and not retrying_logical_request
                     and session_id
                 ):
                     session_context = self._get_live_session_context(session_id)
-                    release_claims = getattr(
-                        session_context,
-                        "release_llm_message_claims",
-                        None,
-                    )
-                    if callable(release_claims):
-                        release_claims(
+                    if session_context is not None and attempt_yielded_chunks:
+                        session_context.mark_llm_messages_consumed(
                             pending_next_request_message_ids,
                             logical_request_id,
                         )
+                    elif session_context is not None:
+                        release_claims = getattr(
+                            session_context,
+                            "release_llm_message_claims",
+                            None,
+                        )
+                        if callable(release_claims):
+                            release_claims(
+                                pending_next_request_message_ids,
+                                logical_request_id,
+                            )
+                    llm_scope_finalized = True
                 # 只有在成功完成或最终失败时才记录。
                 # 重试后成功也必须落盘（stream_succeeded），不能只看 retry_count==0。
                 if (

--- a/sagents/agent/self_check_agent.py
+++ b/sagents/agent/self_check_agent.py
@@ -103,6 +103,24 @@ class SelfCheckAgent(AgentBase):
         structured_tag_issues = self._validate_structured_tag_payloads(
             latest_assistant_content
         )
+        structured_tag_names = self._structured_tag_names(latest_assistant_content)
+        invalid_structured_tag_names = (
+            self._invalid_structured_tag_names(latest_assistant_content)
+        )
+        required_structured_tag_names = {
+            str(tag_name).lower()
+            for tag_name in audit_status.get(
+                "self_check_required_structured_tags", []
+            )
+            if str(tag_name).strip()
+        }
+        missing_required_structured_tags = (
+            required_structured_tag_names - structured_tag_names
+        )
+        for tag_name in sorted(missing_required_structured_tags):
+            structured_tag_issues.append(
+                f"<{tag_name}> 必须在修复后的完整回复中重新输出，不能省略"
+            )
         markdown_link_issues = self._validate_markdown_file_link_syntax(
             latest_assistant_content
         )
@@ -174,6 +192,15 @@ class SelfCheckAgent(AgentBase):
         audit_status["self_check_issues"] = issues
 
         if issues:
+            unresolved_structured_tag_names = (
+                missing_required_structured_tags | invalid_structured_tag_names
+            )
+            if unresolved_structured_tag_names:
+                audit_status["self_check_required_structured_tags"] = sorted(
+                    unresolved_structured_tag_names
+                )
+            else:
+                audit_status.pop("self_check_required_structured_tags", None)
             audit_status["self_check_passed"] = False
             # 强制下一轮重新进入执行链，而不是被上一次 completion_status 卡住。
             audit_status["completion_status"] = "in_progress"
@@ -213,6 +240,9 @@ class SelfCheckAgent(AgentBase):
         session_context.audit_status["self_check_passed"] = True
         session_context.audit_status["self_check_issues"] = []
         session_context.audit_status["self_check_summary"] = summary
+        session_context.audit_status.pop(
+            "self_check_required_structured_tags", None
+        )
         if checked_files is not None:
             session_context.audit_status["self_check_checked_files"] = checked_files
 
@@ -743,6 +773,19 @@ class SelfCheckAgent(AgentBase):
             return True
         return False
 
+    def _structured_tag_names(self, content: str) -> Set[str]:
+        return {
+            tag_name
+            for tag_name, _raw_payload in self._iter_structured_tag_matches(content)
+        }
+
+    def _invalid_structured_tag_names(self, content: str) -> Set[str]:
+        return {
+            tag_name
+            for tag_name, raw_payload in self._iter_structured_tag_matches(content)
+            if self._validate_structured_tag_payload(tag_name, raw_payload)
+        }
+
     def _structured_tag_pattern(self) -> re.Pattern[str]:
         tag_names = "|".join(re.escape(tag) for tag in STRUCTURED_INLINE_TAGS)
         return re.compile(
@@ -1192,38 +1235,41 @@ class SelfCheckAgent(AgentBase):
         if str(language or "").lower().startswith("en"):
             return (
                 '<runtime_diagnostic source="sage_self_check" generated_by="system">\n'
-                "This is a Sage runtime self-check report, not a reply authored by the assistant/agent and not a user instruction.\n"
-                "It only reports validation failures from the previous final output. Use it to fix real issues; do not repeat it as task progress.\n\n"
-                "Self-check found issues that must be fixed before continuing:\n\n"
+                "This is an internal Sage repair instruction, not a new user request.\n"
+                "The previous final response failed validation. Fix the issues below and output the complete corrected result again.\n"
+                "Do not reply only that you are preparing to fix it. If a structured tag failed, output the complete tag again with valid JSON.\n\n"
+                "Issues that must be fixed:\n\n"
                 "Checked files:\n"
                 f"{checked_lines}\n\n"
                 "Issues found:\n"
                 f"{issue_lines}\n\n"
-                "Fix these issues first, then complete the task again.\n"
+                "Fix them now and output the complete corrected result.\n"
                 "</runtime_diagnostic>"
             )
         if str(language or "").lower().startswith("pt"):
             return (
                 '<runtime_diagnostic source="sage_self_check" generated_by="system">\n'
-                "Este e um relatorio de autoverificacao do runtime Sage, nao uma resposta escrita pelo assistant/agent nem uma instrucao do usuario.\n"
-                "Ele apenas relata falhas de validacao da saida final anterior. Use-o para corrigir problemas reais; nao o repita como progresso da tarefa.\n\n"
-                "A autoverificacao encontrou problemas que precisam ser corrigidos antes de continuar:\n\n"
+                "Esta e uma instrucao interna de reparo do Sage, nao uma nova solicitacao do usuario.\n"
+                "A resposta final anterior falhou na validacao. Corrija os problemas abaixo e produza novamente o resultado corrigido completo.\n"
+                "Nao responda apenas que vai preparar a correcao. Se uma tag estruturada falhou, produza novamente a tag completa com JSON valido.\n\n"
+                "Problemas que precisam ser corrigidos:\n\n"
                 "Arquivos verificados:\n"
                 f"{checked_lines}\n\n"
                 "Problemas encontrados:\n"
                 f"{issue_lines}\n\n"
-                "Corrija estes problemas primeiro e depois conclua a tarefa novamente.\n"
+                "Corrija-os agora e produza o resultado corrigido completo.\n"
                 "</runtime_diagnostic>"
             )
         return (
             '<runtime_diagnostic source="sage_self_check" generated_by="system">\n'
-            "这是 Sage 运行时自检报告，不是 assistant/agent 自己生成的回复，也不是用户指令。\n"
-            "它只说明上一轮最终产物校验失败，下一轮应据此修复真实问题，不要把这段报告当作可复述的任务成果。\n\n"
-            "自检发现以下问题，需要先修复后再继续：\n\n"
+            "这是 Sage 内部修复指令，不是新的用户需求。\n"
+            "上一轮最终回复未通过校验。请修复以下问题，并重新输出修复后的完整结果。\n"
+            "禁止只回复“准备修复”。如果结构化标签校验失败，必须重新输出完整标签，并确保其中的 JSON 合法。\n\n"
+            "必须修复的问题：\n\n"
             "已检查文件：\n"
             f"{checked_lines}\n\n"
             "发现的问题：\n"
             f"{issue_lines}\n\n"
-            "请优先修复这些问题，然后重新完成任务。\n"
+            "请立即修复并重新输出完整结果。\n"
             "</runtime_diagnostic>"
         )

--- a/sagents/context/session_context.py
+++ b/sagents/context/session_context.py
@@ -691,11 +691,11 @@ class SessionContext:
     ) -> List[str]:
         """Atomically reserve pending request-scoped messages for one request.
 
-        Claims are intentionally kept in memory only. A successful provider
-        response journals the final ``consumed`` state, while a request that
-        fails before its first response releases the claim back to ``pending``.
-        This also means a process restart restores the last journaled pending
-        state instead of stranding an in-flight claim.
+        Claims are intentionally kept in memory only. A terminal provider
+        response journals the final ``consumed`` state, while a tool-call
+        response or a request that fails before its first response releases the
+        claim back to ``pending``. This also means a process restart restores
+        the last journaled pending state instead of stranding an in-flight claim.
         """
 
         if not message_ids or not logical_request_id:
@@ -742,7 +742,7 @@ class SessionContext:
         message_ids: List[str],
         logical_request_id: str,
     ) -> int:
-        """Release claims owned by a request that produced no provider response."""
+        """Release claims when a request did not produce a terminal response."""
 
         if not message_ids or not logical_request_id:
             return 0

--- a/sagents/session_runtime.py
+++ b/sagents/session_runtime.py
@@ -850,6 +850,9 @@ class Session:
             session_context.audit_status.pop("self_check_issues", None)
             session_context.audit_status.pop("self_check_summary", None)
             session_context.audit_status.pop("self_check_checked_files", None)
+            session_context.audit_status.pop(
+                "self_check_required_structured_tags", None
+            )
 
             # 2. 准备工具白名单
             # 这里直接按显式 agent_mode 收敛可用工具，不再经过自动路由分叉

--- a/tests/common/services/test_conversation_service_hidden_messages.py
+++ b/tests/common/services/test_conversation_service_hidden_messages.py
@@ -1,4 +1,12 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from common.services import conversation_service
 from common.services.conversation_service import _find_last_user_message_index
+from sagents import session_runtime
+from sagents.context.messages.message import MessageChunk, MessageRole
 
 
 def test_find_last_user_message_skips_hidden_context_messages():
@@ -19,3 +27,208 @@ def test_find_last_user_message_skips_hidden_context_messages():
     ]
 
     assert _find_last_user_message_index(messages) == 0
+
+
+@pytest.mark.asyncio
+async def test_get_conversation_messages_uses_client_visible_view(monkeypatch):
+    conversation = SimpleNamespace(
+        session_id="main-session",
+        agent_id="agent-1",
+        agent_name="Agent",
+        title="Title",
+        created_at="created",
+        updated_at="updated",
+    )
+
+    class FakeDao:
+        async def get_by_session_id(self, session_id):
+            assert session_id == "main-session"
+            return conversation
+
+    class FakeManager:
+        def get(self, session_id):
+            return SimpleNamespace()
+
+    monkeypatch.setattr(conversation_service, "ConversationDao", FakeDao)
+    monkeypatch.setattr(
+        conversation_service, "get_global_session_manager", lambda: FakeManager()
+    )
+    monkeypatch.setattr(
+        conversation_service,
+        "build_conversation_messages_view",
+        lambda session_id: {
+            "conversation_id": session_id,
+            "messages": [
+                {"role": "user", "content": "visible", "message_id": "visible"}
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        conversation_service,
+        "_get_stream_manager",
+        lambda: SimpleNamespace(get_history_length=lambda session_id: 3),
+    )
+
+    result = await conversation_service.get_conversation_messages("main-session")
+
+    assert [message["message_id"] for message in result["messages"]] == ["visible"]
+    assert result["message_count"] == 1
+    assert result["next_stream_index"] == 3
+    assert result["conversation_info"]["title"] == "Title"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("session_kind", ["disk-session", "child-session"])
+async def test_get_conversation_messages_without_conversation_record(
+    monkeypatch, session_kind
+):
+    context = SimpleNamespace(
+        agent_id="agent-context",
+        agent_config={"agent_id": "agent-config", "name": "Restored Agent"},
+    )
+    restored_session = SimpleNamespace(
+        get_context=lambda: context,
+        get_start_time=lambda: 123.0,
+        end_time=456.0,
+    )
+
+    class FakeDao:
+        async def get_by_session_id(self, session_id):
+            return None
+
+    class FakeManager:
+        def get(self, session_id):
+            assert session_id == session_kind
+            return restored_session
+
+    monkeypatch.setattr(conversation_service, "ConversationDao", FakeDao)
+    monkeypatch.setattr(
+        conversation_service, "get_global_session_manager", lambda: FakeManager()
+    )
+    monkeypatch.setattr(
+        conversation_service,
+        "build_conversation_messages_view",
+        lambda session_id: {
+            "conversation_id": session_id,
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "restored",
+                    "message_id": "restored-message",
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        conversation_service,
+        "_get_stream_manager",
+        lambda: SimpleNamespace(get_history_length=lambda session_id: 0),
+    )
+
+    result = await conversation_service.get_conversation_messages(session_kind)
+
+    assert result["conversation_id"] == session_kind
+    assert result["conversation_info"] == {
+        "session_id": session_kind,
+        "agent_id": "agent-config",
+        "agent_name": "Restored Agent",
+        "title": "",
+        "created_at": 123.0,
+        "updated_at": 456.0,
+    }
+    assert result["messages"][0]["message_id"] == "restored-message"
+
+
+@pytest.mark.asyncio
+async def test_get_conversation_messages_returns_404_only_when_session_is_absent(
+    monkeypatch,
+):
+    class FakeDao:
+        async def get_by_session_id(self, session_id):
+            return SimpleNamespace(session_id=session_id)
+
+    class FakeManager:
+        def get(self, session_id):
+            return None
+
+    monkeypatch.setattr(conversation_service, "ConversationDao", FakeDao)
+    monkeypatch.setattr(
+        conversation_service, "get_global_session_manager", lambda: FakeManager()
+    )
+    monkeypatch.setattr(
+        conversation_service, "_is_desktop_mode", lambda: False
+    )
+
+    with pytest.raises(conversation_service.SageHTTPException) as exc_info:
+        await conversation_service.get_conversation_messages("missing-session")
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_conversation_messages_restores_disk_child_and_preserves_ledger(
+    monkeypatch, tmp_path
+):
+    session_id = "disk-child"
+    session_root = tmp_path / "sessions"
+    session_workspace = (
+        session_root / "parent-session" / "sub_sessions" / session_id
+    )
+    session_workspace.mkdir(parents=True)
+    raw_messages = [
+        MessageChunk(
+            role=MessageRole.USER.value,
+            content="visible",
+            message_id="visible",
+        ).to_dict(),
+        MessageChunk(
+            role=MessageRole.USER.value,
+            content="internal self-check",
+            message_id="hidden-self-check",
+            metadata={"hidden_from_chat": True},
+        ).to_dict(),
+        MessageChunk(
+            role=MessageRole.USER.value,
+            content="internal tool parse",
+            message_id="hidden-tool-parse",
+            metadata={"hide_from_chat": True},
+        ).to_dict(),
+        MessageChunk(
+            role=MessageRole.USER.value,
+            content="internal repeat loop",
+            message_id="hidden-repeat-loop",
+            metadata={"sse_visible": False},
+        ).to_dict(),
+    ]
+    messages_path = session_workspace / "messages.json"
+    messages_path.write_text(json.dumps(raw_messages), encoding="utf-8")
+    manager = session_runtime.SessionManager(str(session_root), enable_obs=False)
+
+    class FakeDao:
+        async def get_by_session_id(self, requested_session_id):
+            assert requested_session_id == session_id
+            return None
+
+    monkeypatch.setattr(conversation_service, "ConversationDao", FakeDao)
+    monkeypatch.setattr(
+        conversation_service, "get_global_session_manager", lambda: manager
+    )
+    monkeypatch.setattr(session_runtime, "_global_session_manager", manager)
+    monkeypatch.setattr(
+        conversation_service,
+        "_get_stream_manager",
+        lambda: SimpleNamespace(get_history_length=lambda requested_session_id: 0),
+    )
+
+    result = await conversation_service.get_conversation_messages(session_id)
+
+    assert [message["message_id"] for message in result["messages"]] == ["visible"]
+    assert result["conversation_info"] == {
+        "session_id": session_id,
+        "agent_id": "",
+        "agent_name": "",
+        "title": "",
+        "created_at": "",
+        "updated_at": "",
+    }
+    assert json.loads(messages_path.read_text(encoding="utf-8")) == raw_messages

--- a/tests/sagents/test_llm_stream_retry.py
+++ b/tests/sagents/test_llm_stream_retry.py
@@ -80,7 +80,7 @@ class DummyObservabilityManager:
 
 
 @pytest.mark.asyncio
-async def test_llm_stream_consumes_next_request_message_after_first_chunk():
+async def test_llm_stream_consumes_next_request_message_after_terminal_reply():
     client = FakeClient(attempts=[_attempt_yields(_content_chunk("ok"))])
     agent = DummyAgent(model=client, model_config={"model": "gpt-test"})
     agent._get_live_session = lambda session_id: None
@@ -118,6 +118,185 @@ async def test_llm_stream_consumes_next_request_message_after_first_chunk():
     assert context.calls[0][0] == ["notice-once"]
     sent_messages = client.chat.completions.requests[0]["messages"]
     assert "<runtime_diagnostic" in sent_messages[-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_llm_stream_keeps_next_request_message_through_tool_round_trip():
+    class ClaimingSessionContext:
+        def __init__(self):
+            self.state = "pending"
+            self.owner = None
+            self.claim_calls = 0
+            self.release_calls = 0
+            self.consume_calls = 0
+
+        def claim_llm_messages_for_request(self, message_ids, logical_request_id):
+            assert self.state == "pending"
+            self.state = "claimed"
+            self.owner = logical_request_id
+            self.claim_calls += 1
+            return list(message_ids)
+
+        def release_llm_message_claims(self, message_ids, logical_request_id):
+            assert self.state == "claimed"
+            assert self.owner == logical_request_id
+            self.state = "pending"
+            self.owner = None
+            self.release_calls += 1
+            return len(message_ids)
+
+        def mark_llm_messages_consumed(self, message_ids, logical_request_id):
+            assert self.state == "claimed"
+            assert self.owner == logical_request_id
+            self.state = "consumed"
+            self.consume_calls += 1
+            return len(message_ids)
+
+        def add_llm_request(self, request, response):
+            pass
+
+    context = ClaimingSessionContext()
+    notice = MessageChunk(
+        role=MessageRole.USER.value,
+        content="<runtime_diagnostic>repair and re-output</runtime_diagnostic>",
+        message_id="repair-notice",
+        message_type=MessageType.AGENT_EXECUTION_ERROR.value,
+        metadata={"llm_scope": "next_request", "llm_state": "pending"},
+    )
+    tool_client = FakeClient(
+        attempts=[
+            _attempt_yields(
+                _tool_call_chunk("call-1", '{"tasks":[]}'),
+                _content_chunk("", finish_reason="tool_calls"),
+            )
+        ]
+    )
+    terminal_client = FakeClient(
+        attempts=[_attempt_yields(_content_chunk("complete", finish_reason="stop"))]
+    )
+
+    for index, client in enumerate((tool_client, terminal_client)):
+        agent = DummyAgent(model=client, model_config={"model": "gpt-test"})
+        agent._get_live_session = lambda session_id: None
+        agent._get_live_session_context = lambda session_id: context
+        request_messages = [
+            MessageChunk(role=MessageRole.USER.value, content="run"),
+            notice,
+        ]
+        if index == 1:
+            request_messages.extend(
+                [
+                    MessageChunk(
+                        role=MessageRole.ASSISTANT.value,
+                        content=None,
+                        tool_calls=[
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {
+                                    "name": "todo_write",
+                                    "arguments": '{"tasks":[]}',
+                                },
+                            }
+                        ],
+                    ),
+                    MessageChunk(
+                        role=MessageRole.TOOL.value,
+                        content='{"ok":true}',
+                        tool_call_id="call-1",
+                    ),
+                ]
+            )
+        async for _ in agent._call_llm_streaming(
+            messages=request_messages,
+            session_id="sid",
+            step_name="direct_execution",
+        ):
+            pass
+
+    for client in (tool_client, terminal_client):
+        sent_messages = client.chat.completions.requests[0]["messages"]
+        assert any(
+            "repair and re-output" in str(message.get("content", ""))
+            for message in sent_messages
+        )
+    assert context.claim_calls == 2
+    assert context.release_calls == 1
+    assert context.consume_calls == 1
+    assert context.state == "consumed"
+
+
+@pytest.mark.asyncio
+async def test_network_retry_keeps_claim_and_consumes_once_after_terminal_reply(
+    monkeypatch,
+):
+    async def fast_sleep(_seconds):
+        return None
+
+    class ClaimingSessionContext:
+        def __init__(self):
+            self.state = "pending"
+            self.owner = None
+            self.claim_calls = 0
+            self.release_calls = 0
+            self.consume_calls = 0
+
+        def claim_llm_messages_for_request(self, message_ids, logical_request_id):
+            self.state = "claimed"
+            self.owner = logical_request_id
+            self.claim_calls += 1
+            return list(message_ids)
+
+        def release_llm_message_claims(self, message_ids, logical_request_id):
+            self.state = "pending"
+            self.owner = None
+            self.release_calls += 1
+            return len(message_ids)
+
+        def mark_llm_messages_consumed(self, message_ids, logical_request_id):
+            assert self.state == "claimed"
+            assert self.owner == logical_request_id
+            self.state = "consumed"
+            self.consume_calls += 1
+            return len(message_ids)
+
+        def add_llm_request(self, request, response):
+            pass
+
+    monkeypatch.setattr("sagents.agent.agent_base.asyncio.sleep", fast_sleep)
+    context = ClaimingSessionContext()
+    client = FakeClient(
+        attempts=[
+            _attempt_raises_before_yield(httpx.ReadTimeout("no bytes yet")),
+            _attempt_yields(_content_chunk("complete", finish_reason="stop")),
+        ]
+    )
+    agent = DummyAgent(model=client, model_config={"model": "gpt-test"})
+    agent._get_live_session = lambda session_id: None
+    agent._get_live_session_context = lambda session_id: context
+    notice = MessageChunk(
+        role=MessageRole.USER.value,
+        content="<runtime_diagnostic>repair</runtime_diagnostic>",
+        message_id="retry-notice",
+        message_type=MessageType.AGENT_EXECUTION_ERROR.value,
+        metadata={"llm_scope": "next_request", "llm_state": "pending"},
+    )
+
+    async for _ in agent._call_llm_streaming(
+        [MessageChunk(role=MessageRole.USER.value, content="run"), notice],
+        session_id="sid",
+        step_name="direct_execution",
+    ):
+        pass
+
+    assert client.chat.completions.calls == 2
+    assert client.chat.completions.requests[0]["messages"] == (
+        client.chat.completions.requests[1]["messages"]
+    )
+    assert context.claim_calls == 1
+    assert context.release_calls == 0
+    assert context.consume_calls == 1
+    assert context.state == "consumed"
 
 
 @pytest.mark.asyncio

--- a/tests/sagents/test_self_check_agent_paths.py
+++ b/tests/sagents/test_self_check_agent_paths.py
@@ -176,8 +176,10 @@ def test_self_check_failure_message_uses_english_runtime_diagnostic(monkeypatch)
     assert (
         '<runtime_diagnostic source="sage_self_check" generated_by="system">' in content
     )
-    assert "not a reply authored by the assistant/agent" in content
-    assert "Self-check found issues" in content
+    assert "not a new user request" in content
+    assert "output the complete corrected result again" in content
+    assert "Do not reply only that you are preparing to fix it" in content
+    assert "complete tag again with valid JSON" in content
     assert "Checked files:" in content
 
 
@@ -192,8 +194,26 @@ def test_self_check_failure_message_uses_portuguese_runtime_diagnostic(monkeypat
     assert (
         '<runtime_diagnostic source="sage_self_check" generated_by="system">' in content
     )
-    assert "nao uma resposta escrita pelo assistant/agent" in content
+    assert "nao uma nova solicitacao do usuario" in content
+    assert "resultado corrigido completo" in content
+    assert "Nao responda apenas que vai preparar a correcao" in content
+    assert "tag completa com JSON valido" in content
     assert "Arquivos verificados:" in content
+
+
+def test_self_check_failure_message_uses_chinese_reoutput_instruction(monkeypatch):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+
+    content = agent._format_failure_message(
+        ["问卷 JSON 非法"], [], language="zh"
+    )
+
+    assert "不是新的用户需求" in content
+    assert "重新输出修复后的完整结果" in content
+    assert "禁止只回复“准备修复”" in content
+    assert "重新输出完整标签" in content
+    assert "JSON 合法" in content
 
 
 def test_absolute_markdown_link_checks_file_existence(monkeypatch):
@@ -664,6 +684,62 @@ def test_valid_questionnaire_without_files_passes_self_check(monkeypatch, tmp_pa
     assert chunks == []
     assert session_context.audit_status["self_check_passed"] is True
     assert session_context.audit_status["self_check_summary"] == "checked 0 files"
+
+
+def test_invalid_questionnaire_must_be_reoutput_before_requirement_clears(
+    monkeypatch, tmp_path
+):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    class DummySandbox:
+        async def file_exists(self, path):
+            return True
+
+    invalid_questionnaire = (
+        '<yiii-questionnaire>{"title":"确认","questions":['
+        '{"type":"single_choice","text":"继续？","options":["是","否"],'
+        '"default":"是"}]}></yiii-questionnaire>'
+    )
+    valid_questionnaire = invalid_questionnaire.replace(
+        "]}>", "]}"
+    )
+    session_context = SimpleNamespace(
+        audit_status={},
+        sandbox=DummySandbox(),
+        sandbox_agent_workspace=str(workspace),
+        system_context={"private_workspace": str(workspace)},
+        message_manager=SimpleNamespace(messages=[]),
+    )
+
+    async def run_with_reply(reply):
+        session_context.message_manager.messages = [
+            _make_message("user", "请确认"),
+            _make_message("assistant", reply),
+        ]
+        chunks = []
+        async for batch in agent.run_stream(session_context):
+            chunks.extend(batch)
+        return chunks
+
+    first_chunks = asyncio.run(run_with_reply(invalid_questionnaire))
+    assert first_chunks
+    assert session_context.audit_status[
+        "self_check_required_structured_tags"
+    ] == ["yiii-questionnaire"]
+
+    second_chunks = asyncio.run(run_with_reply("我会继续处理。"))
+    assert second_chunks
+    assert "必须在修复后的完整回复中重新输出" in second_chunks[0].content
+    assert session_context.audit_status["self_check_passed"] is False
+
+    final_chunks = asyncio.run(run_with_reply(valid_questionnaire))
+    assert final_chunks == []
+    assert session_context.audit_status["self_check_passed"] is True
+    assert "self_check_required_structured_tags" not in session_context.audit_status
 
 
 def test_inline_code_wrapped_file_link_triggers_execution_error(monkeypatch):

--- a/tests/sagents/test_session_runtime_messages_view.py
+++ b/tests/sagents/test_session_runtime_messages_view.py
@@ -79,3 +79,45 @@ def test_conversation_messages_view_filters_self_check_hidden_context(
     assert [message["message_id"] for message in view["messages"]] == [
         "visible-assistant",
     ]
+
+
+def test_conversation_messages_view_filters_every_client_visibility_flag(
+    monkeypatch,
+):
+    raw_messages = [
+        MessageChunk(
+            role=MessageRole.USER.value,
+            content="hidden_from_chat",
+            message_id="hidden-from-chat",
+            metadata={"hidden_from_chat": True},
+        ),
+        MessageChunk(
+            role=MessageRole.USER.value,
+            content="hide_from_chat",
+            message_id="hide-from-chat",
+            metadata={"hide_from_chat": True},
+        ),
+        MessageChunk(
+            role=MessageRole.USER.value,
+            content="sse_visible",
+            message_id="sse-hidden",
+            metadata={"sse_visible": False},
+        ),
+        MessageChunk(
+            role=MessageRole.ASSISTANT.value,
+            content="visible",
+            message_id="visible",
+        ),
+    ]
+    manager = FakeSessionManager(raw_messages)
+    monkeypatch.setattr(session_runtime, "_global_session_manager", manager)
+
+    view = session_runtime.build_conversation_messages_view("sess-1")
+
+    assert [message["message_id"] for message in view["messages"]] == ["visible"]
+    assert [message.message_id for message in raw_messages] == [
+        "hidden-from-chat",
+        "hide-from-chat",
+        "sse-hidden",
+        "visible",
+    ]


### PR DESCRIPTION
## Summary
- serve client-visible conversation history from live or persisted Sage sessions, including child sessions without conversation rows
- keep SelfCheck repair requirements active until structured tags are validly re-emitted
- retain next-request correction messages through tool-call rounds and consume them only after a terminal reply
- preserve hidden diagnostics in the raw message ledger while filtering all client history through the shared visibility view

## Validation
- 80 focused conversation, SelfCheck, lifecycle, journal, and message tests passed
- 75 adjacent SimpleAgent, tool correction, parallel call, and session runtime tests passed
- Ruff checks passed
- git diff --check passed