### PR TITLE
Stop writing Sage docs into Server agent workspaces

### DIFF
--- a/app/terminal/src/backend/tests/handle.rs
+++ b/app/terminal/src/backend/tests/handle.rs
@@ -15,8 +15,11 @@ fn backend_handle_supports_two_round_trips_without_respawn() {
     fs::create_dir_all(&temp_dir).expect("temp dir should be created");
     let script_path = write_fake_backend_script(&temp_dir);
     let log_path = temp_dir.join("backend-prompts.log");
+    let args_path = temp_dir.join("backend-args.log");
     let _python_guard = EnvVarGuard::set("PYTHON", &script_path.display().to_string());
+    let _cli_guard = EnvVarGuard::set("SAGE_TERMINAL_CLI", &script_path.display().to_string());
     let _log_guard = EnvVarGuard::set("TEST_BACKEND_LOG", &log_path.display().to_string());
+    let _args_guard = EnvVarGuard::set("TEST_BACKEND_ARGS_LOG", &args_path.display().to_string());
 
     let request = BackendRequest {
         session_id: "local-0001".to_string(),
@@ -55,6 +58,11 @@ fn backend_handle_supports_two_round_trips_without_respawn() {
         prompts.lines().collect::<Vec<_>>(),
         vec!["first prompt", "second prompt"]
     );
+    let args = fs::read_to_string(&args_path).expect("backend args log should exist");
+    let lines = args.lines().collect::<Vec<_>>();
+    assert!(lines
+        .windows(2)
+        .any(|pair| { pair[0] == "--workspace" && pair[1] == temp_dir.display().to_string() }));
 
     handle.stop();
     let _ = wait_for_exit(&handle);
@@ -68,6 +76,7 @@ fn backend_handle_writes_sandbox_approval_decision_to_stdin() {
     let script_path = write_fake_backend_script(&temp_dir);
     let log_path = temp_dir.join("backend-prompts.log");
     let _python_guard = EnvVarGuard::set("PYTHON", &script_path.display().to_string());
+    let _cli_guard = EnvVarGuard::set("SAGE_TERMINAL_CLI", &script_path.display().to_string());
     let _log_guard = EnvVarGuard::set("TEST_BACKEND_LOG", &log_path.display().to_string());
 
     let request = BackendRequest {
@@ -121,6 +130,7 @@ fn backend_handle_omits_workspace_flag_when_not_overridden() {
     let script_path = write_fake_backend_script(&temp_dir);
     let args_path = temp_dir.join("backend-args.log");
     let _python_guard = EnvVarGuard::set("PYTHON", &script_path.display().to_string());
+    let _cli_guard = EnvVarGuard::set("SAGE_TERMINAL_CLI", &script_path.display().to_string());
     let _args_guard = EnvVarGuard::set("TEST_BACKEND_ARGS_LOG", &args_path.display().to_string());
 
     let request = BackendRequest {
@@ -165,6 +175,7 @@ fn backend_handle_forwards_agent_config_flag_without_agent_id() {
     let config_path = temp_dir.join("coding_config.json");
     fs::write(&config_path, "{}").expect("config file should be created");
     let _python_guard = EnvVarGuard::set("PYTHON", &script_path.display().to_string());
+    let _cli_guard = EnvVarGuard::set("SAGE_TERMINAL_CLI", &script_path.display().to_string());
     let _args_guard = EnvVarGuard::set("TEST_BACKEND_ARGS_LOG", &args_path.display().to_string());
     let _env_guard = EnvVarGuard::set("TEST_BACKEND_ENV_LOG", &env_path.display().to_string());
 

--- a/app/terminal/src/terminal/tests/interaction.rs
+++ b/app/terminal/src/terminal/tests/interaction.rs
@@ -517,6 +517,7 @@ fn retry_command_resubmits_last_task_through_backend() {
     let script_path = write_fake_backend_script(&temp_dir);
     let log_path = temp_dir.join("backend-prompts.log");
     let _python_guard = EnvVarGuard::set("PYTHON", &script_path.display().to_string());
+    let _cli_guard = EnvVarGuard::set("SAGE_TERMINAL_CLI", &script_path.display().to_string());
     let _log_guard = EnvVarGuard::set("TEST_BACKEND_LOG", &log_path.display().to_string());
 
     let mut app = App::new();

--- a/common/services/chat_service.py
+++ b/common/services/chat_service.py
@@ -39,6 +39,7 @@ from common.services.agent_workspace import (
     get_agent_workspace_root,
     get_agent_skill_dir,
 )
+from common.services.agent_service import delete_workspace_entry
 from common.services.chat_utils import (
     create_model_client,
     create_skill_proxy,
@@ -536,6 +537,21 @@ def _copy_sage_usage_docs_to_workspace(agent_workspace: str) -> None:
         logger.info(f"已将 sage-usage-docs 复制到 agent workspace: {target_dir}")
     except Exception as e:
         logger.warning(f"复制 sage-usage-docs 到 workspace 失败: {e}")
+
+
+def _cleanup_server_workspace_sage_docs(agent_workspace: str) -> None:
+    for directory_name in (".sage-docs", "sage_usage_docs"):
+        try:
+            delete_workspace_entry(
+                agent_workspace,
+                directory_name,
+                missing_ok=True,
+            )
+        except Exception as e:
+            logger.warning(
+                f"清理 Server Agent workspace 框架文档目录失败: "
+                f"workspace={agent_workspace}, directory={directory_name}, error={e}"
+            )
 
 
 def _copy_docs_to_agent_workspace(agent_workspace: str) -> None:
@@ -1183,7 +1199,7 @@ class SageStreamService:
             )
 
         await asyncio.to_thread(
-            _copy_sage_usage_docs_to_workspace, self.agent_workspace
+            _cleanup_server_workspace_sage_docs, self.agent_workspace
         )
 
     async def process_stream(self):

--- a/tests/common/services/test_chat_service_workspace_assets.py
+++ b/tests/common/services/test_chat_service_workspace_assets.py
@@ -1,0 +1,170 @@
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from app.cli.services import runtime as cli_runtime
+from common.services import chat_service, chat_utils
+
+
+def _server_stream_service(
+    workspace: Path,
+    *,
+    workspace_existed: bool,
+    agent_id: str = "agent_demo",
+):
+    service = object.__new__(chat_service.SageStreamService)
+    service.agent_workspace = str(workspace)
+    service._workspace_existed = workspace_existed
+    service.request = SimpleNamespace(agent_id=agent_id)
+    return service
+
+
+def test_server_new_workspace_does_not_create_sage_docs_and_repeats_cleanly(
+    tmp_path, monkeypatch
+):
+    workspace = tmp_path / "agent_workspace"
+    workspace.mkdir()
+    service = _server_stream_service(workspace, workspace_existed=False)
+
+    def copy_inherit(_agent_id, target_workspace):
+        (Path(target_workspace) / "inherited.txt").write_text(
+            "kept", encoding="utf-8"
+        )
+
+    monkeypatch.setattr(chat_service, "_is_desktop_mode", lambda: False)
+    monkeypatch.setattr(
+        chat_service.importlib,
+        "import_module",
+        lambda _name: SimpleNamespace(
+            copy_agent_inherit_to_workspace=copy_inherit
+        ),
+    )
+    monkeypatch.setattr(
+        chat_service,
+        "_copy_sage_usage_docs_to_workspace",
+        lambda _workspace: (_ for _ in ()).throw(
+            AssertionError("Server must not copy .sage-docs")
+        ),
+    )
+
+    asyncio.run(service.initialize_workspace_assets())
+    asyncio.run(service.initialize_workspace_assets())
+
+    assert (workspace / "inherited.txt").read_text(encoding="utf-8") == "kept"
+    assert not (workspace / ".sage-docs").exists()
+    assert not (workspace / "sage_usage_docs").exists()
+
+
+def test_server_existing_workspace_cleans_exact_historical_directories(
+    tmp_path, monkeypatch
+):
+    workspace = tmp_path / "agent_workspace"
+    for directory_name in (
+        ".sage-docs",
+        "sage_usage_docs",
+        ".sage-docs-user",
+        "sage_usage_docs_backup",
+    ):
+        directory = workspace / directory_name
+        directory.mkdir(parents=True)
+        (directory / "guide.md").write_text("content", encoding="utf-8")
+    (workspace / "user-file.txt").write_text("keep", encoding="utf-8")
+    nested_docs = workspace / "project" / ".sage-docs"
+    nested_docs.mkdir(parents=True)
+    (nested_docs / "user-guide.md").write_text("keep", encoding="utf-8")
+    service = _server_stream_service(workspace, workspace_existed=True)
+
+    monkeypatch.setattr(chat_service, "_is_desktop_mode", lambda: False)
+
+    asyncio.run(service.initialize_workspace_assets())
+    asyncio.run(service.initialize_workspace_assets())
+
+    assert not (workspace / ".sage-docs").exists()
+    assert not (workspace / "sage_usage_docs").exists()
+    assert (workspace / ".sage-docs-user" / "guide.md").exists()
+    assert (workspace / "sage_usage_docs_backup" / "guide.md").exists()
+    assert (nested_docs / "user-guide.md").exists()
+    assert (workspace / "user-file.txt").read_text(encoding="utf-8") == "keep"
+
+
+def test_server_workspace_cleanup_failure_warns_and_continues(monkeypatch):
+    calls = []
+    warnings = []
+
+    def fail_delete(_workspace, directory_name, *, missing_ok):
+        calls.append((directory_name, missing_ok))
+        raise RuntimeError("read-only")
+
+    monkeypatch.setattr(chat_service, "delete_workspace_entry", fail_delete)
+    monkeypatch.setattr(chat_service.logger, "warning", warnings.append)
+
+    chat_service._cleanup_server_workspace_sage_docs("/agent/workspace")
+
+    assert calls == [(".sage-docs", True), ("sage_usage_docs", True)]
+    assert len(warnings) == 2
+    assert all("read-only" in warning for warning in warnings)
+
+
+def test_desktop_sage_usage_docs_copy_remains_unchanged(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    source = home / ".sage" / "sage-usage-docs"
+    source.mkdir(parents=True)
+    (source / "guide.md").write_text("desktop docs", encoding="utf-8")
+    agents_root = tmp_path / "desktop_agents"
+    monkeypatch.setenv("HOME", str(home))
+
+    chat_service._copy_sage_usage_docs_to_agent_workspace_sync(
+        "agent_desktop",
+        str(agents_root),
+    )
+
+    copied = agents_root / "agent_desktop" / "sage_usage_docs" / "guide.md"
+    assert copied.read_text(encoding="utf-8") == "desktop docs"
+
+
+def test_cli_and_tui_stream_workspace_still_copy_sage_docs(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    source = home / ".sage" / "sage-usage-docs"
+    source.mkdir(parents=True)
+    (source / "guide.md").write_text("cli docs", encoding="utf-8")
+    workspace = tmp_path / "cli_workspace"
+    monkeypatch.setenv("HOME", str(home))
+
+    request = SimpleNamespace(
+        sandbox_approval_mode=None,
+        system_context={},
+        available_skills=[],
+        user_id="cli_user",
+    )
+    stream_service = SimpleNamespace(agent_workspace="unused")
+
+    async def populate_request(_request, *, require_agent_id):
+        assert require_agent_id is False
+
+    async def prepare_session(_request):
+        return stream_service, None
+
+    async def execute_chat_session(_stream_service):
+        yield json.dumps({"type": "done"})
+
+    monkeypatch.setattr(
+        chat_service, "populate_request_from_agent_config", populate_request
+    )
+    monkeypatch.setattr(chat_service, "prepare_session", prepare_session)
+    monkeypatch.setattr(chat_service, "execute_chat_session", execute_chat_session)
+    monkeypatch.setattr(
+        chat_utils, "create_skill_proxy", lambda *args, **kwargs: (object(), None)
+    )
+
+    async def collect_events():
+        return [
+            event
+            async for event in cli_runtime.run_request_stream(
+                request, workspace=str(workspace)
+            )
+        ]
+
+    assert asyncio.run(collect_events()) == [{"type": "done"}]
+    copied = workspace / ".sage-docs" / "guide.md"
+    assert copied.read_text(encoding="utf-8") == "cli docs"


### PR DESCRIPTION
## Summary

- stop Server session initialization from copying Sage framework usage docs into Agent workspaces
- clean historical root-level `.sage-docs` and `sage_usage_docs` directories idempotently without blocking sessions on cleanup failures
- preserve the existing Desktop and CLI/TUI document-copying behavior
- add Server, Desktop, CLI, and TUI regression coverage

## Root cause

`SageStreamService.initialize_workspace_assets()` reused the CLI-oriented `.sage-docs` copy helper in Server mode, so framework-internal usage docs were written into user Agent workspaces on every initialization. Cleanup alone would not be durable because the same initialization path recreated the directory.

## Impact

New and existing Server Agent workspaces no longer retain Sage framework documentation directories after initialization. Only exact directory names at the workspace root are removed; similarly named and nested user directories remain untouched. Desktop and CLI/TUI behavior is unchanged.

## Validation

- `.venv/bin/pytest tests/common/services tests/app/cli -q` — 240 passed
- `cargo test --manifest-path app/terminal/Cargo.toml` — 299 passed
- Ruff, Rust formatting, and `git diff --check` passed
