### PR TITLE
refactor: sandbox interface

### DIFF
--- a/sagents/context/session_context.py
+++ b/sagents/context/session_context.py
@@ -1492,6 +1492,9 @@ class SessionContext:
         if sandbox_mode == SandboxType.REMOTE:
             self.sandbox_agent_workspace = self.sandbox.workspace_path
 
+        # 基础沙箱由工厂初始化；代码运行时作为独立生命周期阶段准备。
+        await self.sandbox.prepare_code_environment()
+
         logger.debug(
             f"SessionContext: 沙箱环境初始化完成，耗时: {time.time() - t0:.3f}s"
         )
@@ -1538,10 +1541,9 @@ class SessionContext:
         初始化沙箱技能管理器：按宿主 SkillProxy 给出的名称，仅从沙箱内
         ``<agent_workspace>/skills/<name>/`` 加载（与挂载目录一致），供 load_skill 与提示词使用。
         """
-        # 创建沙箱技能管理器
-        skills_dir = os.path.join(self.sandbox_agent_workspace, "skills")  # pyright: ignore[reportArgumentType,reportCallIssue]
-        self.sandbox_skill_manager = SandboxSkillManager(self.sandbox, skills_dir)
-        await self.sandbox_skill_manager.sync_from_host(self.skill_manager)
+        self.sandbox_skill_manager = await self.sandbox.sync_skills(
+            self.skill_manager
+        )
 
     async def _finalize_system_context(self):
         """

--- a/sagents/utils/sandbox/factory.py
+++ b/sagents/utils/sandbox/factory.py
@@ -112,7 +112,7 @@ class SandboxProviderFactory:
                 raise ValueError(
                     "sandbox_agent_workspace is required for local sandbox"
                 )
-            return provider_class(
+            provider = provider_class(
                 sandbox_id=sandbox_id,  # pyright: ignore[reportCallIssue]
                 sandbox_agent_workspace=config.sandbox_agent_workspace,  # pyright: ignore[reportCallIssue]
                 volume_mounts=config.volume_mounts,  # pyright: ignore[reportCallIssue]
@@ -142,7 +142,7 @@ class SandboxProviderFactory:
             if config.remote_provider == "opensandbox":
                 if not config.remote_server_url:
                     raise ValueError("OpenSandbox requires server_url")
-                return provider_class(
+                provider = provider_class(
                     **common_kwargs,
                     server_url=config.remote_server_url,  # pyright: ignore[reportCallIssue]
                     api_key=config.remote_api_key,  # pyright: ignore[reportCallIssue]
@@ -153,7 +153,7 @@ class SandboxProviderFactory:
                 )
 
             elif config.remote_provider == "kubernetes":
-                return provider_class(
+                provider = provider_class(
                     **common_kwargs,
                     namespace=provider_config.get("namespace", "default"),  # pyright: ignore[reportCallIssue]
                     image=config.remote_image,  # pyright: ignore[reportCallIssue]
@@ -166,7 +166,7 @@ class SandboxProviderFactory:
                 )
 
             elif config.remote_provider == "firecracker":
-                return provider_class(
+                provider = provider_class(
                     **common_kwargs,
                     microvm_config=provider_config.get("microvm_config", {}),  # pyright: ignore[reportCallIssue]
                     **{
@@ -178,7 +178,7 @@ class SandboxProviderFactory:
 
             else:
                 # 自定义提供者，传递所有配置
-                return provider_class(**common_kwargs, **provider_config)
+                provider = provider_class(**common_kwargs, **provider_config)
 
         else:  # PASSTHROUGH
             provider_class = cls._get_passthrough_provider()
@@ -186,17 +186,32 @@ class SandboxProviderFactory:
                 raise ValueError(
                     "sandbox_agent_workspace is required for passthrough sandbox"
                 )
-            return provider_class(
+            provider = provider_class(
                 sandbox_id=sandbox_id,  # pyright: ignore[reportCallIssue]
                 sandbox_agent_workspace=config.sandbox_agent_workspace,  # pyright: ignore[reportCallIssue]
                 volume_mounts=config.volume_mounts,  # pyright: ignore[reportCallIssue]
             )
+
+        if not isinstance(provider, ISandboxHandle):
+            raise TypeError(
+                f"Sandbox provider {provider.__class__.__name__} must implement "
+                "ISandboxHandle"
+            )
+
+        # 工厂返回的 handle 始终已经完成基础资源初始化。代码运行时和技能
+        # 同步是两个独立阶段，由会话初始化流程按需显式调用。
+        await provider.initialize()
+        return provider
 
     @classmethod
     def register_local_provider(
         cls, mode: SandboxType, provider_class: Type[ISandboxHandle]
     ):
         """注册本地/直通模式提供者"""
+        if not isinstance(provider_class, type) or not issubclass(
+            provider_class, ISandboxHandle
+        ):
+            raise TypeError("provider_class must inherit ISandboxHandle")
         cls._providers[mode] = provider_class
 
     @classmethod
@@ -207,4 +222,8 @@ class SandboxProviderFactory:
             name: 提供者名称，如 "opensandbox", "kubernetes"
             provider_class: 提供者类，必须继承 RemoteSandboxProvider
         """
+        if not isinstance(provider_class, type) or not issubclass(
+            provider_class, ISandboxHandle
+        ):
+            raise TypeError("provider_class must inherit ISandboxHandle")
         cls._remote_providers[name] = provider_class

--- a/sagents/utils/sandbox/interface.py
+++ b/sagents/utils/sandbox/interface.py
@@ -6,8 +6,11 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 from enum import Enum
+
+if TYPE_CHECKING:
+    from sagents.skill.sandbox_skill_manager import SandboxSkillManager
 
 
 class SandboxType(Enum):
@@ -330,6 +333,20 @@ class ISandboxHandle(ABC):
         pass
 
     # ========== 生命周期 ==========
+
+    @abstractmethod
+    async def prepare_code_environment(self) -> None:
+        """准备代码执行所需的运行时环境。
+
+        该步骤与沙箱基础资源初始化分离，可安全地重复调用。不同 provider
+        可以在这里准备 Python venv、远端解释器或其他代码运行时。
+        """
+        pass
+
+    @abstractmethod
+    async def sync_skills(self, host_skill_manager: Any) -> "SandboxSkillManager":
+        """将宿主技能同步到沙箱，并返回沙箱侧技能管理器。"""
+        pass
 
     @abstractmethod
     async def initialize(self) -> None:

--- a/sagents/utils/sandbox/providers/local/local.py
+++ b/sagents/utils/sandbox/providers/local/local.py
@@ -422,6 +422,24 @@ class LocalSandboxProvider(ISandboxHandle):
         """初始化本地沙箱"""
         await self._ensure_initialized_async()
 
+    async def prepare_code_environment(self) -> None:
+        """准备本地代码运行时配置，venv 在首次执行代码时按需创建。
+
+        Session 初始化不能被创建 venv 和安装 uv 阻塞；``execute_command`` /
+        ``execute_python`` 会在真正需要代码环境时调用 ``_ensure_venv``。
+        """
+        await self._ensure_initialized_async()
+
+    async def sync_skills(self, host_skill_manager):
+        """同步宿主技能到本地沙箱工作区。"""
+        from sagents.skill.sandbox_skill_manager import SandboxSkillManager
+
+        manager = SandboxSkillManager(
+            self, os.path.join(self.workspace_path, "skills")
+        )
+        await manager.sync_from_host(host_skill_manager)
+        return manager
+
     async def cleanup(self) -> None:
         """清理本地沙箱资源"""
         # 本地沙箱不需要特殊清理

--- a/sagents/utils/sandbox/providers/passthrough/passthrough.py
+++ b/sagents/utils/sandbox/providers/passthrough/passthrough.py
@@ -257,8 +257,21 @@ class PassthroughSandboxProvider(ISandboxHandle):
 
     async def initialize(self) -> None:
         """初始化直通模式沙箱"""
-        # 直通模式不需要特殊初始化
-        pass
+        await self.ensure_directory(self.workspace_path)
+
+    async def prepare_code_environment(self) -> None:
+        """直通模式直接复用宿主机代码环境。"""
+        await self.ensure_directory(self.workspace_path)
+
+    async def sync_skills(self, host_skill_manager):
+        """同步宿主技能到直通沙箱工作区。"""
+        from sagents.skill.sandbox_skill_manager import SandboxSkillManager
+
+        manager = SandboxSkillManager(
+            self, os.path.join(self.workspace_path, "skills")
+        )
+        await manager.sync_from_host(host_skill_manager)
+        return manager
 
     async def cleanup(self) -> None:
         """清理直通模式沙箱资源"""

--- a/sagents/utils/sandbox/providers/remote/base.py
+++ b/sagents/utils/sandbox/providers/remote/base.py
@@ -101,6 +101,25 @@ class RemoteSandboxProvider(ISandboxHandle):
         """初始化远程沙箱"""
         pass
 
+    async def prepare_code_environment(self) -> None:
+        """确保远端沙箱及代码工作区可用。
+
+        具体远端 provider 若需安装额外运行时可覆写本方法。
+        """
+        if not self._is_initialized:
+            await self.initialize()
+        await self.ensure_directory(self.workspace_path)
+
+    async def sync_skills(self, host_skill_manager):
+        """通过远端文件接口同步宿主技能。"""
+        from sagents.skill.sandbox_skill_manager import SandboxSkillManager
+
+        manager = SandboxSkillManager(
+            self, os.path.join(self.workspace_path, "skills")
+        )
+        await manager.sync_from_host(host_skill_manager)
+        return manager
+
     @abstractmethod
     async def cleanup(self) -> None:
         """清理沙箱资源（断开连接，不删除沙箱）"""

--- a/tests/sagents/utils/sandbox/test_factory_lifecycle.py
+++ b/tests/sagents/utils/sandbox/test_factory_lifecycle.py
@@ -1,0 +1,33 @@
+import asyncio
+
+from sagents.utils.sandbox.config import SandboxConfig
+from sagents.utils.sandbox.factory import SandboxProviderFactory
+from sagents.utils.sandbox.interface import SandboxType
+from sagents.utils.sandbox.providers.passthrough.passthrough import (
+    PassthroughSandboxProvider,
+)
+
+
+def test_factory_initializes_provider_before_returning(monkeypatch, tmp_path):
+    calls = []
+
+    class FakeProvider(PassthroughSandboxProvider):
+        async def initialize(self):
+            calls.append("initialize")
+
+    monkeypatch.setitem(
+        SandboxProviderFactory._providers, SandboxType.PASSTHROUGH, FakeProvider
+    )
+
+    provider = asyncio.run(
+        SandboxProviderFactory.create(
+            SandboxConfig(
+                sandbox_id="test-sandbox",
+                mode=SandboxType.PASSTHROUGH,
+                sandbox_agent_workspace=str(tmp_path),
+            )
+        )
+    )
+
+    assert isinstance(provider, FakeProvider)
+    assert calls == ["initialize"]

--- a/tests/sagents/utils/sandbox/test_lifecycle_e2e.py
+++ b/tests/sagents/utils/sandbox/test_lifecycle_e2e.py
@@ -1,0 +1,63 @@
+import asyncio
+
+import pytest
+
+from sagents.skill.skill_manager import SkillManager
+from sagents.utils.sandbox.config import SandboxConfig
+from sagents.utils.sandbox.factory import SandboxProviderFactory
+from sagents.utils.sandbox.interface import SandboxType
+
+
+@pytest.mark.parametrize("mode", [SandboxType.PASSTHROUGH, SandboxType.LOCAL])
+@pytest.mark.timeout(60)
+def test_sandbox_lifecycle_syncs_skill_and_executes_python(tmp_path, mode):
+    host_skills = tmp_path / "host-skills"
+    skill_dir = host_skills / "e2e-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: e2e-skill\n"
+        "description: End-to-end sandbox lifecycle test\n"
+        "---\n"
+        "Use this skill to verify sandbox initialization.\n",
+        encoding="utf-8",
+    )
+    workspace = tmp_path / f"{mode.value}-workspace"
+    workspace.mkdir()
+    host_skill_manager = SkillManager([str(host_skills)], isolated=True)
+
+    async def run_lifecycle():
+        sandbox = await SandboxProviderFactory.create(
+            SandboxConfig(
+                sandbox_id=f"e2e-{mode.value}",
+                mode=mode,
+                sandbox_agent_workspace=str(workspace),
+                # E2E 关注生命周期；subprocess 避免依赖主机是否安装 bwrap。
+                linux_isolation_mode="subprocess",
+                macos_isolation_mode="subprocess",
+            )
+        )
+        try:
+            await sandbox.prepare_code_environment()
+            sandbox_skills = await sandbox.sync_skills(host_skill_manager)
+            result = await sandbox.execute_python(
+                "from pathlib import Path\n"
+                "p = Path('lifecycle-result.txt')\n"
+                "p.write_text('ready', encoding='utf-8')\n"
+                "print(p.read_text(encoding='utf-8'))\n",
+                workdir=sandbox.workspace_path,
+            )
+
+            assert sandbox_skills.list_skills() == ["e2e-skill"]
+            assert await sandbox.file_exists(
+                f"{sandbox.workspace_path}/skills/e2e-skill/SKILL.md"
+            )
+            assert result.success, result.error
+            assert result.output.strip() == "ready"
+            assert await sandbox.read_file(
+                f"{sandbox.workspace_path}/lifecycle-result.txt"
+            ) == "ready"
+        finally:
+            await sandbox.cleanup()
+
+    asyncio.run(run_lifecycle())

--- a/tests/sagents/utils/sandbox/test_provider_interface_conformance.py
+++ b/tests/sagents/utils/sandbox/test_provider_interface_conformance.py
@@ -1,0 +1,47 @@
+import inspect
+
+import pytest
+
+from sagents.utils.sandbox.factory import SandboxProviderFactory
+from sagents.utils.sandbox.interface import ISandboxHandle, SandboxType
+from sagents.utils.sandbox.providers.local.local import LocalSandboxProvider
+from sagents.utils.sandbox.providers.passthrough.passthrough import (
+    PassthroughSandboxProvider,
+)
+from sagents.utils.sandbox.providers.remote.firecracker import (
+    FirecrackerSandboxProvider,
+)
+from sagents.utils.sandbox.providers.remote.kubernetes import (
+    KubernetesSandboxProvider,
+)
+from sagents.utils.sandbox.providers.remote.opensandbox import OpenSandboxProvider
+
+
+@pytest.mark.parametrize(
+    "provider_class",
+    [
+        LocalSandboxProvider,
+        PassthroughSandboxProvider,
+        OpenSandboxProvider,
+        KubernetesSandboxProvider,
+        FirecrackerSandboxProvider,
+    ],
+)
+def test_builtin_provider_follows_sandbox_interface(provider_class):
+    assert issubclass(provider_class, ISandboxHandle)
+    assert not inspect.isabstract(provider_class)
+    assert callable(getattr(provider_class, "prepare_code_environment", None))
+    assert callable(getattr(provider_class, "sync_skills", None))
+
+
+def test_factory_rejects_provider_outside_interface():
+    class InvalidProvider:
+        pass
+
+    with pytest.raises(TypeError, match="ISandboxHandle"):
+        SandboxProviderFactory.register_local_provider(
+            SandboxType.LOCAL, InvalidProvider
+        )
+
+    with pytest.raises(TypeError, match="ISandboxHandle"):
+        SandboxProviderFactory.register_remote_provider("invalid", InvalidProvider)


### PR DESCRIPTION
## Summary

重构沙箱初始化流程，拆分基础初始化、代码环境准备和 Skill 同步职责。

主要改动：

- `ISandboxHandle` 新增 `prepare_code_environment()` 和 `sync_skills()`
- Local、Passthrough 和 Remote Provider 统一实现新接口
- 工厂负责基础初始化，`SessionContext` 负责后续环境准备和 Skill 同步
- 增加 Provider 接口校验，拒绝未实现 `ISandboxHandle` 的自定义 Provider
- 新增生命周期端到端和接口一致性测试