### PR TITLE
Support multiple inline questionnaire formats

### DIFF
--- a/docs/en/QUESTIONNAIRE_FORMATS.md
+++ b/docs/en/QUESTIONNAIRE_FORMATS.md
@@ -1,0 +1,153 @@
+---
+layout: default
+title: Questionnaire Formats
+nav_order: 8.5
+description: "YAML and XML+JSON protocols for Sage Inline Questionnaires"
+lang: en
+ref: questionnaire-formats
+---
+
+{% include lang_switcher.html %}
+
+# Questionnaire Formats Supported by Sage
+
+Sage Self-check supports two Inline Questionnaire encodings:
+
+1. fenced YAML
+2. an XML element containing a JSON object
+
+Both encodings are supported formats. XML+JSON is not deprecated and has no migration deadline.
+
+An Inline Questionnaire is a text protocol inside an assistant message. It is separate from the `questionnaire` tool used by Sage Server Web, which has its own session, submission API, and UI card and does not use the inline tags described here.
+
+## Registered Questionnaire Names
+
+Both encodings use these five registered names:
+
+| Name | Typical use |
+| --- | --- |
+| `yiii-questionnaire` | Yiii integration |
+| `movo-questionnaire` | Movo and Sage Desktop compatibility flows |
+| `ling-questionnaire` | Ling integration |
+| `sage-questionnaire` | Sage namespace |
+| `questionnaire` | Generic format without a product prefix |
+
+Unknown prefixes such as `foo-questionnaire` are not registered protocol names. Self-check requires the response to be rewritten with one of the names above.
+
+Response tags append `-response` to a registered name, for example `yiii-questionnaire-response` and `questionnaire-response`. Responses continue to use XML+JSON rather than fenced YAML.
+
+## Fenced YAML
+
+Fenced YAML is intended for direct model or human authoring. A non-empty ordinary-prose explanation must appear before the questionnaire; the questionnaire block cannot be the whole reply.
+
+The current facts and the decision boundary have been summarized.
+
+```yiii-questionnaire
+title: "Project confirmation"
+questions:
+  - type: single_choice
+    text: "How should the next step proceed?"
+    options:
+      - "Continue"
+      - "Revise"
+    default: "Continue"
+    allow_other: true
+  - type: multi_choice
+    text: "Which parts need revision?"
+    options:
+      - "Content"
+      - "Style"
+    default: []
+  - type: free_text
+    text: "What other constraints apply?"
+    default: ""
+```
+
+The fence name may be replaced with any registered name. Opening and closing fences must each occupy their own line, and the closing fence cannot be shorter than the opening fence.
+
+### Top-Level Fields
+
+- `title`: required non-empty string.
+- `questions`: required non-empty array.
+- `id`, `subtitle`, field descriptions, and all other extra fields are forbidden.
+
+### Question Rules
+
+Every question must contain `type`, a non-empty `text`, and `default`.
+
+| `type` | `options` | `default` | `allow_other` |
+| --- | --- | --- | --- |
+| `single_choice` | Required non-empty string array | Must equal one option | Optional boolean |
+| `multi_choice` | Required non-empty string array | String array whose values are all listed options | Optional boolean |
+| `free_text` | Forbidden | String, which may be empty | Forbidden |
+
+The fenced payload must use block-style YAML. JSON objects, XML, nested code fences, and unknown fields fail Self-check.
+
+## XML+JSON
+
+XML+JSON is intended for existing generators, stored conversations, and clients that still depend on this protocol. It remains supported.
+
+```xml
+<yiii-questionnaire>{"title":"Project confirmation","questions":[{"type":"single_choice","text":"How should the next step proceed?","options":["Continue","Revise"],"default":"Continue"}]}</yiii-questionnaire>
+```
+
+The opening and closing elements must use the same registered name, and their content must be a JSON object. Self-check preserves the existing compatibility rules for each alias: `yiii-questionnaire` continues to validate its title, question types, and defaults, while the other aliases retain existing extension fields and `{value, label}` option objects.
+
+XML+JSON is not automatically converted to YAML. A repair may remain XML+JSON or rewrite the same questionnaire name as fenced YAML.
+
+## Response Format
+
+Inline Questionnaire responses continue to use XML+JSON:
+
+```xml
+<yiii-questionnaire-response>{"id":"q_demo","title":"Project confirmation","answers":[{"index":0,"type":"single_choice","question":"How should the next step proceed?","answer":"Continue","answers":["Continue"]}]}</yiii-questionnaire-response>
+```
+
+The submitting client defines the detailed answer fields. Self-check requires a top-level `answers` array.
+
+## Self-check Behavior
+
+Self-check inspects only the latest non-empty assistant reply after the current user message.
+
+- Valid fenced YAML and valid XML+JSON both pass.
+- An invalid questionnaire creates a user-hidden runtime diagnostic and requires the model to emit the complete questionnaire again.
+- `self_check_required_structured_tags` retains the required questionnaire name so a repair cannot omit the questionnaire and return explanation text alone.
+- A repair may switch encodings while retaining the same name, such as replacing invalid YAML with valid XML+JSON.
+- An unknown prefix requires any registered name and is not persisted as an impossible repair requirement.
+
+Self-check does not infer whether prose is asking a question from punctuation or natural-language keywords. Whether a questionnaire is required remains the responsibility of the Agent Prompt, Skill, and business workflow.
+
+## Client Rendering Support
+
+Passing Self-check means the runtime protocol is valid. It does not guarantee that every client renders the encoding as an interactive card.
+
+| Client | Fenced YAML | XML+JSON | `questionnaire` tool call |
+| --- | --- | --- | --- |
+| Sage Desktop | Not currently rendered as an inline card | `movo`, `ling`, `sage`, and unprefixed | Not handled by this inline renderer |
+| Sage Server Web | Not currently rendered as an inline card | Not currently rendered as an inline card | Supported |
+| Yiii Flutter | `yiii-questionnaire` | All five registered names | Not handled by this inline renderer |
+
+Before generating a questionnaire, confirm that the target client supports the selected encoding and name. Self-check support alone does not imply display or submission support in that client.
+
+## Common Errors
+
+### Sending Only the Questionnaire Block
+
+Fenced YAML requires ordinary prose before the block. Message-wrapping requirements for XML+JSON are defined by the relevant Agent Prompt and client contract.
+
+### A Single-Choice Default Outside Its Options
+
+```yaml
+type: single_choice
+text: "How should the next step proceed?"
+options:
+  - "Continue"
+  - "Revise"
+default: "Later"
+```
+
+Change `default` to `Continue` or `Revise`.
+
+### Putting JSON Inside the YAML Fence
+
+The fence named `yiii-questionnaire` must contain block-style YAML. Use the matching XML+JSON format when JSON is required.

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -76,6 +76,7 @@ Read:
   - [Python runtime API](api/API_REFERENCE.md): `SAgent` and related types aligned with `sagents/`, not the main HTTP app
 - [Knowledge Base Guide](KNOWLEDGE_BASE.md): knowledge base module architecture, ingestion, retrieval, and Agent integration
 - [Memory](memory/README.md): memory, retrieval, and memory-search workstream
+- [Questionnaire Formats](QUESTIONNAIRE_FORMATS.md): fenced YAML, XML+JSON, Self-check, and client compatibility for Inline Questionnaires
 - [Solution Playbooks](solutions/README.md): presales documents for concrete business scenarios
 - [OAuth2 Lage Integration Guide](OAUTH2_LAGE_INTEGRATION.md): restored OAuth2 integration guide from historical docs
 - [Development](DEVELOPMENT.md): contributor workflow and source locations

--- a/docs/zh/QUESTIONNAIRE_FORMATS.md
+++ b/docs/zh/QUESTIONNAIRE_FORMATS.md
@@ -1,0 +1,153 @@
+---
+layout: default
+title: 问卷格式
+nav_order: 8.5
+description: "Sage Inline Questionnaire 的 YAML 与 XML+JSON 协议"
+lang: zh
+ref: questionnaire-formats
+---
+
+{% include lang_switcher.html %}
+
+# Sage 支持的问卷格式
+
+Sage 的 Self-check 支持两种 Inline Questionnaire 编码：
+
+1. fenced YAML
+2. XML 标签包裹 JSON 对象
+
+两种编码都正式可用。XML+JSON 没有被废弃，也没有迁移期限。
+
+Inline Questionnaire 是 assistant 消息中的文本协议，与 Sage Server Web 中通过 `questionnaire` 工具调用创建的问卷不同。工具问卷拥有独立的会话、提交接口和 UI 卡片，不使用本文的 Inline Questionnaire 标签。
+
+## 已注册的问卷名称
+
+两种编码都使用以下五个注册名称：
+
+| 名称 | 典型用途 |
+| --- | --- |
+| `yiii-questionnaire` | Yiii 集成 |
+| `movo-questionnaire` | Movo / Sage Desktop 兼容流程 |
+| `ling-questionnaire` | Ling 集成 |
+| `sage-questionnaire` | Sage 命名空间 |
+| `questionnaire` | 无业务前缀的通用格式 |
+
+`foo-questionnaire` 之类的未知前缀不属于注册协议。Self-check 会要求使用上述名称之一重新输出。
+
+对应的回答标签是在名称后追加 `-response`，例如 `yiii-questionnaire-response` 和 `questionnaire-response`。回答继续使用 XML+JSON，不使用 fenced YAML。
+
+## fenced YAML
+
+fenced YAML 适合模型或人工直接编写。问卷前必须先有一段非空普通说明文字，不能只发送问卷块。
+
+当前事实和需要用户决定的边界已经整理完毕。
+
+```yiii-questionnaire
+title: "项目确认"
+questions:
+  - type: single_choice
+    text: "下一步如何处理？"
+    options:
+      - "继续"
+      - "调整"
+    default: "继续"
+    allow_other: true
+  - type: multi_choice
+    text: "需要调整哪些部分？"
+    options:
+      - "内容"
+      - "风格"
+    default: []
+  - type: free_text
+    text: "还有哪些约束？"
+    default: ""
+```
+
+围栏名称可以替换为任一已注册名称。起始和结束围栏必须各自独占一行，结束围栏不能短于起始围栏。
+
+### 顶层字段
+
+- `title`：必填的非空字符串。
+- `questions`：必填的非空数组。
+- 不允许 `id`、`subtitle`、字段描述或其他额外字段。
+
+### 题型规则
+
+每个问题都必须包含 `type`、非空 `text` 和 `default`。
+
+| `type` | `options` | `default` | `allow_other` |
+| --- | --- | --- | --- |
+| `single_choice` | 必填的非空字符串数组 | 必须等于其中一个选项 | 可选布尔值 |
+| `multi_choice` | 必填的非空字符串数组 | 字符串数组，且每项都属于选项 | 可选布尔值 |
+| `free_text` | 禁止 | 字符串，可以为空 | 禁止 |
+
+fenced 内容必须使用块状 YAML。JSON 对象、XML、嵌套代码围栏和未知字段都会触发 Self-check 失败。
+
+## XML+JSON
+
+XML+JSON 适合已有生成器、历史会话和仍依赖该协议的客户端。它继续是受支持格式。
+
+```xml
+<yiii-questionnaire>{"title":"项目确认","questions":[{"type":"single_choice","text":"下一步如何处理？","options":["继续","调整"],"default":"继续"}]}</yiii-questionnaire>
+```
+
+开始标签和结束标签必须使用相同的已注册名称，标签内容必须是 JSON 对象。Self-check 保留各别名现有的兼容规则：`yiii-questionnaire` 继续校验 title、题型和 default；其他别名继续兼容已有扩展字段和 `{value, label}` 选项对象。
+
+XML+JSON 不会被自动转换成 YAML。修复失败问卷时，可以保持 XML+JSON，也可以使用同一问卷名称改写为 fenced YAML。
+
+## 回答格式
+
+Inline Questionnaire 的回答继续使用 XML+JSON：
+
+```xml
+<yiii-questionnaire-response>{"id":"q_demo","title":"项目确认","answers":[{"index":0,"type":"single_choice","question":"下一步如何处理？","answer":"继续","answers":["继续"]}]}</yiii-questionnaire-response>
+```
+
+具体回答字段由提交该问卷的客户端决定，Self-check 要求顶层存在 `answers` 数组。
+
+## Self-check 行为
+
+Self-check 只检查当前用户消息之后最新的一条非空 assistant 回复。
+
+- 合法 fenced YAML 和合法 XML+JSON 都会通过。
+- 无效问卷会生成用户不可见的运行时诊断，并要求模型重新输出完整问卷。
+- `self_check_required_structured_tags` 会保留所需的问卷名称，防止修复回复只输出解释文字而遗漏问卷。
+- 同一名称可以在修复时切换编码，例如从无效 YAML 改成有效 XML+JSON。
+- 未知前缀会要求重新使用任一已注册名称，不会把未知名称永久写入修复要求。
+
+Self-check 不根据问号或自然语言关键词推断“是否应该提问”。是否需要问卷仍由 Agent Prompt、Skill 和业务流程决定。
+
+## 客户端渲染能力
+
+Self-check 通过只表示运行时协议有效，不保证每个客户端都能把该编码渲染成可交互卡片。
+
+| 客户端 | fenced YAML | XML+JSON | questionnaire 工具调用 |
+| --- | --- | --- | --- |
+| Sage Desktop | 当前不渲染为 Inline 卡片 | `movo`、`ling`、`sage`、无前缀 | 不适用此 Inline 渲染器 |
+| Sage Server Web | 当前不渲染为 Inline 卡片 | 当前不渲染为 Inline 卡片 | 支持 |
+| Yiii Flutter | `yiii-questionnaire` | 五种注册名称 | 不适用此 Inline 渲染器 |
+
+生成问卷前应同时确认目标客户端支持对应编码和名称。不要仅因为 Self-check 支持某种格式就假设客户端已经支持显示或提交。
+
+## 常见错误
+
+### 只发送问卷块
+
+fenced YAML 前必须有普通说明文字。XML+JSON 的消息包装规则由具体 Agent Prompt 和客户端合同决定。
+
+### 单选默认值不在选项中
+
+```yaml
+type: single_choice
+text: "下一步如何处理？"
+options:
+  - "继续"
+  - "调整"
+default: "稍后"
+```
+
+应把 `default` 改成 `继续` 或 `调整`。
+
+### 在 YAML 围栏中放 JSON
+
+名为 `yiii-questionnaire` 的围栏内必须写块状 YAML。需要输出 JSON 时，应使用对应的 XML+JSON 格式。

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -76,6 +76,7 @@ ref: home
   - [Python 运行时 API](api/API_REFERENCE.md)：与 `sagents` 源码一致，主站对外 HTTP 请见上条
 - [知识库指南](KNOWLEDGE_BASE.md)：知识库模块架构、入库、检索与 Agent 接入
 - [Memory](memory/README.md)：记忆、检索与 memory-search 工作线
+- [问卷格式](QUESTIONNAIRE_FORMATS.md)：Inline Questionnaire 的 fenced YAML、XML+JSON、自检与客户端兼容性
 - [落地应用方案](solutions/README.md)：面向行业与业务场景的售前方案集合
 - [OAuth2 对接指南（Lage）](OAUTH2_LAGE_INTEGRATION.md)：恢复自历史提交的 OAuth2 对接文档
 - [开发](DEVELOPMENT.md)：贡献流程和源码位置

--- a/sagents/agent/self_check_agent.py
+++ b/sagents/agent/self_check_agent.py
@@ -42,6 +42,17 @@ class MarkdownFileLink:
     in_code: bool = False
 
 
+@dataclass(frozen=True)
+class QuestionnaireFence:
+    tag_name: str
+    raw_payload: str
+    start: int
+    end: int
+    opening_fence_length: int
+    closing_fence_length: Optional[int]
+    supported: bool
+
+
 ARTIFACT_TAGS = (
     "yiii-artifacts",
     "movo-artifacts",
@@ -60,14 +71,26 @@ QUESTIONNAIRE_RESPONSE_TAGS = tuple(f"{tag}-response" for tag in QUESTIONNAIRE_T
 STRUCTURED_INLINE_TAGS = (
     ARTIFACT_TAGS + QUESTIONNAIRE_TAGS + QUESTIONNAIRE_RESPONSE_TAGS
 )
-
-
+QUESTIONNAIRE_FAMILY_REQUIREMENT = "*-questionnaire"
+QUESTIONNAIRE_FENCE_START_PATTERN = re.compile(
+    r"^[ \t]{0,3}(?P<fence>`{2,})(?P<tag>"
+    r"(?:[a-z0-9][a-z0-9_-]*-)?questionnaire)[ \t]*\r?$",
+    re.IGNORECASE | re.MULTILINE,
+)
+QUESTIONNAIRE_FENCE_END_PATTERN = re.compile(
+    r"^[ \t]{0,3}(?P<fence>`{2,})[ \t]*\r?$",
+    re.MULTILINE,
+)
+NESTED_FENCE_PATTERN = re.compile(
+    r"^[ \t]{0,3}(?:`{3,}|~{3,})(?:[^\r\n]*)$",
+    re.MULTILINE,
+)
 class SelfCheckAgent(AgentBase):
     """
     执行后的确定性自检 Agent。
 
     当前聚焦：
-    1. Artifacts / Questionnaire 等特殊标签内 JSON 是否可解析且结构合法；
+    1. Artifacts / Questionnaire 等特殊协议内 JSON/YAML 是否可解析且结构合法；
     2. 最终输出里引用到的结果文件是否真实存在；
     3. 最终消息中的 Markdown 文件链接必须使用绝对路径。
     """
@@ -771,20 +794,37 @@ class SelfCheckAgent(AgentBase):
     def _content_has_structured_tags(self, content: str) -> bool:
         for _tag_name, _raw_payload in self._iter_structured_tag_matches(content):
             return True
+        if any(self._iter_questionnaire_fences(content)):
+            return True
         return False
 
     def _structured_tag_names(self, content: str) -> Set[str]:
-        return {
-            tag_name
-            for tag_name, _raw_payload in self._iter_structured_tag_matches(content)
-        }
+        tag_names: Set[str] = set()
+        for tag_name, _raw_payload in self._iter_structured_tag_matches(content):
+            tag_names.add(tag_name)
+            if tag_name in QUESTIONNAIRE_TAGS:
+                tag_names.add(QUESTIONNAIRE_FAMILY_REQUIREMENT)
+        for fence in self._iter_questionnaire_fences(content):
+            if fence.supported:
+                tag_names.add(fence.tag_name)
+            tag_names.add(QUESTIONNAIRE_FAMILY_REQUIREMENT)
+        return tag_names
 
     def _invalid_structured_tag_names(self, content: str) -> Set[str]:
-        return {
+        invalid_names = {
             tag_name
             for tag_name, raw_payload in self._iter_structured_tag_matches(content)
             if self._validate_structured_tag_payload(tag_name, raw_payload)
         }
+        for fence, issues in self._fenced_questionnaire_validation_results(content):
+            if not issues:
+                continue
+            invalid_names.add(
+                fence.tag_name
+                if fence.supported
+                else QUESTIONNAIRE_FAMILY_REQUIREMENT
+            )
+        return invalid_names
 
     def _structured_tag_pattern(self) -> re.Pattern[str]:
         tag_names = "|".join(re.escape(tag) for tag in STRUCTURED_INLINE_TAGS)
@@ -813,10 +853,93 @@ class SelfCheckAgent(AgentBase):
                 seen_spans.add(span_key)
                 yield tag_name, match.group(2) or ""
 
+    def _iter_questionnaire_fences(self, content: str):
+        if not content:
+            return
+
+        markdown_code_ranges = self._markdown_code_ranges(content)
+        cursor = 0
+        while cursor < len(content):
+            opening = QUESTIONNAIRE_FENCE_START_PATTERN.search(content, cursor)
+            if opening is None:
+                break
+            if any(
+                range_start < opening.start() < range_end
+                for range_start, range_end in markdown_code_ranges
+            ):
+                cursor = opening.end()
+                continue
+
+            payload_start = opening.end()
+            if payload_start < len(content) and content[payload_start] == "\n":
+                payload_start += 1
+
+            closing = QUESTIONNAIRE_FENCE_END_PATTERN.search(content, payload_start)
+            if closing is None:
+                end = len(content)
+                raw_payload = content[payload_start:]
+                closing_fence_length = None
+            else:
+                end = closing.end()
+                raw_payload = content[payload_start : closing.start()]
+                closing_fence_length = len(closing.group("fence"))
+
+            tag_name = str(opening.group("tag") or "").lower()
+            yield QuestionnaireFence(
+                tag_name=tag_name,
+                raw_payload=raw_payload,
+                start=opening.start(),
+                end=end,
+                opening_fence_length=len(opening.group("fence")),
+                closing_fence_length=closing_fence_length,
+                supported=tag_name in QUESTIONNAIRE_TAGS,
+            )
+
+            if closing is None:
+                break
+            cursor = end
+
+    def _fenced_questionnaire_validation_results(
+        self, content: str
+    ) -> List[tuple[QuestionnaireFence, List[str]]]:
+        fences = list(self._iter_questionnaire_fences(content))
+        results: List[tuple[QuestionnaireFence, List[str]]] = []
+        has_preface = True
+        if fences:
+            has_preface = self._has_questionnaire_preface(content[: fences[0].start])
+
+        for index, fence in enumerate(fences):
+            issues: List[str] = []
+            if index == 0 and not has_preface:
+                issues.append(
+                    f"```{fence.tag_name}``` 不能作为整条回复的唯一内容；"
+                    "问卷前必须包含非空的普通说明文字"
+                )
+            issues.extend(self._validate_fenced_questionnaire(fence))
+            results.append((fence, issues))
+        return results
+
+    def _has_questionnaire_preface(self, prefix: str) -> bool:
+        visible_prefix = self._structured_tag_pattern().sub("", prefix)
+        code_ranges = self._markdown_code_ranges(visible_prefix)
+        if code_ranges:
+            fragments: List[str] = []
+            cursor = 0
+            for start, end in code_ranges:
+                fragments.append(visible_prefix[cursor:start])
+                cursor = end
+            fragments.append(visible_prefix[cursor:])
+            visible_prefix = "".join(fragments)
+        return bool(visible_prefix.strip())
+
     def _validate_structured_tag_payloads(self, content: str) -> List[str]:
         issues: List[str] = []
         for tag_name, raw_payload in self._iter_structured_tag_matches(content):
             issues.extend(self._validate_structured_tag_payload(tag_name, raw_payload))
+        for _fence, fence_issues in self._fenced_questionnaire_validation_results(
+            content
+        ):
+            issues.extend(fence_issues)
         return issues
 
     def _validate_structured_tag_payload(
@@ -835,6 +958,149 @@ class SelfCheckAgent(AgentBase):
             return self._validate_questionnaire_payload(tag_name, payload)
         if tag_name in QUESTIONNAIRE_RESPONSE_TAGS:
             return self._validate_questionnaire_response_payload(tag_name, payload)
+        return []
+
+    def _validate_fenced_questionnaire(
+        self, fence: QuestionnaireFence
+    ) -> List[str]:
+        label = f"```{fence.tag_name}```"
+        if not fence.supported:
+            supported = ", ".join(QUESTIONNAIRE_TAGS)
+            return [
+                f"{label} 不是受支持的问卷别名；请使用以下之一: {supported}"
+            ]
+        if fence.opening_fence_length < 3:
+            return [f"{label} 的起始围栏至少需要三个反引号"]
+        if fence.closing_fence_length is None:
+            return [f"{label} 缺少独占一行的结束围栏"]
+        if fence.closing_fence_length < fence.opening_fence_length:
+            return [
+                f"{label} 的结束围栏不能短于起始围栏"
+            ]
+
+        raw_payload = str(fence.raw_payload or "")
+        payload_text = raw_payload.strip()
+        if not payload_text:
+            return [f"{label} 的 YAML 内容不能为空"]
+        if payload_text.startswith(("{", "[")):
+            return [f"{label} 必须使用块状 YAML，不能放入 JSON 载荷"]
+        if NESTED_FENCE_PATTERN.search(raw_payload):
+            return [f"{label} 内不能嵌套代码围栏"]
+        if yaml is None:
+            return [f"{label} 无法校验：当前运行环境缺少 YAML 解析器"]
+
+        try:
+            payload = yaml.safe_load(payload_text)
+        except Exception as exc:
+            return [f"{label} 不是合法 YAML: {self._format_yaml_error(exc)}"]
+
+        if not isinstance(payload, dict):
+            return [f"{label} 的 YAML 顶层必须是对象"]
+        return self._validate_strict_fenced_questionnaire_payload(
+            fence.tag_name, payload
+        )
+
+    @staticmethod
+    def _format_yaml_error(error: Exception) -> str:
+        problem = str(getattr(error, "problem", "") or "").strip()
+        mark = getattr(error, "problem_mark", None)
+        if problem and mark is not None:
+            return f"line {mark.line + 1} column {mark.column + 1}: {problem}"
+        return problem or str(error)
+
+    def _validate_strict_fenced_questionnaire_payload(
+        self, tag_name: str, payload: Dict[str, Any]
+    ) -> List[str]:
+        label = f"```{tag_name}```"
+        top_level_fields = set(payload.keys())
+        allowed_top_level_fields = {"title", "questions"}
+        unexpected_top_level_fields = sorted(
+            str(field)
+            for field in top_level_fields - allowed_top_level_fields
+        )
+        if unexpected_top_level_fields:
+            return [
+                f"{label} 顶层包含不允许的字段: "
+                f"{', '.join(unexpected_top_level_fields)}"
+            ]
+
+        title = payload.get("title")
+        if not isinstance(title, str) or not title.strip():
+            return [f"{label} 缺少合法的 title 字段"]
+
+        questions = payload.get("questions")
+        if not isinstance(questions, list):
+            return [f"{label} 缺少合法的 questions 数组"]
+        if not questions:
+            return [f"{label} questions 不能为空"]
+
+        for index, question in enumerate(questions, start=1):
+            issue_prefix = f"{label} questions[{index}]"
+            if not isinstance(question, dict):
+                return [f"{issue_prefix} 必须是对象"]
+            if any(not isinstance(field, str) for field in question):
+                return [f"{issue_prefix} 的字段名必须是字符串"]
+
+            question_type = str(question.get("type") or "").strip().lower()
+            if question_type not in {
+                "single_choice",
+                "multi_choice",
+                "free_text",
+            }:
+                return [
+                    f"{issue_prefix} 的 type 不受支持: "
+                    f"{question_type or '空'}"
+                ]
+
+            allowed_fields = {"type", "text", "default"}
+            if question_type in {"single_choice", "multi_choice"}:
+                allowed_fields.update({"options", "allow_other"})
+            unexpected_fields = sorted(set(question) - allowed_fields)
+            if unexpected_fields:
+                return [
+                    f"{issue_prefix} 包含不允许的字段: "
+                    f"{', '.join(unexpected_fields)}"
+                ]
+
+            text = question.get("text")
+            if not isinstance(text, str) or not text.strip():
+                return [f"{issue_prefix} 缺少合法的 text 字段"]
+            if "default" not in question:
+                return [f"{issue_prefix} 缺少 default 字段"]
+
+            if question_type in {"single_choice", "multi_choice"}:
+                options = question.get("options")
+                if (
+                    not isinstance(options, list)
+                    or not options
+                    or any(
+                        not isinstance(option, str) or not option.strip()
+                        for option in options
+                    )
+                ):
+                    return [f"{issue_prefix} 的 options 必须是非空字符串数组"]
+                allow_other = question.get("allow_other")
+                if allow_other is not None and not isinstance(allow_other, bool):
+                    return [f"{issue_prefix} 的 allow_other 必须是布尔值"]
+
+                default = question.get("default")
+                if question_type == "single_choice":
+                    if not isinstance(default, str) or default not in options:
+                        return [
+                            f"{issue_prefix} 的 default 必须等于一个 options 选项"
+                        ]
+                else:
+                    if not isinstance(default, list) or any(
+                        not isinstance(value, str) or value not in options
+                        for value in default
+                    ):
+                        return [
+                            f"{issue_prefix} 的 default 必须是 options 的字符串子集"
+                        ]
+                continue
+
+            if not isinstance(question.get("default"), str):
+                return [f"{issue_prefix} 的 default 必须是字符串"]
         return []
 
     def _validate_artifacts_payload(

--- a/tests/sagents/test_self_check_agent_paths.py
+++ b/tests/sagents/test_self_check_agent_paths.py
@@ -1,9 +1,21 @@
 import asyncio
 import importlib.util
+import re
 import sys
 import types
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
+
+
+QUESTIONNAIRE_TAGS = (
+    "yiii-questionnaire",
+    "movo-questionnaire",
+    "ling-questionnaire",
+    "sage-questionnaire",
+    "questionnaire",
+)
 
 
 def _load_self_check_agent(monkeypatch):
@@ -108,6 +120,32 @@ def _assert_hidden_self_check_message(chunk):
     assert chunk.metadata["llm_scope"] == "next_request"
     assert chunk.metadata["llm_state"] == "pending"
     assert chunk.metadata["runtime_diagnostic_source"] == "sage_self_check"
+
+
+def _valid_fenced_questionnaire(tag_name="yiii-questionnaire"):
+    return (
+        "当前事实已经整理完毕，请在问卷中提供下一步所需信息。\n\n"
+        f"```{tag_name}\n"
+        'title: "项目确认"\n'
+        "questions:\n"
+        "  - type: single_choice\n"
+        '    text: "下一步如何处理？"\n'
+        "    options:\n"
+        '      - "继续"\n'
+        '      - "调整"\n'
+        '    default: "继续"\n'
+        "    allow_other: true\n"
+        "  - type: multi_choice\n"
+        '    text: "需要调整哪些部分？"\n'
+        "    options:\n"
+        '      - "内容"\n'
+        '      - "风格"\n'
+        "    default: []\n"
+        "  - type: free_text\n"
+        '    text: "还有哪些约束？"\n'
+        '    default: ""\n'
+        "```"
+    )
 
 
 def test_only_latest_assistant_message_is_checked(monkeypatch):
@@ -757,6 +795,272 @@ def test_invalid_questionnaire_must_be_reoutput_before_requirement_clears(
     assert final_chunks == []
     assert session_context.audit_status["self_check_passed"] is True
     assert "self_check_required_structured_tags" not in session_context.audit_status
+
+
+@pytest.mark.parametrize("tag_name", QUESTIONNAIRE_TAGS)
+def test_registered_fenced_questionnaire_aliases_are_accepted(monkeypatch, tag_name):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+    content = _valid_fenced_questionnaire(tag_name)
+
+    assert agent._content_has_structured_tags(content) is True
+    assert agent._validate_structured_tag_payloads(content) == []
+    assert tag_name in agent._structured_tag_names(content)
+
+
+@pytest.mark.parametrize("tag_name", QUESTIONNAIRE_TAGS)
+def test_registered_xml_json_questionnaire_aliases_remain_accepted(
+    monkeypatch, tag_name
+):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+    content = (
+        f"<{tag_name}>"
+        '{"title":"确认","questions":['
+        '{"type":"single_choice","text":"继续？",'
+        '"options":["是","否"],"default":"是"}]}'
+        f"</{tag_name}>"
+    )
+
+    assert agent._content_has_structured_tags(content) is True
+    assert agent._validate_structured_tag_payloads(content) == []
+
+
+@pytest.mark.parametrize(
+    ("content", "expected_issue"),
+    [
+        (
+            "说明。\n\n```yiii-questionnaire\n"
+            '{"title":"确认","questions":[]}\n```',
+            "不能放入 JSON 载荷",
+        ),
+        (
+            "说明。\n\n```foo-questionnaire\n"
+            'title: "确认"\nquestions: []\n```',
+            "不是受支持的问卷别名",
+        ),
+        (
+            "```yiii-questionnaire\n"
+            'title: "确认"\nquestions:\n'
+            "  - type: free_text\n"
+            '    text: "补充？"\n'
+            '    default: ""\n```',
+            "问卷前必须包含非空的普通说明文字",
+        ),
+        (
+            "说明。\n\n```yiii-questionnaire\n"
+            'title: "确认"\nquestions:\n'
+            "  - type: free_text\n"
+            '    text: "补充？"\n'
+            '    default: ""',
+            "缺少独占一行的结束围栏",
+        ),
+        (
+            "说明。\n\n``yiii-questionnaire\n"
+            'title: "确认"\nquestions: []\n``',
+            "起始围栏至少需要三个反引号",
+        ),
+        (
+            "说明。\n\n```yiii-questionnaire\n"
+            'title: "确认"\nquestions:\n'
+            "  - type: single_choice\n"
+            '    text: "继续？"\n'
+            "    options:\n"
+            '      - "是"\n'
+            '      - "否"\n'
+            '    default: "稍后"\n```',
+            "default 必须等于一个 options 选项",
+        ),
+        (
+            "说明。\n\n```yiii-questionnaire\n"
+            'title: "确认"\nsubtitle: "不允许"\nquestions: []\n```',
+            "顶层包含不允许的字段: subtitle",
+        ),
+        (
+            "说明。\n\n```yiii-questionnaire\n"
+            'title: "确认"\nquestions:\n'
+            "  - type: free_text\n"
+            '    text: "补充？"\n'
+            '    default: ""\n'
+            "    allow_other: true\n```",
+            "包含不允许的字段: allow_other",
+        ),
+    ],
+)
+def test_invalid_fenced_questionnaire_variants_are_rejected(
+    monkeypatch, content, expected_issue
+):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+
+    issues = agent._validate_structured_tag_payloads(content)
+
+    assert any(expected_issue in issue for issue in issues), issues
+
+
+def test_questionnaire_fence_shown_inside_larger_code_block_is_not_executed(
+    monkeypatch,
+):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+    content = (
+        "下面只是格式示例。\n\n"
+        "````markdown\n"
+        "```yiii-questionnaire\n"
+        'title: "示例"\nquestions: []\n'
+        "```\n"
+        "````"
+    )
+
+    assert agent._content_has_structured_tags(content) is False
+    assert agent._validate_structured_tag_payloads(content) == []
+
+
+def test_invalid_fenced_questionnaire_can_be_repaired_with_xml_json(
+    monkeypatch, tmp_path
+):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    class DummySandbox:
+        async def file_exists(self, path):
+            return True
+
+    session_context = SimpleNamespace(
+        audit_status={},
+        sandbox=DummySandbox(),
+        sandbox_agent_workspace=str(workspace),
+        system_context={"private_workspace": str(workspace)},
+        message_manager=SimpleNamespace(messages=[]),
+    )
+
+    async def run_with_reply(reply):
+        session_context.message_manager.messages = [
+            _make_message("user", "请确认"),
+            _make_message("assistant", reply),
+        ]
+        chunks = []
+        async for batch in agent.run_stream(session_context):
+            chunks.extend(batch)
+        return chunks
+
+    invalid_yaml = (
+        "说明。\n\n```yiii-questionnaire\n"
+        'title: "确认"\nquestions:\n'
+        "  - type: single_choice\n"
+        '    text: "继续？"\n'
+        "    options:\n"
+        '      - "是"\n'
+        '      - "否"\n'
+        '    default: "稍后"\n```'
+    )
+    valid_xml_json = (
+        '<yiii-questionnaire>{"title":"确认","questions":['
+        '{"type":"single_choice","text":"继续？",'
+        '"options":["是","否"],"default":"是"}]}'
+        "</yiii-questionnaire>"
+    )
+
+    first_chunks = asyncio.run(run_with_reply(invalid_yaml))
+    assert first_chunks
+    assert session_context.audit_status[
+        "self_check_required_structured_tags"
+    ] == ["yiii-questionnaire"]
+
+    final_chunks = asyncio.run(run_with_reply(valid_xml_json))
+    assert final_chunks == []
+    assert session_context.audit_status["self_check_passed"] is True
+    assert "self_check_required_structured_tags" not in session_context.audit_status
+
+
+def test_unknown_fenced_alias_can_be_repaired_with_registered_alias(
+    monkeypatch, tmp_path
+):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    class DummySandbox:
+        async def file_exists(self, path):
+            return True
+
+    session_context = SimpleNamespace(
+        audit_status={},
+        sandbox=DummySandbox(),
+        sandbox_agent_workspace=str(workspace),
+        system_context={"private_workspace": str(workspace)},
+        message_manager=SimpleNamespace(messages=[]),
+    )
+
+    async def run_with_reply(reply):
+        session_context.message_manager.messages = [
+            _make_message("user", "请确认"),
+            _make_message("assistant", reply),
+        ]
+        chunks = []
+        async for batch in agent.run_stream(session_context):
+            chunks.extend(batch)
+        return chunks
+
+    unknown = _valid_fenced_questionnaire("foo-questionnaire")
+    first_chunks = asyncio.run(run_with_reply(unknown))
+    assert first_chunks
+    assert session_context.audit_status[
+        "self_check_required_structured_tags"
+    ] == ["*-questionnaire"]
+
+    final_chunks = asyncio.run(
+        run_with_reply(_valid_fenced_questionnaire("sage-questionnaire"))
+    )
+    assert final_chunks == []
+    assert session_context.audit_status["self_check_passed"] is True
+
+
+@pytest.mark.parametrize(
+    "relative_doc_path",
+    [
+        "docs/zh/QUESTIONNAIRE_FORMATS.md",
+        "docs/en/QUESTIONNAIRE_FORMATS.md",
+    ],
+)
+def test_documented_questionnaire_examples_pass_self_check(
+    monkeypatch, relative_doc_path
+):
+    self_check_agent = _load_self_check_agent(monkeypatch)
+    agent = self_check_agent(model=None, model_config={})
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    document = (repo_root / relative_doc_path).read_text(encoding="utf-8")
+
+    yaml_example = re.search(
+        r"```(?P<tag>(?:yiii|movo|ling|sage)-questionnaire|questionnaire)\n"
+        r"(?P<payload>[\s\S]*?)\n```",
+        document,
+    )
+    assert yaml_example is not None
+    fenced_content = (
+        "Documented context.\n\n"
+        f"```{yaml_example.group('tag')}\n"
+        f"{yaml_example.group('payload')}\n```"
+    )
+    assert agent._validate_structured_tag_payloads(fenced_content) == []
+
+    xml_json_example = re.search(
+        r"<(?P<tag>(?:yiii|movo|ling|sage)-questionnaire|questionnaire)>"
+        r"(?P<payload>\{[\s\S]*?\})</(?P=tag)>",
+        document,
+    )
+    assert xml_json_example is not None
+    xml_json_content = (
+        f"<{xml_json_example.group('tag')}>"
+        f"{xml_json_example.group('payload')}"
+        f"</{xml_json_example.group('tag')}>"
+    )
+    assert agent._validate_structured_tag_payloads(xml_json_content) == []
 
 
 def test_inline_code_wrapped_file_link_triggers_execution_error(monkeypatch):


### PR DESCRIPTION
## Summary

- add strict fenced YAML validation for all five registered inline questionnaire aliases
- preserve the existing XML-tag-wrapped JSON protocol and alias-specific compatibility behavior
- carry both encodings through Self-check retry requirements
- document the supported formats in Chinese and English and link them from both docs indexes

## Scope

This PR intentionally does not add generic scanning for malformed or unknown XML questionnaire tags. It keeps the existing XML+JSON detection boundary and only implements the agreed multi-format support.

## Validation

- `.venv/bin/pytest tests/sagents/test_self_check_agent_paths.py tests/sagents/flow/test_default_self_check_flow.py -q` — 57 passed
- `.venv/bin/pytest tests/sagents -q` — 877 passed, 3 skipped, 37 subtests passed
- `.venv/bin/ruff check sagents/agent/self_check_agent.py tests/sagents/test_self_check_agent_paths.py` — passed
- `git diff --check origin/main...HEAD` — passed
- bilingual documentation examples are exercised by the Self-check tests

## Remaining validation

The local Jekyll build could not run because the environment does not provide the `jekyll` executable (`bundler: command not found: jekyll`). The PR is therefore opened as Draft.
