### PR TITLE
fix: release session-scoped memory and bound cleanup

### DIFF
--- a/app/desktop/core/lifecycle.py
+++ b/app/desktop/core/lifecycle.py
@@ -318,6 +318,11 @@ async def cleanup_system():
     if _browser_capability_coordinator:
         await _browser_capability_coordinator.stop()
         _browser_capability_coordinator = None
+    from common.services.async_task_service import shutdown_async_task_service
+    from sagents.session_runtime import shutdown_global_session_manager
+
+    await shutdown_async_task_service()
+    await shutdown_global_session_manager()
     await close_observability()
     # 关闭第三方客户端
     await shutdown_clients()

--- a/app/server/lifecycle.py
+++ b/app/server/lifecycle.py
@@ -99,6 +99,11 @@ async def _start_task_scheduler():
 async def cleanup_system():
     logger.info("Sage正在清理资源...")
     await shutdown_scheduler()
+    from common.services.async_task_service import shutdown_async_task_service
+    from sagents.session_runtime import shutdown_global_session_manager
+
+    await shutdown_async_task_service()
+    await shutdown_global_session_manager()
     # 关闭 观测链路上报 (需在 DB 关闭前)
     await close_observability()
     # 关闭第三方客户端

--- a/common/services/agent_service.py
+++ b/common/services/agent_service.py
@@ -11,9 +11,10 @@ import tempfile
 import threading
 import uuid
 import zipfile
+from contextlib import contextmanager
 from io import BytesIO, StringIO
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 from urllib.parse import urlparse
 
 from loguru import logger
@@ -58,9 +59,17 @@ DEFAULT_OPENCLAW_AGENT_TOOLS = [
 ]
 
 _WORKSPACE_FILE_HASH_ALGORITHM = "md5"
-_WORKSPACE_CSV_LOCKS: Dict[str, threading.Lock] = {}
+
+
+class _RefCountedWorkspaceLock:
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.users = 0
+
+
+_WORKSPACE_CSV_LOCKS: Dict[str, _RefCountedWorkspaceLock] = {}
 _WORKSPACE_CSV_LOCKS_GUARD = threading.Lock()
-_WORKSPACE_ARCHIVE_LOCKS: Dict[str, threading.Lock] = {}
+_WORKSPACE_ARCHIVE_LOCKS: Dict[str, _RefCountedWorkspaceLock] = {}
 _WORKSPACE_ARCHIVE_LOCKS_GUARD = threading.Lock()
 _WORKSPACE_ARCHIVE_MAX_COMPRESSED_BYTES = 32 * 1024 * 1024
 _WORKSPACE_ARCHIVE_MAX_UNCOMPRESSED_BYTES = 128 * 1024 * 1024
@@ -1985,9 +1994,48 @@ def delete_workspace_entry(
         )
 
 
-def _workspace_csv_lock(file_path: str) -> threading.Lock:
-    with _WORKSPACE_CSV_LOCKS_GUARD:
-        return _WORKSPACE_CSV_LOCKS.setdefault(file_path, threading.Lock())
+@contextmanager
+def _workspace_path_lock(
+    registry: Dict[str, _RefCountedWorkspaceLock],
+    guard: threading.Lock,
+    key: str,
+) -> Iterator[threading.Lock]:
+    """Hold a keyed lock and remove it after the final holder/waiter exits."""
+    with guard:
+        entry = registry.get(key)
+        if entry is None:
+            entry = _RefCountedWorkspaceLock()
+            registry[key] = entry
+        entry.users += 1
+
+    acquired = False
+    try:
+        entry.lock.acquire()
+        acquired = True
+        yield entry.lock
+    finally:
+        if acquired:
+            entry.lock.release()
+        with guard:
+            entry.users -= 1
+            if entry.users == 0 and registry.get(key) is entry:
+                registry.pop(key, None)
+
+
+def _workspace_csv_lock(file_path: str):
+    return _workspace_path_lock(
+        _WORKSPACE_CSV_LOCKS,
+        _WORKSPACE_CSV_LOCKS_GUARD,
+        file_path,
+    )
+
+
+def _workspace_archive_lock(directory_path: str):
+    return _workspace_path_lock(
+        _WORKSPACE_ARCHIVE_LOCKS,
+        _WORKSPACE_ARCHIVE_LOCKS_GUARD,
+        directory_path,
+    )
 
 
 def _csv_row_key(row: Dict[str, str], columns: List[str]) -> str:
@@ -2044,8 +2092,7 @@ def mutate_workspace_csv(
     ):
         raise SageHTTPException(status_code=400, detail="Invalid CSV key or sort columns")
 
-    lock = _workspace_csv_lock(target_path)
-    with lock:
+    with _workspace_csv_lock(target_path):
         existing_bytes = b""
         rows_by_key: Dict[str, Dict[str, str]] = {}
         if os.path.exists(target_path):
@@ -2421,9 +2468,7 @@ def import_workspace_archive(
                 )
 
         lock_key = os.path.normcase(os.path.abspath(target_dir))
-        with _WORKSPACE_ARCHIVE_LOCKS_GUARD:
-            lock = _WORKSPACE_ARCHIVE_LOCKS.setdefault(lock_key, threading.Lock())
-        with lock:
+        with _workspace_archive_lock(lock_key):
             lock_path = os.path.join(workspace_abs, ".workspace-archive-import.lock")
             with open(lock_path, "a+b") as lock_file:
                 if fcntl is not None:

--- a/common/services/async_task_service.py
+++ b/common/services/async_task_service.py
@@ -9,9 +9,20 @@ from common.core.exceptions import SageHTTPException
 
 
 class AsyncTaskService:
-    def __init__(self) -> None:
+    TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
+
+    def __init__(
+        self,
+        *,
+        retention_seconds: float = 60 * 30,
+        cleanup_interval_seconds: float = 60,
+    ) -> None:
         self._tasks: Dict[str, Dict[str, Any]] = {}
         self._lock = asyncio.Lock()
+        self._retention_seconds = retention_seconds
+        self._cleanup_interval_seconds = cleanup_interval_seconds
+        self._cleanup_task: Optional[asyncio.Task] = None
+        self._shutdown = False
 
     async def submit(
         self,
@@ -35,13 +46,9 @@ class AsyncTaskService:
             "updated_at": now,
         }
 
-        async with self._lock:
-            self._cleanup_locked()
-            self._tasks[task_id] = task_data
-
         async def _run() -> None:
-            await self._update(task_id, status="running")
             try:
+                await self._update(task_id, status="running")
                 result = await runner()
                 await self._update(task_id, status="completed", result=result)
             except asyncio.CancelledError:
@@ -62,9 +69,21 @@ class AsyncTaskService:
                         "code": getattr(exc, "code", "TASK_FAILED"),
                     },
                 )
+            finally:
+                await self._drop_runner_reference(task_id, asyncio.current_task())
 
-        task = asyncio.create_task(_run())
-        await self._update(task_id, asyncio_task=task)
+        async with self._lock:
+            if self._shutdown:
+                raise RuntimeError("AsyncTaskService is shut down")
+            self._ensure_cleanup_task()
+            self._cleanup_locked()
+            self._tasks[task_id] = task_data
+            try:
+                task = asyncio.create_task(_run())
+            except BaseException:
+                self._tasks.pop(task_id, None)
+                raise
+            task_data["asyncio_task"] = task
         return self._public_task(task_data)
 
     async def get(self, task_id: str, owner_id: str) -> Dict[str, Any]:
@@ -108,6 +127,14 @@ class AsyncTaskService:
             task.update(updates)
             task["updated_at"] = time.time()
 
+    async def _drop_runner_reference(
+        self, task_id: str, runner_task: Optional[asyncio.Task]
+    ) -> None:
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if task and task.get("asyncio_task") is runner_task:
+                task.pop("asyncio_task", None)
+
     def _public_task(self, task: Dict[str, Any]) -> Dict[str, Any]:
         return {
             "task_id": task["task_id"],
@@ -125,11 +152,52 @@ class AsyncTaskService:
         expired_task_ids = [
             task_id
             for task_id, task in self._tasks.items()
-            if task.get("status") in {"completed", "failed", "cancelled"}
-            and now - task.get("updated_at", now) > 60 * 30
+            if task.get("status") in self.TERMINAL_STATUSES
+            and now - task.get("updated_at", now) > self._retention_seconds
         ]
         for task_id in expired_task_ids:
             self._tasks.pop(task_id, None)
+
+    def _ensure_cleanup_task(self) -> None:
+        if self._cleanup_task is not None and not self._cleanup_task.done():
+            return
+        self._cleanup_task = asyncio.create_task(
+            self._cleanup_loop(),
+            name="async-task-service-cleanup",
+        )
+
+    async def _cleanup_loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self._cleanup_interval_seconds)
+                async with self._lock:
+                    self._cleanup_locked()
+        except asyncio.CancelledError:
+            raise
+
+    async def shutdown(self) -> None:
+        """Cancel owned tasks and release all retained task results."""
+        async with self._lock:
+            self._shutdown = True
+            cleanup_task = self._cleanup_task
+            self._cleanup_task = None
+            runners = [
+                task.get("asyncio_task")
+                for task in self._tasks.values()
+                if task.get("asyncio_task") is not None
+                and not task["asyncio_task"].done()
+            ]
+        if cleanup_task:
+            if not cleanup_task.done():
+                cleanup_task.cancel()
+            await asyncio.gather(cleanup_task, return_exceptions=True)
+
+        for runner in runners:
+            runner.cancel()
+        if runners:
+            await asyncio.gather(*runners, return_exceptions=True)
+        async with self._lock:
+            self._tasks.clear()
 
 
 _async_task_service: Optional[AsyncTaskService] = None
@@ -140,3 +208,12 @@ def get_async_task_service() -> AsyncTaskService:
     if _async_task_service is None:
         _async_task_service = AsyncTaskService()
     return _async_task_service
+
+
+async def shutdown_async_task_service() -> None:
+    global _async_task_service
+    service = _async_task_service
+    if service is None:
+        return
+    await service.shutdown()
+    _async_task_service = None

--- a/common/services/conversation_service.py
+++ b/common/services/conversation_service.py
@@ -431,8 +431,20 @@ async def get_conversation_messages(
     dao = ConversationDao()
     conversation = await dao.get_by_session_id(session_id)
     session_manager = get_global_session_manager()
-    session = session_manager.get(session_id) if session_manager else None
-    if not session:
+    session = None
+    session_workspace = None
+    if session_manager:
+        get_live_session = getattr(session_manager, "get_live_session", None)
+        if callable(get_live_session):
+            session = get_live_session(session_id)
+        else:
+            # Compatibility with small integrations/test doubles implementing
+            # only the historical SessionManager.get() surface.
+            session = session_manager.get(session_id)
+        get_workspace = getattr(session_manager, "get_session_workspace", None)
+        if callable(get_workspace):
+            session_workspace = get_workspace(session_id)
+    if not session and not session_workspace:
         raise SageHTTPException(
             **{
                 **_conversation_error_kwargs(
@@ -460,6 +472,8 @@ async def get_conversation_messages(
             "updated_at": conversation.updated_at,
         }
     else:
+        if session is None and session_manager is not None:
+            session = session_manager.get(session_id)
         session_context = session.get_context() if session else None
         session_created_at = session.get_start_time() if session else None
         agent_config = (
@@ -644,11 +658,9 @@ def _load_session_raw_messages(session_id: str) -> List[Dict[str, Any]]:
     session_manager = get_global_session_manager()
     if session_manager:
         try:
-            session = session_manager.get(session_id)
-            if session:
-                raw_messages = session.get_messages()
-                if raw_messages:
-                    return [message.to_dict() for message in raw_messages]
+            raw_messages = session_manager.get_session_messages(session_id)
+            if raw_messages:
+                return [message.to_dict() for message in raw_messages]
         except Exception as exc:
             logger.bind(session_id=session_id).warning(
                 f"读取 session 原始消息失败，回退数据库: {exc}"
@@ -861,7 +873,7 @@ async def edit_last_user_message(
     manager = get_global_session_manager()
     if manager:
         try:
-            await asyncio.to_thread(manager.close_session, session_id)
+            await manager.aclose_session(session_id)
         except Exception:
             manager.remove_session_context(session_id)
 

--- a/common/services/skill_service.py
+++ b/common/services/skill_service.py
@@ -7,6 +7,7 @@ import threading
 import time
 import zipfile
 import hashlib
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -27,9 +28,11 @@ from common.services.agent_workspace import get_agent_skill_dir
 
 
 _SERVER_SKILLS_CACHE_TTL_SECONDS = 5.0
+_SERVER_SKILLS_CACHE_MAX_ENTRIES = 256
 _server_skills_cache_lock = threading.Lock()
 _server_skills_cache_expires_at: Dict[Tuple[str, str, str], float] = {}
 _server_skills_cache: Dict[Tuple[str, str, str], List[SkillSchema]] = {}
+_server_skills_cache_lru: "OrderedDict[Tuple[str, str, str], None]" = OrderedDict()
 
 
 def _calculate_skill_hash(skill_path: str) -> str:
@@ -446,10 +449,10 @@ def _sync_desktop_agent_skills() -> None:
 
 
 def _invalidate_server_skills_cache() -> None:
-    global _server_skills_cache_expires_at, _server_skills_cache
     with _server_skills_cache_lock:
-        _server_skills_cache_expires_at = {}
-        _server_skills_cache = {}
+        _server_skills_cache_expires_at.clear()
+        _server_skills_cache.clear()
+        _server_skills_cache_lru.clear()
 
 
 def _load_server_skill_info_from_dir(skill_path: str) -> Optional[SkillSchema]:
@@ -584,20 +587,42 @@ def _collect_server_skills(
     role: str = "admin",
     dimension: Optional[str] = None,
 ) -> List[SkillSchema]:
-    global _server_skills_cache_expires_at, _server_skills_cache
-
     now = time.monotonic()
     cache_key = _server_skills_cache_key(current_user_id, role, dimension)
     with _server_skills_cache_lock:
+        expired_keys = [
+            key
+            for key, expires_at in _server_skills_cache_expires_at.items()
+            if now >= expires_at
+        ]
+        for key in expired_keys:
+            _server_skills_cache_expires_at.pop(key, None)
+            _server_skills_cache.pop(key, None)
+            _server_skills_cache_lru.pop(key, None)
         if now < _server_skills_cache_expires_at.get(cache_key, 0.0):
+            _server_skills_cache_lru.move_to_end(cache_key)
             return list(_server_skills_cache.get(cache_key, []))
 
     skills = _collect_server_skills_uncached(current_user_id, role, dimension)
     with _server_skills_cache_lock:
+        now = time.monotonic()
+        expired_keys = [
+            key
+            for key, expires_at in _server_skills_cache_expires_at.items()
+            if now >= expires_at
+        ]
+        for key in expired_keys:
+            _server_skills_cache_expires_at.pop(key, None)
+            _server_skills_cache.pop(key, None)
+            _server_skills_cache_lru.pop(key, None)
         _server_skills_cache[cache_key] = list(skills)
-        _server_skills_cache_expires_at[cache_key] = (
-            time.monotonic() + _SERVER_SKILLS_CACHE_TTL_SECONDS
-        )
+        _server_skills_cache_expires_at[cache_key] = now + _SERVER_SKILLS_CACHE_TTL_SECONDS
+        _server_skills_cache_lru[cache_key] = None
+        _server_skills_cache_lru.move_to_end(cache_key)
+        while len(_server_skills_cache_lru) > _SERVER_SKILLS_CACHE_MAX_ENTRIES:
+            evicted_key, _ = _server_skills_cache_lru.popitem(last=False)
+            _server_skills_cache.pop(evicted_key, None)
+            _server_skills_cache_expires_at.pop(evicted_key, None)
     return skills
 
 

--- a/common/utils/stream_merge.py
+++ b/common/utils/stream_merge.py
@@ -17,7 +17,19 @@ from __future__ import annotations
 import asyncio
 from typing import Any, AsyncIterator, Tuple
 
+from loguru import logger
+
 _MERGE_SENTINEL = object()
+_WORKER_SHUTDOWN_TIMEOUT_SECONDS = 13.0
+
+
+def _consume_task_exception(task: asyncio.Task) -> None:
+    if task.cancelled():
+        return
+    try:
+        task.exception()
+    except (asyncio.CancelledError, Exception):
+        pass
 
 
 async def interleave_message_and_progress(
@@ -80,10 +92,30 @@ async def interleave_message_and_progress(
                         yield ("tool_progress", p2)
                 break
     finally:
-        if not msg_task.done():
-            msg_task.cancel()
-        if not prog_task.done():
-            prog_task.cancel()
+        workers = (msg_task, prog_task)
+        for task in workers:
+            if not task.done():
+                task.cancel()
+        try:
+            done, pending = await asyncio.wait(
+                workers, timeout=_WORKER_SHUTDOWN_TIMEOUT_SECONDS
+            )
+        except asyncio.CancelledError:
+            for task in workers:
+                task.add_done_callback(_consume_task_exception)
+            raise
+
+        for task in done:
+            _consume_task_exception(task)
+        if pending:
+            logger.warning(
+                "Stream merge worker cleanup timed out; detaching "
+                f"{len(pending)} task(s) after "
+                f"{_WORKER_SHUTDOWN_TIMEOUT_SECONDS:.3f}s"
+            )
+            for task in pending:
+                task.cancel()
+                task.add_done_callback(_consume_task_exception)
 
 
 __all__ = ["interleave_message_and_progress"]

--- a/sagents/context/session_context.py
+++ b/sagents/context/session_context.py
@@ -3,7 +3,7 @@ import asyncio
 import time
 import threading
 import uuid
-from typing import Dict, Any, Optional, List, Union
+from typing import Dict, Any, Optional, List, Set, Union
 from enum import Enum
 from concurrent.futures import ThreadPoolExecutor
 
@@ -47,6 +47,9 @@ class SessionStatus(Enum):
 
 
 class SessionContext:
+    LOG_FLUSH_TIMEOUT_SECONDS = 5.0
+    LOG_WRITER_CANCEL_TIMEOUT_SECONDS = 0.5
+
     def __init__(
         self,
         session_id: str,
@@ -260,6 +263,21 @@ class SessionContext:
         self._llm_request_save_lock = threading.Lock()
         self._mcp_calls_lock = threading.Lock()
         self._mcp_calls_save_lock = threading.Lock()
+        # One writer task serializes all diagnostic log I/O for this session.
+        # The existing log lists are also the pending queue, avoiding one task
+        # (and one retained SessionContext) per LLM or MCP call.
+        self._log_writer_task: Optional[asyncio.Task] = None
+        self._llm_log_save_cursor = 0
+        self._dirty_mcp_request_ids: Set[str] = set()
+        self._mcp_request_versions: Dict[str, int] = {}
+        self._log_writer_closed = False
+        self._log_flush_lock = asyncio.Lock()
+        try:
+            self._owner_loop: Optional[asyncio.AbstractEventLoop] = (
+                asyncio.get_running_loop()
+            )
+        except RuntimeError:
+            self._owner_loop = None
         self._save_lock = threading.Lock()
         self._message_journal_lock = threading.RLock()
         self._message_journal_seq = 0
@@ -2062,6 +2080,12 @@ class SessionContext:
         时序列化到 ``<session_workspace>/tokens_usage/<request_id>.json``。
         """
 
+        if self._log_writer_closed:
+            logger.warning(
+                f"SessionContext: ignore late LLM log after close, session_id={self.session_id}"
+            )
+            return
+
         llm_request = {
             "request": request,
             "response": response,
@@ -2074,11 +2098,16 @@ class SessionContext:
         except Exception as exc:
             logger.warning(f"SessionContext: 累加 per-request usage 失败: {exc}")
 
-        # 异步保存日志，不阻塞主流程
-        asyncio.create_task(self._async_save_llm_request(llm_request))
+        self._schedule_log_writer()
 
     def add_mcp_call(self, call: Dict[str, Any]) -> Optional[str]:
         """记录一次 MCP 调用，并按当前 chat request 聚合落盘。"""
+        if self._log_writer_closed:
+            logger.warning(
+                f"SessionContext: ignore late MCP log after close, session_id={self.session_id}"
+            )
+            return None
+
         with self._request_lock:
             cur = self._current_request
             if cur is None:
@@ -2102,9 +2131,175 @@ class SessionContext:
                 **call,
             }
             self.mcp_calls_logs.append(make_serializable(mcp_call))  # pyright: ignore[reportArgumentType]
+            self._dirty_mcp_request_ids.add(request_id)
+            self._mcp_request_versions[request_id] = (
+                self._mcp_request_versions.get(request_id, 0) + 1
+            )
 
-        asyncio.create_task(self._async_save_mcp_calls(request_id))
+        self._schedule_log_writer()
         return request_id
+
+    def _schedule_log_writer(self) -> None:
+        if self._log_writer_closed:
+            return
+        if self._log_writer_task is not None and not self._log_writer_task.done():
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # The canonical lists retain the data until close flushes it on the
+            # owning event loop.
+            return
+        self._owner_loop = self._owner_loop or loop
+        self._log_writer_task = loop.create_task(
+            self._drain_pending_log_writes(),
+            name=f"session-log-writer-{self.session_id}",
+        )
+
+    async def _drain_pending_log_writes(self) -> None:
+        current_task = asyncio.current_task()
+        reached_empty_queue = False
+        try:
+            while True:
+                if self._llm_log_save_cursor < len(self.llm_requests_logs):
+                    llm_request = self.llm_requests_logs[self._llm_log_save_cursor]
+                    await self._async_save_llm_request(llm_request)
+                    self._llm_log_save_cursor += 1
+                    continue
+
+                with self._mcp_calls_lock:
+                    request_id = (
+                        next(iter(self._dirty_mcp_request_ids))
+                        if self._dirty_mcp_request_ids
+                        else None
+                    )
+                    request_version = (
+                        self._mcp_request_versions.get(request_id, 0)
+                        if request_id is not None
+                        else 0
+                    )
+                if request_id is not None:
+                    await self._async_save_mcp_calls(request_id)
+                    with self._mcp_calls_lock:
+                        # A call may have arrived for this request while the
+                        # aggregate was being written. Keep it dirty so the
+                        # next pass persists the newer snapshot.
+                        if (
+                            self._mcp_request_versions.get(request_id, 0)
+                            == request_version
+                        ):
+                            self._dirty_mcp_request_ids.discard(request_id)
+                            self._mcp_request_versions.pop(request_id, None)
+                    continue
+                reached_empty_queue = True
+                return
+        finally:
+            if self._log_writer_task is current_task:
+                self._log_writer_task = None
+                if (
+                    reached_empty_queue
+                    and not self._log_writer_closed
+                    and self._has_pending_log_writes()
+                ):
+                    # An item can arrive after the empty-queue check but before
+                    # this task clears the writer slot. Ensure that race always
+                    # hands off to a successor writer.
+                    self._schedule_log_writer()
+
+    def _has_pending_log_writes(self) -> bool:
+        if self._llm_log_save_cursor < len(self.llm_requests_logs):
+            return True
+        with self._mcp_calls_lock:
+            return bool(self._dirty_mcp_request_ids)
+
+    def _discard_diagnostic_log_buffers(self) -> None:
+        """Release diagnostic payloads after flush or a bounded-flush failure."""
+        self.llm_requests_logs.clear()
+        self._llm_log_save_cursor = 0
+        with self._mcp_calls_lock:
+            self.mcp_calls_logs.clear()
+            self._dirty_mcp_request_ids.clear()
+            self._mcp_request_versions.clear()
+
+    async def _cancel_log_writer(self, task: Optional[asyncio.Task]) -> None:
+        if task is not None and not task.done():
+            task.cancel()
+        if task is not None:
+            done, pending = await asyncio.wait(
+                {task}, timeout=self.LOG_WRITER_CANCEL_TIMEOUT_SECONDS
+            )
+            for finished in done:
+                if not finished.cancelled():
+                    finished.exception()
+            for unfinished in pending:
+                # A broken I/O adapter may suppress cancellation. Do not let it
+                # retain the SessionContext through the global writer slot.
+                unfinished.add_done_callback(
+                    lambda item: None if item.cancelled() else item.exception()
+                )
+        if self._log_writer_task is task:
+            self._log_writer_task = None
+
+    async def flush_pending_log_writes(
+        self, timeout_seconds: Optional[float] = None
+    ) -> bool:
+        async with self._log_flush_lock:
+            return await self._flush_pending_log_writes(timeout_seconds)
+
+    async def _flush_pending_log_writes(
+        self, timeout_seconds: Optional[float] = None
+    ) -> bool:
+        """Persist registered diagnostics within a bounded close window.
+
+        Returns ``True`` when every queued item was handled. On timeout the
+        writer is cancelled and all remaining diagnostic payloads are dropped
+        so Session cleanup can release its object graph.
+        """
+        self._log_writer_closed = True
+        timeout = (
+            self.LOG_FLUSH_TIMEOUT_SECONDS
+            if timeout_seconds is None
+            else max(0.0, float(timeout_seconds))
+        )
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        try:
+            while True:
+                task = self._log_writer_task
+                if task is None or task.done():
+                    if (
+                        self._llm_log_save_cursor >= len(self.llm_requests_logs)
+                        and not self._dirty_mcp_request_ids
+                    ):
+                        self._discard_diagnostic_log_buffers()
+                        return True
+                    task = asyncio.create_task(
+                        self._drain_pending_log_writes(),
+                        name=f"session-log-flush-{self.session_id}",
+                    )
+                    self._log_writer_task = task
+
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    raise asyncio.TimeoutError
+                await asyncio.wait_for(asyncio.shield(task), timeout=remaining)
+        except asyncio.TimeoutError:
+            pending_llm = max(
+                0, len(self.llm_requests_logs) - self._llm_log_save_cursor
+            )
+            pending_mcp = len(self._dirty_mcp_request_ids)
+            logger.warning(
+                "SessionContext: diagnostic log flush timed out; dropping "
+                f"pending payloads session_id={self.session_id} "
+                f"llm={pending_llm} mcp={pending_mcp} timeout={timeout:.3f}s"
+            )
+            await self._cancel_log_writer(self._log_writer_task)
+            self._discard_diagnostic_log_buffers()
+            return False
+        except asyncio.CancelledError:
+            await self._cancel_log_writer(self._log_writer_task)
+            self._discard_diagnostic_log_buffers()
+            raise
 
     def current_request_id(self) -> Optional[str]:
         with self._request_lock:

--- a/sagents/sagents.py
+++ b/sagents/sagents.py
@@ -479,7 +479,7 @@ class SAgent:
         finally:
             total_ms = int((time.time() - start_time) * 1000)
             logger.info(f"SAgent: 会话完整执行耗时 {total_ms} ms", session_id)
-            self.session_manager.close_session(session_id)
+            await self.session_manager.aclose_session(session_id)
 
     def _build_default_flow(
         self, agent_mode: Optional[str], max_loop_count: int

--- a/sagents/session_runtime.py
+++ b/sagents/session_runtime.py
@@ -1,12 +1,14 @@
 import asyncio
+import concurrent.futures
 import json
 import os
+import threading
 import time
 import traceback
 import uuid
 import contextvars
 from contextlib import contextmanager
-from typing import Any, AsyncGenerator, Dict, List, Optional, Union, Type
+from typing import Any, AsyncGenerator, Dict, List, Optional, Set, Union, Type
 
 from sagents.agent import (
     AgentBase,
@@ -59,6 +61,82 @@ from sagents.utils.i18n import normalize_language, t
 _session_id_var: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     "session_id", default=None
 )
+
+_SESSION_SHELL_CLEANUP_TIMEOUT_SECONDS = 6.0
+_SESSION_LOG_FLUSH_TIMEOUT_SECONDS = 6.0
+_SYNC_SESSION_CLOSE_WAIT_TIMEOUT_SECONDS = 13.0
+
+
+def _consume_cleanup_task_result(task: asyncio.Task) -> None:
+    if task.cancelled():
+        return
+    task.exception()
+
+
+async def _cleanup_session_shells_with_timeout(
+    session_id: str, session_context: Optional[SessionContext]
+) -> None:
+    """Detach session shell state and bound slow sandbox cleanup."""
+    from sagents.tool.impl.execute_command_tool import ExecuteCommandTool
+
+    cleanup_task = asyncio.create_task(
+        ExecuteCommandTool().cleanup_session_tasks(
+            session_id,
+            sandbox=getattr(session_context, "sandbox", None),
+        ),
+        name=f"cleanup-session-shells-{session_id}",
+    )
+    try:
+        _, pending = await asyncio.wait(
+            {cleanup_task}, timeout=_SESSION_SHELL_CLEANUP_TIMEOUT_SECONDS
+        )
+    except asyncio.CancelledError:
+        cleanup_task.cancel()
+        cleanup_task.add_done_callback(_consume_cleanup_task_result)
+        raise
+    if pending:
+        cleanup_task.cancel()
+        cleanup_task.add_done_callback(_consume_cleanup_task_result)
+        logger.warning(
+            f"Session shell cleanup timed out: session_id={session_id} "
+            f"timeout={_SESSION_SHELL_CLEANUP_TIMEOUT_SECONDS:.3f}s"
+        )
+        return
+    await cleanup_task
+
+
+async def _flush_session_logs_with_timeout(
+    session_id: str, session_context: Optional[SessionContext]
+) -> None:
+    """Bound even third-party/fake SessionContext flush implementations."""
+    if session_context is None:
+        return
+    flush_task = asyncio.create_task(
+        session_context.flush_pending_log_writes(),
+        name=f"flush-session-logs-{session_id}",
+    )
+    try:
+        _, pending = await asyncio.wait(
+            {flush_task}, timeout=_SESSION_LOG_FLUSH_TIMEOUT_SECONDS
+        )
+    except asyncio.CancelledError:
+        flush_task.cancel()
+        flush_task.add_done_callback(_consume_cleanup_task_result)
+        raise
+    if pending:
+        flush_task.cancel()
+        flush_task.add_done_callback(_consume_cleanup_task_result)
+        logger.warning(
+            f"Session diagnostic log flush timed out: session_id={session_id} "
+            f"timeout={_SESSION_LOG_FLUSH_TIMEOUT_SECONDS:.3f}s"
+        )
+        return
+    completed = await flush_task
+    if completed is False:
+        logger.warning(
+            f"Session diagnostic logs were only partially flushed: "
+            f"session_id={session_id}"
+        )
 
 
 def _load_json_file_sync(file_path: str) -> Optional[Any]:
@@ -1254,6 +1332,38 @@ class Session:
         统一的会话清理逻辑
         """
         try:
+            from sagents.tool.impl.memory_tool import SessionHistoryRetriever
+
+            SessionHistoryRetriever.clear_session_cache(
+                session_id, self.session_context
+            )
+        except Exception as e:
+            logger.error(
+                f"SAgent: 清理会话 {session_id} 历史检索缓存时出错: {e}",
+                session_id=session_id,
+            )
+
+        try:
+            await _cleanup_session_shells_with_timeout(
+                session_id, self.session_context
+            )
+        except Exception as e:
+            logger.error(
+                f"SAgent: 清理会话 {session_id} 后台 shell 时出错: {e}",
+                session_id=session_id,
+            )
+
+        try:
+            await _flush_session_logs_with_timeout(
+                session_id, self.session_context
+            )
+        except Exception as e:
+            logger.error(
+                f"SAgent: flush session {session_id} diagnostic logs failed: {e}",
+                session_id=session_id,
+            )
+
+        try:
             lock = get_session_run_lock(session_id)
             if lock and lock.locked():
                 await safe_release(lock, session_id, "SAgent 会话清理")
@@ -1278,6 +1388,12 @@ class SessionManager:
         self.session_root_space = str(session_root_space)
         self.enable_obs = enable_obs
         self._sessions: Dict[str, Session] = {}
+        self._session_cleanup_tasks: Set[asyncio.Task] = set()
+        self._session_close_lock = threading.RLock()
+        self._session_close_futures: Dict[
+            str, concurrent.futures.Future[None]
+        ] = {}
+        self._shutdown = False
 
         from sagents.session_registry import SessionRegistry
 
@@ -1287,6 +1403,22 @@ class SessionManager:
         self._registry = SessionRegistry(db_path, root_dir=self.session_root_space)
         if need_migrate:
             self._migrate_from_filesystem()
+
+    def _track_cleanup_task(self, task: asyncio.Task) -> None:
+        self._session_cleanup_tasks.add(task)
+
+        def cleanup_done(done_task: asyncio.Task) -> None:
+            self._session_cleanup_tasks.discard(done_task)
+            if done_task.cancelled():
+                return
+            try:
+                exc = done_task.exception()
+            except asyncio.CancelledError:
+                return
+            if exc is not None:
+                logger.error(f"Session cleanup task failed: {exc}")
+
+        task.add_done_callback(cleanup_done)
 
     def _migrate_from_filesystem(self):
         """One-time migration: scan existing directories and populate the SQLite registry."""
@@ -1398,20 +1530,28 @@ class SessionManager:
         Returns:
             Session 实例
         """
-        if session_id not in self._sessions:
-            self._sessions[session_id] = Session(
-                session_id=session_id,
-                enable_obs=self.enable_obs,
-                sandbox_type=sandbox_type,
-            )
-        else:
-            self._sessions[session_id].sandbox_type = sandbox_type
+        with self._session_close_lock:
+            if self._shutdown:
+                raise RuntimeError("SessionManager is shut down")
+            if session_id in self._session_close_futures:
+                raise RuntimeError(
+                    f"Session {session_id!r} is still closing; "
+                    "await aclose_session() before reusing its ID"
+                )
+            if session_id not in self._sessions:
+                self._sessions[session_id] = Session(
+                    session_id=session_id,
+                    enable_obs=self.enable_obs,
+                    sandbox_type=sandbox_type,
+                )
+            else:
+                self._sessions[session_id].sandbox_type = sandbox_type
 
-        return self._sessions[session_id]
+            return self._sessions[session_id]
 
     def get(self, session_id: str) -> Optional[Session]:
         """
-        获取 Session。优先返回内存中的活对象；如果不存在，则尝试从磁盘恢复。
+        获取 Session。活对象直接返回；历史对象只临时从磁盘恢复。
 
         Args:
             session_id: 会话 ID
@@ -1427,17 +1567,23 @@ class SessionManager:
         if not workspace:
             return None
 
-        session = self.get_or_create(session_id)
+        # Historical reads must not repopulate the process-wide live-session
+        # registry.  Callers may inspect this transient object for the duration
+        # of one request; dropping their reference releases its full context.
+        session = Session(
+            session_id=session_id,
+            enable_obs=self.enable_obs,
+        )
         session.set_workspace(workspace)
         loaded = session.load_persisted_state(workspace)
         if not loaded and not session.has_context() and not session.get_messages():
-            self._sessions.pop(session_id, None)
             return None
         return session
 
     def get_live_session(self, session_id: str) -> Optional[Session]:
         """仅获取内存中的活 session，不做磁盘恢复。"""
-        return self._sessions.get(session_id)
+        with self._session_close_lock:
+            return self._sessions.get(session_id)
 
     def _get_live_session(self, session_id: str) -> Optional[Session]:
         """兼容旧内部调用，优先使用 get_live_session。"""
@@ -1457,15 +1603,199 @@ class SessionManager:
         if session:
             session.clear_context()
 
-    def close_session(self, session_id: str):
-        """关闭 Session"""
-        session = self._sessions.pop(session_id, None)
+    async def _finish_session_close(
+        self, session_id: str, session: Optional[Session]
+    ) -> None:
+        """Release one detached session without crossing event-loop ownership."""
+        session_context = getattr(session, "session_context", None)
+
+        try:
+            await _cleanup_session_shells_with_timeout(session_id, session_context)
+        except Exception as e:
+            logger.warning(f"清理session {session_id} 后台 shell 时出错: {e}")
+
+        try:
+            await _flush_session_logs_with_timeout(session_id, session_context)
+        except Exception as e:
+            logger.warning(f"flush session {session_id} diagnostic logs failed: {e}")
+
+        try:
+            lock = get_session_run_lock(session_id)
+            if lock and lock.locked():
+                await safe_release(lock, session_id, "SessionManager close")
+            delete_session_run_lock(session_id)
+        except Exception as e:
+            logger.warning(f"清理session {session_id} 运行锁时出错: {e}")
+
+        try:
+            logger.cleanup_session_logger(session_id)
+        except Exception as e:
+            logger.warning(f"清理session {session_id} 日志资源时出错: {e}")
+
+        try:
+            from sagents.tool.impl.memory_tool import SessionHistoryRetriever
+
+            SessionHistoryRetriever.clear_session_cache(
+                session_id,
+                session_context,
+            )
+        except Exception as e:
+            logger.warning(f"清理session {session_id} 历史检索缓存时出错: {e}")
+
         if session:
-            try:
-                logger.cleanup_session_logger(session_id)
-            except Exception as e:
-                logger.warning(f"清理session {session_id} 日志资源时出错: {e}")
             session.close()
+
+    def _begin_session_close(
+        self, session_id: str
+    ) -> tuple[
+        Optional[Session], concurrent.futures.Future[None], bool
+    ]:
+        """Detach a session and reserve its ID until cleanup has completed."""
+        with self._session_close_lock:
+            existing = self._session_close_futures.get(session_id)
+            if existing is not None:
+                return None, existing, False
+            completion: concurrent.futures.Future[None] = (
+                concurrent.futures.Future()
+            )
+            self._session_close_futures[session_id] = completion
+            return self._sessions.pop(session_id, None), completion, True
+
+    async def _run_session_close(
+        self,
+        session_id: str,
+        session: Optional[Session],
+        completion: concurrent.futures.Future[None],
+    ) -> None:
+        try:
+            await self._finish_session_close(session_id, session)
+        except BaseException as exc:
+            if not completion.done():
+                completion.set_exception(exc)
+            raise
+        else:
+            if not completion.done():
+                completion.set_result(None)
+        finally:
+            with self._session_close_lock:
+                if self._session_close_futures.get(session_id) is completion:
+                    self._session_close_futures.pop(session_id, None)
+
+    async def _wait_for_session_close(
+        self, completion: concurrent.futures.Future[None]
+    ) -> None:
+        await asyncio.shield(asyncio.wrap_future(completion))
+
+    async def aclose_session(self, session_id: str) -> None:
+        """Asynchronously close a session and wait for all owned resources."""
+        session, completion, owns_close = self._begin_session_close(session_id)
+        if not owns_close:
+            await self._wait_for_session_close(completion)
+            return
+        cleanup_task = asyncio.create_task(
+            self._run_session_close(session_id, session, completion),
+            name=f"close-session-{session_id}",
+        )
+        self._track_cleanup_task(cleanup_task)
+        await asyncio.shield(cleanup_task)
+
+    def close_session(self, session_id: str):
+        """Compatibility wrapper that schedules cleanup on the owning loop."""
+        session, completion, owns_close = self._begin_session_close(session_id)
+        if not owns_close:
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                try:
+                    completion.result(
+                        timeout=_SYNC_SESSION_CLOSE_WAIT_TIMEOUT_SECONDS
+                    )
+                except concurrent.futures.TimeoutError:
+                    logger.warning(
+                        f"Synchronous session close wait timed out; cleanup "
+                        f"continues on owner loop: session_id={session_id} "
+                        f"timeout={_SYNC_SESSION_CLOSE_WAIT_TIMEOUT_SECONDS:.3f}s"
+                    )
+            return
+        session_context = getattr(session, "session_context", None)
+        owner_loop = getattr(session_context, "_owner_loop", None)
+
+        if owner_loop is None:
+            try:
+                from sagents.tool.impl.execute_command_tool import ExecuteCommandTool
+
+                owner_loop = ExecuteCommandTool.get_session_loop(session_id)
+            except Exception:
+                owner_loop = None
+
+        cleanup_coro = self._run_session_close(session_id, session, completion)
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+
+        if owner_loop is not None and owner_loop.is_running():
+            if running_loop is owner_loop:
+                cleanup_task = owner_loop.create_task(
+                    cleanup_coro,
+                    name=f"close-session-{session_id}",
+                )
+                self._track_cleanup_task(cleanup_task)
+            else:
+                cleanup_future = asyncio.run_coroutine_threadsafe(
+                    cleanup_coro, owner_loop
+                )
+                try:
+                    cleanup_future.result(
+                        timeout=_SYNC_SESSION_CLOSE_WAIT_TIMEOUT_SECONDS
+                    )
+                except concurrent.futures.TimeoutError:
+                    # Cleanup remains scheduled on the owner loop. Returning is
+                    # essential for callers such as signal/worker threads.
+                    logger.warning(
+                        f"Synchronous session close timed out; cleanup continues "
+                        f"on owner loop: session_id={session_id} "
+                        f"timeout={_SYNC_SESSION_CLOSE_WAIT_TIMEOUT_SECONDS:.3f}s"
+                    )
+            return
+
+        if running_loop is not None:
+            cleanup_task = running_loop.create_task(
+                cleanup_coro,
+                name=f"close-session-{session_id}",
+            )
+            self._track_cleanup_task(cleanup_task)
+            return
+
+        asyncio.run(cleanup_coro)
+
+    async def shutdown(self) -> None:
+        """Close live sessions and wait for scheduled cleanup before shutdown."""
+        with self._session_close_lock:
+            if self._shutdown:
+                return
+            self._shutdown = True
+            live_session_ids = list(self._sessions)
+        try:
+            for session_id in live_session_ids:
+                await self.aclose_session(session_id)
+            with self._session_close_lock:
+                closing = list(self._session_close_futures.values())
+            if closing:
+                await asyncio.gather(
+                    *(self._wait_for_session_close(item) for item in closing),
+                    return_exceptions=True,
+                )
+            current_loop = asyncio.get_running_loop()
+            pending = [
+                task
+                for task in list(self._session_cleanup_tasks)
+                if not task.done() and task.get_loop() is current_loop
+            ]
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+        finally:
+            self._registry.close()
 
     def interrupt_session(
         self, session_id: str, message: str = "User requested interruption"
@@ -1483,9 +1813,24 @@ class SessionManager:
 
     def get_session_status(self, session_id: str) -> Optional[Dict[str, Any]]:
         """获取 Session 状态"""
-        session = self.get(session_id)
+        session = self.get_live_session(session_id)
         if session:
             return {"status": session.get_status().value}
+        workspace = self.get_session_workspace(session_id)
+        if not workspace:
+            return None
+        try:
+            snapshot = _load_json_file_sync(
+                os.path.join(workspace, "session_context.json")
+            )
+            if isinstance(snapshot, dict) and snapshot.get("status"):
+                return {"status": str(snapshot["status"])}
+        except FileNotFoundError:
+            pass
+        except Exception as exc:
+            logger.warning(
+                f"SessionManager: 读取 session {session_id} 状态失败: {exc}"
+            )
         return None
 
     def list_active_sessions(self) -> List[Dict[str, Any]]:
@@ -1507,8 +1852,8 @@ class SessionManager:
         Args:
             session_id: 会话 ID（全局唯一）
         """
-        # 1. 尝试从内存获取（只有根会话会保留在内存中）
-        session = self.get(session_id)
+        # 1. Only a truly live session may serve messages from memory.
+        session = self.get_live_session(session_id)
         if session:
             return session.get_messages()
 
@@ -1553,13 +1898,30 @@ class SessionManager:
         return messages
 
     def get_tasks_status(self, session_id: str) -> Optional[Dict[str, Any]]:
-        session = self.get(session_id)
-        if not session:
+        session = self.get_live_session(session_id)
+        if session:
+            return session.get_tasks_status()
+        workspace = self.get_session_workspace(session_id)
+        if not workspace:
             return None
-        return session.get_tasks_status()
+        try:
+            snapshot = _load_json_file_sync(
+                os.path.join(workspace, "session_context.json")
+            )
+            if isinstance(snapshot, dict):
+                return snapshot.get("tasks_status") or {"tasks": []}
+        except FileNotFoundError:
+            pass
+        except Exception as exc:
+            logger.warning(
+                f"SessionManager: 读取 session {session_id} 任务状态失败: {exc}"
+            )
+        return None
 
     def save_session(self, session_id: str) -> bool:
-        session = self.get(session_id)
+        # Completed sessions are already persisted before close.  Never restore
+        # one merely to save it again, as that used to repopulate _sessions.
+        session = self.get_live_session(session_id)
         if not session or not session.has_context():
             return False
         try:
@@ -1659,6 +2021,16 @@ def initialize_global_session_manager(session_root_space: str, enable_obs: bool 
     global _global_session_manager
     _global_session_manager = SessionManager(session_root_space, enable_obs)
     return _global_session_manager
+
+
+async def shutdown_global_session_manager() -> None:
+    """Drain all session-owned cleanup and release the global manager."""
+    global _global_session_manager
+    manager = _global_session_manager
+    if manager is None:
+        return
+    await manager.shutdown()
+    _global_session_manager = None
 
 
 def get_global_session_manager(

--- a/sagents/tool/impl/execute_command_tool.py
+++ b/sagents/tool/impl/execute_command_tool.py
@@ -21,7 +21,7 @@ import re
 import shlex
 import time
 import uuid
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from ..tool_base import tool
 from ..tool_progress import emit_tool_event, emit_tool_progress, get_progress_queue
@@ -144,10 +144,151 @@ class ExecuteCommandTool:
     # 两条路径互斥：被 await_shell 消费过的不会再走 LLM flush。
     _COMPLETION_EVENTS: Dict[str, Dict[str, Dict[str, Any]]] = {}
 
+    # watcher tasks must be cancelled together with their owning session.  Keeping
+    # them here also gives them a strong reference until their done callback runs.
+    _WATCHER_TASKS: Dict[str, Set[asyncio.Task]] = {}
+
     _APPROVAL_TTL_S = 30 * 60
 
     def __init__(self):
         self.security_manager = SecurityManager()
+
+    @classmethod
+    def _track_watcher(cls, session_id: str, watcher: asyncio.Task) -> None:
+        bucket = cls._WATCHER_TASKS.setdefault(session_id, set())
+        bucket.add(watcher)
+
+        def discard_finished_task(done_task: asyncio.Task) -> None:
+            current_bucket = cls._WATCHER_TASKS.get(session_id)
+            if current_bucket is None:
+                return
+            current_bucket.discard(done_task)
+            if not current_bucket:
+                cls._WATCHER_TASKS.pop(session_id, None)
+
+        watcher.add_done_callback(discard_finished_task)
+
+    @classmethod
+    def has_session_tasks(cls, session_id: str) -> bool:
+        if session_id in cls._WATCHER_TASKS:
+            return True
+        if session_id in cls._COMPLETION_EVENTS:
+            return True
+        return any(
+            info.get("session_id") == session_id
+            for info in cls._BG_TASKS.values()
+        )
+
+    @classmethod
+    def get_session_loop(
+        cls, session_id: str
+    ) -> Optional[asyncio.AbstractEventLoop]:
+        """Return the event loop that owns this session's watcher tasks."""
+        for watcher in cls._WATCHER_TASKS.get(session_id, set()):
+            try:
+                return watcher.get_loop()
+            except Exception:
+                continue
+        return None
+
+    @classmethod
+    def detach_session_tasks(
+        cls, session_id: str
+    ) -> Tuple[List[asyncio.Task], List[Dict[str, Any]]]:
+        """Atomically detach all process state owned by one closing session."""
+        watchers = list(cls._WATCHER_TASKS.pop(session_id, set()))
+        for watcher in watchers:
+            watcher.cancel()
+
+        cls._COMPLETION_EVENTS.pop(session_id, None)
+        task_infos: List[Dict[str, Any]] = []
+        for task_id, task_info in list(cls._BG_TASKS.items()):
+            if task_info.get("session_id") != session_id:
+                continue
+            detached = cls._BG_TASKS.pop(task_id, None)
+            if detached is not None:
+                task_infos.append(detached)
+        return watchers, task_infos
+
+    async def cleanup_detached_session_tasks(
+        self,
+        session_id: str,
+        watchers: List[asyncio.Task],
+        task_infos: List[Dict[str, Any]],
+        sandbox: Any = None,
+    ) -> None:
+        """Stop detached watcher tasks and sandbox processes for one session."""
+        current_task = asyncio.current_task()
+        pending_watchers = [
+            watcher for watcher in watchers if watcher is not current_task
+        ]
+
+        for task_info in task_infos:
+            task_id = task_info.get("task_id", "")
+            task_sandbox = sandbox or task_info.get("sandbox")
+            if task_sandbox is None:
+                logger.warning(
+                    "Session shell cleanup could not stop task without a sandbox: "
+                    f"session_id={session_id} task_id={task_id}"
+                )
+                continue
+
+            try:
+                if task_info.get("mode") == "native":
+                    try:
+                        await task_sandbox.kill_background(task_id, force=True)
+                    except Exception as exc:
+                        logger.warning(
+                            "Session shell force-kill failed: "
+                            f"session_id={session_id} task_id={task_id} "
+                            f"error={exc}"
+                        )
+                    try:
+                        await task_sandbox.cleanup_background(task_id)
+                    except Exception as exc:
+                        logger.warning(
+                            "Session shell sandbox cleanup failed: "
+                            f"session_id={session_id} task_id={task_id} "
+                            f"error={exc}"
+                        )
+                    continue
+
+                pid = int(task_info.get("pid"))
+                await self._shell(
+                    task_sandbox,
+                    f"kill -9 -- -{pid} 2>/dev/null; kill -9 {pid} 2>/dev/null",
+                    timeout=5,
+                )
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Session shell cleanup found a task without a valid pid: "
+                    f"session_id={session_id} task_id={task_id}"
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Session shell cleanup failed: "
+                    f"session_id={session_id} task_id={task_id} error={exc}"
+                )
+
+        if pending_watchers:
+            try:
+                await asyncio.wait(pending_watchers, timeout=5)
+            except Exception as exc:
+                logger.debug(
+                    "Session shell cleanup could not await every watcher "
+                    f"for session_id={session_id}: {exc}"
+                )
+
+        # A cancelled watcher cannot repopulate this bucket after gather, but a
+        # concurrent consumer may have raced with cleanup.  Make the terminal
+        # ownership rule explicit once more.
+        self.__class__._COMPLETION_EVENTS.pop(session_id, None)
+
+    async def cleanup_session_tasks(self, session_id: str, sandbox: Any = None) -> None:
+        watchers, task_infos = self.detach_session_tasks(session_id)
+        await self.cleanup_detached_session_tasks(
+            session_id, watchers, task_infos, sandbox=sandbox
+        )
 
     @classmethod
     def pop_completion_events(cls, session_id: str) -> List[Dict[str, Any]]:
@@ -553,6 +694,8 @@ class ExecuteCommandTool:
                 "command": command,
                 "started_at": time.time(),
                 "mode": "native",
+                "session_id": session_id,
+                "sandbox": sandbox,
             }
             ExecuteCommandTool._BG_TASKS[task_id] = task_info
             return task_info
@@ -606,6 +749,8 @@ class ExecuteCommandTool:
             "command": command,
             "started_at": time.time(),
             "mode": "shell",
+            "session_id": session_id,
+            "sandbox": sandbox,
         }
         ExecuteCommandTool._BG_TASKS[task_id] = task_info
         return task_info
@@ -992,7 +1137,10 @@ class ExecuteCommandTool:
 
         # 启动后台 watcher：命令结束时写入 completion 事件，供下一次 LLM 请求 flush 注入
         try:
-            asyncio.create_task(self._watch_completion(sandbox, task_info, session_id))
+            watcher = asyncio.create_task(
+                self._watch_completion(sandbox, task_info, session_id)
+            )
+            self._track_watcher(session_id, watcher)
         except RuntimeError:
             logger.warning("无法启动 completion watcher：当前无运行中的 event loop")
 

--- a/sagents/tool/impl/file_memory/index_backend.py
+++ b/sagents/tool/impl/file_memory/index_backend.py
@@ -4,7 +4,7 @@ import asyncio
 import hashlib
 import re
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, List
 
 from sagents.utils.logger import logger
@@ -12,8 +12,10 @@ from sagents.utils.logger import logger
 
 @dataclass
 class _FileIndexCacheEntry:
-    index: Any
+    index: Any = None
     last_refresh_at: float = 0.0
+    active_searches: int = 0
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 class ScopedIndexFileMemoryBackend:
@@ -21,7 +23,6 @@ class ScopedIndexFileMemoryBackend:
 
     INDEX_REFRESH_INTERVAL_SECONDS = 10.0
     _index_cache: Dict[str, _FileIndexCacheEntry] = {}
-    _scope_locks: Dict[str, asyncio.Lock] = {}
 
     def __init__(self, memory_tool):
         self.memory_tool = memory_tool
@@ -29,7 +30,6 @@ class ScopedIndexFileMemoryBackend:
     @classmethod
     def clear_shared_cache(cls) -> None:
         cls._index_cache.clear()
-        cls._scope_locks.clear()
 
     def clear_cache(self) -> None:
         self.clear_shared_cache()
@@ -38,6 +38,93 @@ class ScopedIndexFileMemoryBackend:
     def _build_scope_key(user_id: str, agent_id: str, workspace_path: str) -> str:
         scope = f"{user_id}|{agent_id}|{workspace_path}"
         return hashlib.md5(scope.encode("utf-8")).hexdigest()
+
+    @classmethod
+    def _acquire_scope(cls, scope_key: str) -> _FileIndexCacheEntry:
+        """Register a search before it waits for the scope lock."""
+        cache_entry = cls._index_cache.get(scope_key)
+        if cache_entry is None:
+            cache_entry = _FileIndexCacheEntry()
+            cls._index_cache[scope_key] = cache_entry
+        cache_entry.active_searches += 1
+        return cache_entry
+
+    @classmethod
+    def _release_scope(
+        cls, scope_key: str, cache_entry: _FileIndexCacheEntry
+    ) -> None:
+        """Drop the scoped index as soon as its last active search finishes."""
+        cache_entry.active_searches -= 1
+        if cache_entry.active_searches < 0:
+            logger.error(
+                "MemoryTool: File memory scope active search count became negative"
+            )
+            cache_entry.active_searches = 0
+
+        if (
+            cache_entry.active_searches == 0
+            and cls._index_cache.get(scope_key) is cache_entry
+        ):
+            cls._index_cache.pop(scope_key, None)
+            cache_entry.index = None
+
+    @classmethod
+    def _release_cancelled_scope_when_done(
+        cls,
+        operation_task: asyncio.Task,
+        scope_key: str,
+        cache_entry: _FileIndexCacheEntry,
+    ) -> None:
+        """Keep the scope alive until a shielded operation really stops."""
+        try:
+            error = operation_task.exception()
+            if error is not None:
+                logger.warning(
+                    "MemoryTool: Cancelled file memory operation finished with "
+                    f"an error: {error}"
+                )
+        except asyncio.CancelledError:
+            pass
+        finally:
+            cls._release_scope(scope_key, cache_entry)
+
+    async def _search_scope(
+        self,
+        cache_entry: _FileIndexCacheEntry,
+        memory_index_type,
+        sandbox,
+        workspace_path: str,
+        index_path: str,
+        query: str,
+        top_k: int,
+    ):
+        async with cache_entry.lock:
+            if cache_entry.index is None:
+                cache_entry.index = await asyncio.to_thread(
+                    memory_index_type,
+                    sandbox,
+                    workspace_path,
+                    index_path,
+                )
+            else:
+                cache_entry.index.sandbox = sandbox
+                cache_entry.index.workspace_path = workspace_path.rstrip("/")
+
+            now = time.time()
+            has_search_index = await asyncio.to_thread(
+                cache_entry.index.has_search_index
+            )
+            should_refresh = (
+                not has_search_index
+                or (now - cache_entry.last_refresh_at)
+                >= self.INDEX_REFRESH_INTERVAL_SECONDS
+            )
+            if should_refresh:
+                stats = await cache_entry.index.update_index()
+                cache_entry.last_refresh_at = now
+                logger.debug(f"MemoryTool: File memory index update stats: {stats}")
+
+            return await asyncio.to_thread(cache_entry.index.search, query, top_k)
 
     async def search(
         self, query: str, top_k: int, session_context
@@ -69,42 +156,32 @@ class ScopedIndexFileMemoryBackend:
                 agent_id=agent_id,
                 workspace_path=workspace_path,
             )
-            cache_entry = self._index_cache.get(scope_key)
-
-            lock = self._scope_locks.setdefault(scope_key, asyncio.Lock())
-            async with lock:
-                cache_entry = self._index_cache.get(scope_key)
-                if not cache_entry:
-                    cache_entry = _FileIndexCacheEntry(
-                        index=await asyncio.to_thread(
-                            MemoryIndex,
-                            sandbox,
-                            workspace_path,
-                            index_path,
-                        )
+            cache_entry = self._acquire_scope(scope_key)
+            operation_task = asyncio.create_task(
+                self._search_scope(
+                    cache_entry,
+                    MemoryIndex,
+                    sandbox,
+                    workspace_path,
+                    index_path,
+                    query,
+                    top_k,
+                )
+            )
+            release_deferred = False
+            try:
+                results = await asyncio.shield(operation_task)
+            except asyncio.CancelledError:
+                release_deferred = True
+                operation_task.add_done_callback(
+                    lambda task: self._release_cancelled_scope_when_done(
+                        task, scope_key, cache_entry
                     )
-                    self._index_cache[scope_key] = cache_entry
-                else:
-                    cache_entry.index.sandbox = sandbox
-                    cache_entry.index.workspace_path = workspace_path.rstrip("/")
-
-                now = time.time()
-                has_search_index = await asyncio.to_thread(
-                    cache_entry.index.has_search_index
                 )
-                should_refresh = (
-                    not has_search_index
-                    or (now - cache_entry.last_refresh_at)
-                    >= self.INDEX_REFRESH_INTERVAL_SECONDS
-                )
-                if should_refresh:
-                    stats = await cache_entry.index.update_index()
-                    cache_entry.last_refresh_at = now
-                    logger.debug(f"MemoryTool: File memory index update stats: {stats}")
-
-                results = await asyncio.to_thread(
-                    cache_entry.index.search, query, top_k
-                )
+                raise
+            finally:
+                if not release_deferred:
+                    self._release_scope(scope_key, cache_entry)
 
             formatted_results = []
             for result in results:

--- a/sagents/tool/impl/memory_tool.py
+++ b/sagents/tool/impl/memory_tool.py
@@ -11,6 +11,7 @@ import asyncio
 import hashlib
 import os
 import re
+import threading
 from copy import copy
 from dataclasses import dataclass
 from pathlib import Path
@@ -33,6 +34,12 @@ class _SessionHistoryCacheEntry:
     messages_fingerprint: str
     agent_config_fingerprint: str
     history_messages: List[Any]
+
+
+@dataclass
+class _SessionHistoryCacheState:
+    active_searches: int = 0
+    closed: bool = False
 
 
 class FileMemoryRetriever:
@@ -87,13 +94,62 @@ class SessionHistoryRetriever:
     """
 
     _history_cache: Dict[str, _SessionHistoryCacheEntry] = {}
+    _history_states: Dict[str, _SessionHistoryCacheState] = {}
+    _history_cache_lock = threading.RLock()
 
     def __init__(self, memory_tool: "MemoryTool"):
         self.memory_tool = memory_tool
 
     @classmethod
     def clear_cache(cls) -> None:
-        cls._history_cache.clear()
+        with cls._history_cache_lock:
+            cls._history_cache.clear()
+            for state in cls._history_states.values():
+                state.closed = True
+            cls._history_states = {
+                session_id: state
+                for session_id, state in cls._history_states.items()
+                if state.active_searches > 0
+            }
+
+    @classmethod
+    def clear_session_cache(cls, session_id: str, session_context: Any = None) -> bool:
+        """Remove the cached history snapshot for one completed session run."""
+        if not session_id:
+            return False
+        if session_context is not None:
+            setattr(session_context, "_session_history_cache_closed", True)
+        with cls._history_cache_lock:
+            removed = cls._history_cache.pop(session_id, None) is not None
+            state = cls._history_states.get(session_id)
+            if state is not None:
+                state.closed = True
+                if state.active_searches == 0:
+                    cls._history_states.pop(session_id, None)
+            return removed
+
+    @classmethod
+    def _begin_cache_use(cls, session_id: str) -> _SessionHistoryCacheState:
+        with cls._history_cache_lock:
+            state = cls._history_states.get(session_id)
+            if state is None:
+                state = _SessionHistoryCacheState()
+                cls._history_states[session_id] = state
+            state.active_searches += 1
+            return state
+
+    @classmethod
+    def _end_cache_use(
+        cls, session_id: str, state: _SessionHistoryCacheState
+    ) -> None:
+        with cls._history_cache_lock:
+            state.active_searches = max(0, state.active_searches - 1)
+            if (
+                state.active_searches == 0
+                and state.closed
+                and cls._history_states.get(session_id) is state
+            ):
+                cls._history_states.pop(session_id, None)
 
     @staticmethod
     def _serialize_message_content(content: Any) -> str:
@@ -128,36 +184,77 @@ class SessionHistoryRetriever:
             serialized = str(agent_config or {})
         return hashlib.md5(serialized.encode("utf-8")).hexdigest()
 
-    def _get_history_messages(self, session_id: str, session_context) -> List[Any]:
-        message_manager = session_context.message_manager
-        agent_config = getattr(session_context, "agent_config", {}) or {}
+    def _get_history_messages(
+        self,
+        session_id: str,
+        session_context,
+        cache_state: Optional[_SessionHistoryCacheState] = None,
+    ) -> List[Any]:
+        owns_cache_state = cache_state is None
+        if cache_state is None:
+            cache_state = self._begin_cache_use(session_id)
 
-        messages_fingerprint = self._fingerprint_messages(message_manager.messages)
-        agent_config_fingerprint = self._fingerprint_agent_config(agent_config)
+        try:
+            message_manager = session_context.message_manager
+            agent_config = getattr(session_context, "agent_config", {}) or {}
 
-        cache_entry = self._history_cache.get(session_id)
-        if (
-            cache_entry
-            and cache_entry.messages_fingerprint == messages_fingerprint
-            and cache_entry.agent_config_fingerprint == agent_config_fingerprint
-        ):
-            return cache_entry.history_messages
+            with self._history_cache_lock:
+                if getattr(
+                    session_context, "_session_history_cache_closed", False
+                ):
+                    cache_state.closed = True
 
-        # 历史边界：最近一次 compress_conversation_history 工具调用之前的所有消息
-        # 没有压缩调用时返回空列表（短会话不需要 RAG 检索）
-        anchor_index = message_manager.compute_history_anchor_index()
-        if anchor_index is None or anchor_index <= 0:
-            history_messages: List[Any] = []
-        else:
-            history_messages = list(message_manager.messages[:anchor_index])
+            messages_fingerprint = self._fingerprint_messages(
+                message_manager.messages
+            )
+            agent_config_fingerprint = self._fingerprint_agent_config(agent_config)
 
-        compact_history_messages = self._compact_history_messages(history_messages)
-        self._history_cache[session_id] = _SessionHistoryCacheEntry(
-            messages_fingerprint=messages_fingerprint,
-            agent_config_fingerprint=agent_config_fingerprint,
-            history_messages=compact_history_messages,
-        )
-        return compact_history_messages
+            with self._history_cache_lock:
+                cache_entry = (
+                    self._history_cache.get(session_id)
+                    if not cache_state.closed
+                    and not getattr(
+                        session_context, "_session_history_cache_closed", False
+                    )
+                    else None
+                )
+            if (
+                cache_entry
+                and cache_entry.messages_fingerprint == messages_fingerprint
+                and cache_entry.agent_config_fingerprint
+                == agent_config_fingerprint
+            ):
+                return cache_entry.history_messages
+
+            # 历史边界：最近一次 compress_conversation_history 工具调用之前的所有消息
+            # 没有压缩调用时返回空列表（短会话不需要 RAG 检索）
+            anchor_index = message_manager.compute_history_anchor_index()
+            if anchor_index is None or anchor_index <= 0:
+                history_messages: List[Any] = []
+            else:
+                history_messages = list(message_manager.messages[:anchor_index])
+
+            compact_history_messages = self._compact_history_messages(
+                history_messages
+            )
+            with self._history_cache_lock:
+                if getattr(
+                    session_context, "_session_history_cache_closed", False
+                ):
+                    cache_state.closed = True
+                if (
+                    not cache_state.closed
+                    and self._history_states.get(session_id) is cache_state
+                ):
+                    self._history_cache[session_id] = _SessionHistoryCacheEntry(
+                        messages_fingerprint=messages_fingerprint,
+                        agent_config_fingerprint=agent_config_fingerprint,
+                        history_messages=compact_history_messages,
+                    )
+            return compact_history_messages
+        finally:
+            if owns_cache_state:
+                self._end_cache_use(session_id, cache_state)
 
     @staticmethod
     def _compact_history_messages(messages: List[Any]) -> List[Any]:
@@ -232,8 +329,11 @@ class SessionHistoryRetriever:
     def search(
         self, query: str, top_k: int, session_id: str, session_context
     ) -> List[Dict[str, Any]]:
+        cache_state = self._begin_cache_use(session_id)
         try:
-            history_messages = self._get_history_messages(session_id, session_context)
+            history_messages = self._get_history_messages(
+                session_id, session_context, cache_state
+            )
             if not history_messages:
                 logger.debug("MemoryTool: No history messages to search")
                 return []
@@ -291,6 +391,8 @@ class SessionHistoryRetriever:
 
             logger.error(traceback.format_exc())
             return []
+        finally:
+            self._end_cache_use(session_id, cache_state)
 
 
 class MemoryTool:

--- a/sagents/utils/logger.py
+++ b/sagents/utils/logger.py
@@ -174,6 +174,7 @@ class Logger:
 
         # Session-specific loggers cache
         self.session_loggers: Dict[str, logging.Logger] = {}
+        self._session_loggers_lock = threading.RLock()
 
         if self.file_logging_enabled:
             # 清理一个月前的日志文件
@@ -321,31 +322,19 @@ class Logger:
                 pass
         target_logger.handlers.clear()
 
-    def _get_session_logger(self, session_id: str) -> logging.Logger:
-        """获取或创建session专用的logger"""
-        if session_id in self.session_loggers:
-            session_logger = self.session_loggers[session_id]
-        else:
-            # 创建session专用logger
-            session_logger = logging.getLogger(f"sage_session_{session_id}")
-            session_logger.setLevel(logging.DEBUG)
-            session_logger.propagate = False
+    def _get_session_logger(self, session_id: str) -> Optional[logging.Logger]:
+        """Return a file logger only while the session is still live.
 
-            # 清除可能存在的handlers
-            if session_logger.handlers:
-                self._close_handlers(session_logger)
+        Python's logging registry keeps every named logger strongly referenced.  Do
+        not create the named logger until a live session workspace is available,
+        and serialize creation with cleanup so late background work cannot recreate
+        a logger after ``close_session``.
+        """
+        if not self.file_logging_enabled:
+            return None
 
-            self.session_loggers[session_id] = session_logger
-
-        # 检查是否已经有FileHandler
-        has_file_handler = any(
-            isinstance(h, logging.FileHandler) for h in session_logger.handlers
-        )
-
-        # 如果没有FileHandler，尝试添加
-        if not has_file_handler:
+        with self._session_loggers_lock:
             try:
-                # 获取session workspace路径
                 from sagents.session_runtime import get_global_session_manager
 
                 session_manager = get_global_session_manager()
@@ -354,33 +343,48 @@ class Logger:
                     if session_manager
                     else None
                 )
-                if session and session.session_context:
-                    # 检查 session_workspace 属性是否存在（init_more 完成后才有）
-                    if hasattr(session.session_context, "session_workspace"):
-                        session_workspace = session.session_context.session_workspace
+                session_context = getattr(session, "session_context", None)
+                status = getattr(session, "status", None)
+                status_value = getattr(status, "value", str(status or ""))
+                if status_value not in {"idle", "running"}:
+                    self.cleanup_session_logger(session_id)
+                    return None
+                session_workspace = getattr(
+                    session_context, "session_workspace", None
+                )
+                if not session_workspace:
+                    return None
 
-                        # 创建session专用的日志文件 - 使用普通FileHandler以确保追加模式
-                        session_log_file = os.path.join(
-                            session_workspace, f"session_{session_id}.log"
-                        )
-                        # 使用FileHandler的追加模式，而不是RotatingFileHandler
-                        session_file_handler = logging.FileHandler(
-                            session_log_file, mode="a", encoding="utf-8"
-                        )
-                        session_file_handler.setLevel(logging.DEBUG)
-                        session_format = logging.Formatter(
-                            "%(asctime)s - %(levelname)s - [%(caller_filename)s:%(caller_lineno)d] - %(message)s"
-                        )
-                        session_file_handler.setFormatter(session_format)
+                cached_logger = self.session_loggers.get(session_id)
+                if cached_logger is not None:
+                    return cached_logger
 
-                        session_logger.addHandler(session_file_handler)
+                session_log_file = os.path.join(
+                    session_workspace, f"session_{session_id}.log"
+                )
+                session_file_handler = logging.FileHandler(
+                    session_log_file, mode="a", encoding="utf-8"
+                )
+                session_file_handler.setLevel(logging.DEBUG)
+                session_file_handler.setFormatter(
+                    logging.Formatter(
+                        "%(asctime)s - %(levelname)s - "
+                        "[%(caller_filename)s:%(caller_lineno)d] - %(message)s"
+                    )
+                )
+
+                session_logger = logging.getLogger(f"sage_session_{session_id}")
+                session_logger.setLevel(logging.DEBUG)
+                session_logger.propagate = False
+                self._close_handlers(session_logger)
+                session_logger.addHandler(session_file_handler)
+                self.session_loggers[session_id] = session_logger
+                return session_logger
             except Exception as e:
-                # 如果无法创建session专用日志文件，记录错误但不影响主要功能
                 print(
                     f"Warning: Failed to create session log file for {session_id}: {e}"
                 )
-
-        return session_logger
+                return None
 
     def _log(self, level, message, explicit_session_id: Optional[str] = None, **kwargs):
         # Get caller frame info to include filename and line number
@@ -437,12 +441,13 @@ class Logger:
         if session_id != "NO_SESSION":
             try:
                 session_logger = self._get_session_logger(session_id)
-                session_log_method = getattr(session_logger, level)
-                session_log_method(
-                    f"{message}",
-                    extra={"caller_filename": filename, "caller_lineno": lineno},
-                    **kwargs,
-                )
+                if session_logger is not None:
+                    session_log_method = getattr(session_logger, level)
+                    session_log_method(
+                        f"{message}",
+                        extra={"caller_filename": filename, "caller_lineno": lineno},
+                        **kwargs,
+                    )
             except Exception:
                 # 如果session日志记录失败，不影响主要功能
                 pass
@@ -497,11 +502,23 @@ class Logger:
 
     def cleanup_session_logger(self, session_id: str):
         """清理session专用的logger"""
-        if session_id in self.session_loggers:
-            session_logger = self.session_loggers[session_id]
-            self._close_handlers(session_logger)
-            # 从缓存中移除
-            del self.session_loggers[session_id]
+        logger_name = f"sage_session_{session_id}"
+        with self._session_loggers_lock:
+            session_logger = self.session_loggers.pop(session_id, None)
+            registered_logger = logging.Logger.manager.loggerDict.pop(
+                logger_name, None
+            )
+
+            loggers_to_close = []
+            if session_logger is not None:
+                loggers_to_close.append(session_logger)
+            if (
+                isinstance(registered_logger, logging.Logger)
+                and registered_logger is not session_logger
+            ):
+                loggers_to_close.append(registered_logger)
+            for target_logger in loggers_to_close:
+                self._close_handlers(target_logger)
 
 
 # Create a global logger instance for easy import

--- a/tests/common/services/test_agent_service_workspace_csv.py
+++ b/tests/common/services/test_agent_service_workspace_csv.py
@@ -1,6 +1,8 @@
 import asyncio
 import csv
 import hashlib
+import threading
+import time
 from io import StringIO
 from pathlib import Path
 
@@ -128,6 +130,58 @@ def test_mutate_workspace_csv_rejects_conflicts_and_unsafe_paths(tmp_path):
             expected_content_hash="wrong",
         )
     assert raised.value.status_code == 409
+
+
+def test_workspace_csv_lock_is_retained_for_waiters_then_removed():
+    key = "/workspace/shared.csv"
+    holder_entered = threading.Event()
+    release_holder = threading.Event()
+    waiter_entered = threading.Event()
+    errors = []
+
+    def holder():
+        try:
+            with agent_service._workspace_csv_lock(key):
+                holder_entered.set()
+                release_holder.wait(timeout=2)
+        except BaseException as exc:
+            errors.append(exc)
+
+    def waiter():
+        try:
+            holder_entered.wait(timeout=2)
+            with agent_service._workspace_csv_lock(key):
+                waiter_entered.set()
+        except BaseException as exc:
+            errors.append(exc)
+
+    first = threading.Thread(target=holder)
+    second = threading.Thread(target=waiter)
+    first.start()
+    assert holder_entered.wait(timeout=2)
+    second.start()
+
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        with agent_service._WORKSPACE_CSV_LOCKS_GUARD:
+            entry = agent_service._WORKSPACE_CSV_LOCKS.get(key)
+            if entry is not None and entry.users == 2:
+                break
+        time.sleep(0.005)
+    else:
+        release_holder.set()
+        first.join(timeout=2)
+        second.join(timeout=2)
+        pytest.fail("waiting thread was not retained by the keyed lock")
+
+    assert not waiter_entered.is_set()
+    release_holder.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert errors == []
+    assert waiter_entered.is_set()
+    assert key not in agent_service._WORKSPACE_CSV_LOCKS
 
 
 def test_server_csv_route_forwards_user_scoped_mutation(monkeypatch):

--- a/tests/common/services/test_agent_service_workspace_upload.py
+++ b/tests/common/services/test_agent_service_workspace_upload.py
@@ -136,6 +136,7 @@ def test_import_workspace_archive_atomically_replaces_target_subtree(tmp_path):
     assert (workspace / "user_health_data" / "activity" / "README.md").read_bytes() == b"activity"
     assert len(result["files"]) == 2
     assert result["idempotency_key"] == "import-1"
+    assert agent_service._WORKSPACE_ARCHIVE_LOCKS == {}
 
 
 def test_import_workspace_archive_rejects_path_traversal(tmp_path):

--- a/tests/common/services/test_async_task_service.py
+++ b/tests/common/services/test_async_task_service.py
@@ -1,0 +1,96 @@
+import asyncio
+
+import pytest
+
+from common.services.async_task_service import AsyncTaskService
+
+
+@pytest.mark.asyncio
+async def test_terminal_task_drops_runner_and_expires_without_access():
+    service = AsyncTaskService(
+        retention_seconds=0.02,
+        cleanup_interval_seconds=0.01,
+    )
+    submitted = await service.submit(
+        task_type="test",
+        owner_id="owner",
+        runner=lambda: asyncio.sleep(0, result={"large": "result"}),
+    )
+    task_id = submitted["task_id"]
+
+    for _ in range(20):
+        task = service._tasks.get(task_id)
+        if task and task.get("status") == "completed":
+            break
+        await asyncio.sleep(0.005)
+
+    assert service._tasks[task_id]["status"] == "completed"
+    assert "asyncio_task" not in service._tasks[task_id]
+
+    await asyncio.sleep(0.05)
+    assert task_id not in service._tasks
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cancels_running_tasks_and_clears_registry():
+    service = AsyncTaskService(cleanup_interval_seconds=60)
+    started = asyncio.Event()
+
+    async def runner():
+        started.set()
+        await asyncio.Event().wait()
+
+    await service.submit(task_type="test", owner_id="owner", runner=runner)
+    await started.wait()
+    await service.shutdown()
+
+    assert service._tasks == {}
+    assert service._cleanup_task is None
+
+
+@pytest.mark.asyncio
+async def test_cancelled_submit_does_not_leave_pending_record_or_runner():
+    service = AsyncTaskService(cleanup_interval_seconds=60)
+    runner_called = False
+
+    async def runner():
+        nonlocal runner_called
+        runner_called = True
+
+    await service._lock.acquire()
+    submit_task = asyncio.create_task(
+        service.submit(task_type="test", owner_id="owner", runner=runner)
+    )
+    await asyncio.sleep(0)
+    submit_task.cancel()
+    service._lock.release()
+
+    with pytest.raises(asyncio.CancelledError):
+        await submit_task
+    await asyncio.sleep(0)
+
+    assert service._tasks == {}
+    assert runner_called is False
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_submit_cannot_register_after_shutdown_cutoff():
+    service = AsyncTaskService(cleanup_interval_seconds=60)
+    await service._lock.acquire()
+    shutdown_task = asyncio.create_task(service.shutdown())
+    await asyncio.sleep(0)
+    submit_task = asyncio.create_task(
+        service.submit(
+            task_type="test",
+            owner_id="owner",
+            runner=lambda: asyncio.sleep(0),
+        )
+    )
+    service._lock.release()
+
+    await shutdown_task
+    with pytest.raises(RuntimeError, match="shut down"):
+        await submit_task
+    assert service._tasks == {}

--- a/tests/common/services/test_skill_service_server_list.py
+++ b/tests/common/services/test_skill_service_server_list.py
@@ -147,3 +147,44 @@ def test_collect_server_skills_only_returns_agent_skills_when_explicit(
     )
 
     assert {skill.name for skill in skills} == {"agent-a-skill"}
+
+
+def test_server_skills_cache_purges_expired_entries(monkeypatch):
+    skill_service._invalidate_server_skills_cache()
+    now = [100.0]
+    monkeypatch.setattr(skill_service.time, "monotonic", lambda: now[0])
+    monkeypatch.setattr(
+        skill_service,
+        "_collect_server_skills_uncached",
+        lambda current_user_id, role, dimension: [],
+    )
+
+    skill_service._collect_server_skills("user-a", "user")
+    assert len(skill_service._server_skills_cache) == 1
+
+    now[0] += skill_service._SERVER_SKILLS_CACHE_TTL_SECONDS + 1
+    skill_service._collect_server_skills("user-b", "user")
+
+    assert list(skill_service._server_skills_cache) == [
+        skill_service._server_skills_cache_key("user-b", "user", None)
+    ]
+
+
+def test_server_skills_cache_enforces_lru_limit(monkeypatch):
+    skill_service._invalidate_server_skills_cache()
+    monkeypatch.setattr(skill_service, "_SERVER_SKILLS_CACHE_MAX_ENTRIES", 2)
+    monkeypatch.setattr(
+        skill_service,
+        "_collect_server_skills_uncached",
+        lambda current_user_id, role, dimension: [],
+    )
+
+    skill_service._collect_server_skills("user-a", "user")
+    skill_service._collect_server_skills("user-b", "user")
+    skill_service._collect_server_skills("user-a", "user")
+    skill_service._collect_server_skills("user-c", "user")
+
+    assert skill_service._server_skills_cache_key(
+        "user-b", "user", None
+    ) not in skill_service._server_skills_cache
+    assert len(skill_service._server_skills_cache) == 2

--- a/tests/common/utils/test_stream_merge.py
+++ b/tests/common/utils/test_stream_merge.py
@@ -1,0 +1,59 @@
+import asyncio
+
+import pytest
+
+import common.utils.stream_merge as stream_merge
+from common.utils.stream_merge import interleave_message_and_progress
+
+
+@pytest.mark.asyncio
+async def test_closing_merge_waits_for_worker_cleanup():
+    cleanup_started = asyncio.Event()
+    allow_cleanup = asyncio.Event()
+
+    async def messages():
+        try:
+            yield "first"
+            await asyncio.Event().wait()
+        finally:
+            cleanup_started.set()
+            await allow_cleanup.wait()
+
+    merged = interleave_message_and_progress(messages(), asyncio.Queue())
+    assert await anext(merged) == ("message", "first")
+
+    close_task = asyncio.create_task(merged.aclose())
+    await cleanup_started.wait()
+    assert not close_task.done()
+
+    allow_cleanup.set()
+    await close_task
+
+
+@pytest.mark.asyncio
+async def test_closing_merge_is_bounded_when_worker_ignores_cancellation(monkeypatch):
+    monkeypatch.setattr(stream_merge, "_WORKER_SHUTDOWN_TIMEOUT_SECONDS", 0.02)
+    cleanup_started = asyncio.Event()
+    allow_cleanup = asyncio.Event()
+
+    async def messages():
+        try:
+            yield "first"
+            await asyncio.Event().wait()
+        finally:
+            cleanup_started.set()
+            while not allow_cleanup.is_set():
+                try:
+                    await allow_cleanup.wait()
+                except asyncio.CancelledError:
+                    continue
+
+    merged = interleave_message_and_progress(messages(), asyncio.Queue())
+    assert await anext(merged) == ("message", "first")
+
+    close_task = asyncio.create_task(merged.aclose())
+    await cleanup_started.wait()
+    await asyncio.wait_for(close_task, timeout=0.2)
+
+    allow_cleanup.set()
+    await asyncio.sleep(0)

--- a/tests/sagents/context/test_session_log_writer.py
+++ b/tests/sagents/context/test_session_log_writer.py
@@ -1,0 +1,180 @@
+import asyncio
+import threading
+
+import pytest
+
+from sagents.context.session_context import SessionContext
+
+
+def _context(tmp_path):
+    context = SessionContext(
+        session_id="log-session",
+        user_id="user-1",
+        agent_id="agent-1",
+        session_root_space=str(tmp_path),
+    )
+    context.session_workspace = str(tmp_path)
+    return context
+
+
+@pytest.mark.asyncio
+async def test_diagnostic_logs_share_one_writer_and_flush_all(tmp_path, monkeypatch):
+    context = _context(tmp_path)
+    llm_writes = []
+    mcp_writes = []
+    monkeypatch.setattr(
+        context,
+        "_save_llm_request_sync",
+        lambda item: llm_writes.append(item),
+    )
+    monkeypatch.setattr(
+        context,
+        "_save_mcp_calls_sync",
+        lambda request_id: mcp_writes.append(request_id),
+    )
+
+    context._current_request = {
+        "request_id": "request-1",
+        "started_at": 1.0,
+        "per_call": [],
+        "total_usage": {},
+    }
+    for index in range(20):
+        context.add_llm_request({"index": index}, {"ok": True})
+        context.add_mcp_call({"tool": f"tool-{index}"})
+
+    writer = context._log_writer_task
+    assert writer is not None
+    await context.flush_pending_log_writes()
+
+    assert len(llm_writes) == 20
+    assert mcp_writes == ["request-1"]
+    assert context._log_writer_task is None
+    assert context._log_writer_closed is True
+
+
+@pytest.mark.asyncio
+async def test_flush_waits_for_inflight_writer(tmp_path, monkeypatch):
+    context = _context(tmp_path)
+    started = threading.Event()
+    release = threading.Event()
+    writes = []
+
+    def blocking_save(item):
+        started.set()
+        release.wait()
+        writes.append(item)
+
+    monkeypatch.setattr(context, "_save_llm_request_sync", blocking_save)
+    context.add_llm_request({"index": 1}, {"ok": True})
+
+    assert await asyncio.to_thread(started.wait, 1)
+    flush_task = asyncio.create_task(context.flush_pending_log_writes())
+    await asyncio.sleep(0)
+    assert not flush_task.done()
+    release.set()
+    await flush_task
+    assert len(writes) == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_flushes_share_the_same_writer(tmp_path, monkeypatch):
+    context = _context(tmp_path)
+    started = threading.Event()
+    release = threading.Event()
+    writes = []
+
+    def blocking_save(item):
+        started.set()
+        release.wait()
+        writes.append(item)
+
+    monkeypatch.setattr(context, "_save_llm_request_sync", blocking_save)
+    context.add_llm_request({"index": 1}, {"ok": True})
+
+    assert await asyncio.to_thread(started.wait, 1)
+    first = asyncio.create_task(context.flush_pending_log_writes())
+    second = asyncio.create_task(context.flush_pending_log_writes())
+    release.set()
+
+    assert await asyncio.gather(first, second) == [True, True]
+    assert len(writes) == 1
+
+
+@pytest.mark.asyncio
+async def test_flush_timeout_releases_writer_and_payloads(tmp_path, monkeypatch):
+    context = _context(tmp_path)
+    context.LOG_FLUSH_TIMEOUT_SECONDS = 0.02
+    context.LOG_WRITER_CANCEL_TIMEOUT_SECONDS = 0.02
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_save(_item):
+        started.set()
+        release.wait()
+
+    monkeypatch.setattr(context, "_save_llm_request_sync", blocking_save)
+    context.add_llm_request({"index": 1}, {"ok": True})
+
+    try:
+        assert await asyncio.to_thread(started.wait, 1)
+        assert await context.flush_pending_log_writes() is False
+        assert context._log_writer_task is None
+        assert context.llm_requests_logs == []
+        assert context.mcp_calls_logs == []
+        assert context._dirty_mcp_request_ids == set()
+    finally:
+        release.set()
+
+
+@pytest.mark.asyncio
+async def test_writer_failure_does_not_block_later_items(tmp_path, monkeypatch):
+    context = _context(tmp_path)
+    attempted = []
+
+    def sometimes_failing_save(item):
+        attempted.append(item["request"]["index"])
+        if len(attempted) == 1:
+            raise OSError("first diagnostic write failed")
+
+    monkeypatch.setattr(context, "_save_llm_request_sync", sometimes_failing_save)
+    context.add_llm_request({"index": 1}, {"ok": True})
+    context.add_llm_request({"index": 2}, {"ok": True})
+
+    assert await context.flush_pending_log_writes() is True
+    assert attempted == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_mcp_call_added_during_write_is_saved_by_next_pass(
+    tmp_path, monkeypatch
+):
+    context = _context(tmp_path)
+    context._current_request = {
+        "request_id": "request-race",
+        "started_at": 1.0,
+        "per_call": [],
+        "total_usage": {},
+    }
+    first_write_started = threading.Event()
+    allow_first_write = threading.Event()
+    writes = []
+
+    def blocking_first_save(request_id):
+        writes.append(request_id)
+        if len(writes) == 1:
+            first_write_started.set()
+            allow_first_write.wait()
+
+    monkeypatch.setattr(context, "_save_mcp_calls_sync", blocking_first_save)
+    context.add_mcp_call({"tool": "first"})
+
+    try:
+        assert await asyncio.to_thread(first_write_started.wait, 1)
+        context.add_mcp_call({"tool": "second"})
+        allow_first_write.set()
+        assert await context.flush_pending_log_writes() is True
+    finally:
+        allow_first_write.set()
+
+    assert writes == ["request-race", "request-race"]

--- a/tests/sagents/test_session_history_cache_cleanup.py
+++ b/tests/sagents/test_session_history_cache_cleanup.py
@@ -1,0 +1,144 @@
+import threading
+import types
+
+from sagents.session_runtime import SessionManager
+from sagents.tool.impl.execute_command_tool import ExecuteCommandTool
+from sagents.tool.impl.memory_tool import MemoryTool, SessionHistoryRetriever
+
+
+def test_close_session_clears_only_its_history_cache(tmp_path):
+    SessionHistoryRetriever.clear_cache()
+    SessionHistoryRetriever._history_cache.update(
+        {
+            "finished-session": object(),
+            "running-session": object(),
+        }
+    )
+    manager = SessionManager(str(tmp_path / "sessions"), enable_obs=False)
+    manager.get_or_create("finished-session")
+
+    try:
+        manager.close_session("finished-session")
+
+        assert "finished-session" not in SessionHistoryRetriever._history_cache
+        assert "running-session" in SessionHistoryRetriever._history_cache
+    finally:
+        SessionHistoryRetriever.clear_cache()
+
+
+def test_close_missing_session_still_clears_stale_history_cache(tmp_path):
+    SessionHistoryRetriever.clear_cache()
+    SessionHistoryRetriever._history_cache["stale-session"] = object()
+    manager = SessionManager(str(tmp_path / "sessions"), enable_obs=False)
+
+    try:
+        manager.close_session("stale-session")
+
+        assert "stale-session" not in SessionHistoryRetriever._history_cache
+    finally:
+        SessionHistoryRetriever.clear_cache()
+
+
+def test_clear_session_cache_prevents_inflight_search_from_reinserting(
+    monkeypatch,
+):
+    SessionHistoryRetriever.clear_cache()
+    compact_started = threading.Event()
+    allow_compact = threading.Event()
+
+    def blocking_compact(_messages):
+        compact_started.set()
+        assert allow_compact.wait(timeout=2)
+        return []
+
+    monkeypatch.setattr(
+        SessionHistoryRetriever,
+        "_compact_history_messages",
+        staticmethod(blocking_compact),
+    )
+    retriever = SessionHistoryRetriever(MemoryTool())
+    session_context = types.SimpleNamespace(
+        message_manager=types.SimpleNamespace(
+            messages=[], compute_history_anchor_index=lambda: 1
+        ),
+        agent_config={},
+    )
+    worker = threading.Thread(
+        target=retriever._get_history_messages,
+        args=("racing-session", session_context),
+    )
+
+    try:
+        worker.start()
+        assert compact_started.wait(timeout=2)
+
+        SessionHistoryRetriever.clear_session_cache("racing-session")
+        allow_compact.set()
+        worker.join(timeout=2)
+
+        assert not worker.is_alive()
+        assert "racing-session" not in SessionHistoryRetriever._history_cache
+        assert "racing-session" not in SessionHistoryRetriever._history_states
+    finally:
+        allow_compact.set()
+        worker.join(timeout=2)
+        SessionHistoryRetriever.clear_cache()
+
+
+def test_closed_context_cannot_cache_when_worker_starts_late():
+    SessionHistoryRetriever.clear_cache()
+    retriever = SessionHistoryRetriever(MemoryTool())
+    session_context = types.SimpleNamespace(
+        message_manager=types.SimpleNamespace(
+            messages=[], compute_history_anchor_index=lambda: 1
+        ),
+        agent_config={},
+    )
+
+    try:
+        SessionHistoryRetriever.clear_session_cache(
+            "late-session", session_context
+        )
+        retriever._get_history_messages("late-session", session_context)
+
+        assert "late-session" not in SessionHistoryRetriever._history_cache
+        assert "late-session" not in SessionHistoryRetriever._history_states
+    finally:
+        SessionHistoryRetriever.clear_cache()
+
+
+def test_direct_close_session_force_kills_background_shell(tmp_path, monkeypatch):
+    class FakeSandbox:
+        def __init__(self):
+            self.killed = []
+            self.cleaned = []
+
+        async def kill_background(self, task_id, force=False):
+            self.killed.append((task_id, force))
+            return True
+
+        async def cleanup_background(self, task_id):
+            self.cleaned.append(task_id)
+
+    monkeypatch.setattr(ExecuteCommandTool, "_BG_TASKS", {})
+    monkeypatch.setattr(ExecuteCommandTool, "_COMPLETION_EVENTS", {})
+    monkeypatch.setattr(ExecuteCommandTool, "_WATCHER_TASKS", {})
+    sandbox = FakeSandbox()
+    ExecuteCommandTool._BG_TASKS["closing-task"] = {
+        "task_id": "closing-task",
+        "session_id": "closing-session",
+        "mode": "native",
+        "sandbox": sandbox,
+    }
+    manager = SessionManager(str(tmp_path / "sessions"), enable_obs=False)
+    session = manager.get_or_create("closing-session")
+    session_context = types.SimpleNamespace(sandbox=sandbox)
+    session.session_context = session_context
+
+    manager.close_session("closing-session")
+
+    assert sandbox.killed == [("closing-task", True)]
+    assert sandbox.cleaned == ["closing-task"]
+    assert ExecuteCommandTool._BG_TASKS == {}
+    assert session.session_context is None
+    assert session_context._session_history_cache_closed is True

--- a/tests/sagents/test_session_runtime_lifecycle.py
+++ b/tests/sagents/test_session_runtime_lifecycle.py
@@ -1,0 +1,213 @@
+import asyncio
+import json
+import sqlite3
+
+import pytest
+
+import sagents.session_runtime as session_runtime
+from sagents.session_runtime import SessionManager
+
+
+def _write_historical_session(tmp_path, session_id: str):
+    workspace = tmp_path / session_id
+    workspace.mkdir()
+    (workspace / "messages.json").write_text(
+        json.dumps(
+            [
+                {
+                    "role": "user",
+                    "content": "persisted",
+                    "session_id": session_id,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (workspace / "session_context.json").write_text(
+        json.dumps(
+            {
+                "session_id": session_id,
+                "user_id": "user-1",
+                "status": "completed",
+                "agent_config": {"agent_id": "agent-1"},
+                "session_root_space": str(tmp_path),
+                "session_workspace": str(workspace),
+                "tasks_status": {"tasks": [{"id": "done"}]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return workspace
+
+
+def test_historical_reads_never_repopulate_live_sessions(tmp_path):
+    manager = SessionManager(str(tmp_path), enable_obs=False)
+    session_id = "historical-session"
+    workspace = _write_historical_session(tmp_path, session_id)
+    manager.cache_session_workspace(session_id, str(workspace))
+
+    restored = manager.get(session_id)
+    assert restored is not None
+    assert restored.get_status().value == "completed"
+    assert manager._sessions == {}
+
+    assert [message.content for message in manager.get_session_messages(session_id)] == [
+        "persisted"
+    ]
+    assert manager.get_session_status(session_id) == {"status": "completed"}
+    assert manager.get_tasks_status(session_id) == {"tasks": [{"id": "done"}]}
+    assert manager.save_session(session_id) is False
+    assert manager._sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_aclose_session_flushes_context_before_release(tmp_path):
+    manager = SessionManager(str(tmp_path), enable_obs=False)
+    session = manager.get_or_create("closing-session")
+    calls = []
+
+    class FakeContext:
+        sandbox = None
+        _owner_loop = None
+
+        async def flush_pending_log_writes(self):
+            calls.append("flush")
+
+    session.set_context(FakeContext())
+    await manager.aclose_session("closing-session")
+
+    assert calls == ["flush"]
+    assert manager._sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_sync_close_from_worker_runs_cleanup_on_owner_loop(tmp_path):
+    manager = SessionManager(str(tmp_path), enable_obs=False)
+    session = manager.get_or_create("thread-close-session")
+    owner_loop = asyncio.get_running_loop()
+    cleaned_on = []
+
+    class FakeContext:
+        sandbox = None
+        _owner_loop = owner_loop
+
+        async def flush_pending_log_writes(self):
+            cleaned_on.append(asyncio.get_running_loop())
+
+    session.set_context(FakeContext())
+    await asyncio.to_thread(manager.close_session, "thread-close-session")
+
+    assert cleaned_on == [owner_loop]
+    assert manager._sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_sync_close_reserves_session_id_until_cleanup_finishes(tmp_path):
+    manager = SessionManager(str(tmp_path), enable_obs=False)
+    session = manager.get_or_create("reused-session")
+    cleanup_started = asyncio.Event()
+    allow_cleanup = asyncio.Event()
+
+    class FakeContext:
+        sandbox = None
+        _owner_loop = asyncio.get_running_loop()
+
+        async def flush_pending_log_writes(self):
+            cleanup_started.set()
+            await allow_cleanup.wait()
+
+    session.set_context(FakeContext())
+    manager.close_session("reused-session")
+    await cleanup_started.wait()
+
+    with pytest.raises(RuntimeError, match="still closing"):
+        manager.get_or_create("reused-session")
+
+    allow_cleanup.set()
+    await manager.aclose_session("reused-session")
+    replacement = manager.get_or_create("reused-session")
+    assert manager.get_live_session("reused-session") is replacement
+
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_aclose_releases_session_when_log_flush_ignores_cancellation(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(session_runtime, "_SESSION_LOG_FLUSH_TIMEOUT_SECONDS", 0.02)
+    manager = SessionManager(str(tmp_path), enable_obs=False)
+    session = manager.get_or_create("stalled-close")
+    flush_started = asyncio.Event()
+    allow_flush_exit = asyncio.Event()
+
+    class FakeContext:
+        sandbox = None
+        _owner_loop = asyncio.get_running_loop()
+
+        async def flush_pending_log_writes(self):
+            flush_started.set()
+            while not allow_flush_exit.is_set():
+                try:
+                    await allow_flush_exit.wait()
+                except asyncio.CancelledError:
+                    # Model a broken adapter that swallows cancellation.
+                    continue
+
+    session.set_context(FakeContext())
+    await manager.aclose_session("stalled-close")
+
+    assert flush_started.is_set()
+    assert manager._sessions == {}
+    assert manager._session_close_futures == {}
+    replacement = manager.get_or_create("stalled-close")
+    assert manager.get_live_session("stalled-close") is replacement
+
+    allow_flush_exit.set()
+    await asyncio.sleep(0)
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_sync_cross_thread_close_has_bounded_wait(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_runtime, "_SESSION_LOG_FLUSH_TIMEOUT_SECONDS", 0.2)
+    monkeypatch.setattr(
+        session_runtime, "_SYNC_SESSION_CLOSE_WAIT_TIMEOUT_SECONDS", 0.02
+    )
+    manager = SessionManager(str(tmp_path), enable_obs=False)
+    session = manager.get_or_create("sync-stalled-close")
+    owner_loop = asyncio.get_running_loop()
+    flush_started = asyncio.Event()
+    allow_flush_exit = asyncio.Event()
+
+    class FakeContext:
+        sandbox = None
+        _owner_loop = owner_loop
+
+        async def flush_pending_log_writes(self):
+            flush_started.set()
+            await allow_flush_exit.wait()
+
+    session.set_context(FakeContext())
+    await asyncio.wait_for(
+        asyncio.to_thread(manager.close_session, "sync-stalled-close"),
+        timeout=0.2,
+    )
+    assert flush_started.is_set()
+    assert "sync-stalled-close" in manager._session_close_futures
+
+    allow_flush_exit.set()
+    await manager.aclose_session("sync-stalled-close")
+    assert manager._session_close_futures == {}
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_closes_session_registry_connection(tmp_path):
+    manager = SessionManager(str(tmp_path), enable_obs=False)
+    assert manager._registry._conn.execute("SELECT 1").fetchone() == (1,)
+
+    await manager.shutdown()
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        manager._registry._conn.execute("SELECT 1")

--- a/tests/sagents/tool/impl/test_execute_command_tool.py
+++ b/tests/sagents/tool/impl/test_execute_command_tool.py
@@ -63,6 +63,8 @@ class _FakeBackgroundSandbox(_FakeSandbox):
         self.workspace_path = str(agent_workspace)
         self.host_workspace_path = str(agent_workspace)
         self.bg_calls = []
+        self.killed_tasks = []
+        self.cleaned_tasks = []
 
     def supports_background(self):
         return True
@@ -89,6 +91,13 @@ class _FakeBackgroundSandbox(_FakeSandbox):
     async def read_background_output(self, task_id, max_bytes=8192):
         return ""
 
+    async def kill_background(self, task_id, force=False):
+        self.killed_tasks.append((task_id, force))
+        return True
+
+    async def cleanup_background(self, task_id):
+        self.cleaned_tasks.append(task_id)
+
 
 def test_shell_tool_descriptions_do_not_expose_completion_reminder_protocol():
     descriptions = []
@@ -102,6 +111,58 @@ def test_shell_tool_descriptions_do_not_expose_completion_reminder_protocol():
     assert "无需轮询" not in combined
     assert "polling is unnecessary" not in combined
     assert "await_shell" in combined
+
+
+def test_session_cleanup_kills_only_its_background_tasks(monkeypatch, tmp_path):
+    monkeypatch.setattr(ExecuteCommandTool, "_BG_TASKS", {})
+    monkeypatch.setattr(ExecuteCommandTool, "_COMPLETION_EVENTS", {})
+    monkeypatch.setattr(ExecuteCommandTool, "_WATCHER_TASKS", {})
+    sandbox = _FakeBackgroundSandbox(tmp_path)
+    tool = ExecuteCommandTool()
+
+    async def scenario():
+        watcher_blocker = asyncio.Event()
+
+        async def watcher():
+            await watcher_blocker.wait()
+
+        watcher_task = asyncio.create_task(watcher())
+        tool._track_watcher("closing-session", watcher_task)
+        ExecuteCommandTool._BG_TASKS.update(
+            {
+                "closing-task": {
+                    "task_id": "closing-task",
+                    "session_id": "closing-session",
+                    "mode": "native",
+                    "sandbox": sandbox,
+                },
+                "other-task": {
+                    "task_id": "other-task",
+                    "session_id": "other-session",
+                    "mode": "native",
+                    "sandbox": sandbox,
+                },
+            }
+        )
+        ExecuteCommandTool._COMPLETION_EVENTS.update(
+            {
+                "closing-session": {"closing-task": {"task_id": "closing-task"}},
+                "other-session": {"other-task": {"task_id": "other-task"}},
+            }
+        )
+
+        await tool.cleanup_session_tasks("closing-session", sandbox=sandbox)
+
+        assert watcher_task.cancelled()
+        assert sandbox.killed_tasks == [("closing-task", True)]
+        assert sandbox.cleaned_tasks == ["closing-task"]
+        assert "closing-task" not in ExecuteCommandTool._BG_TASKS
+        assert "other-task" in ExecuteCommandTool._BG_TASKS
+        assert "closing-session" not in ExecuteCommandTool._COMPLETION_EVENTS
+        assert "other-session" in ExecuteCommandTool._COMPLETION_EVENTS
+        assert "closing-session" not in ExecuteCommandTool._WATCHER_TASKS
+
+    asyncio.run(scenario())
 
 
 def test_execute_shell_command_uses_provider_default_workdir(monkeypatch):

--- a/tests/sagents/tool/impl/test_file_memory_backend.py
+++ b/tests/sagents/tool/impl/test_file_memory_backend.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+import threading
 import types
 import unittest
 from unittest.mock import patch
@@ -55,6 +56,9 @@ class _FakeIndex:
             )
         ]
 
+    def clear_index(self):
+        raise AssertionError("in-memory release must not delete the persisted index")
+
 
 class _FakeMemoryTool:
     def _get_index_path(self, user_id: str, agent_id: str, workspace_path: str) -> str:
@@ -106,7 +110,7 @@ class TestFileMemoryBackend(unittest.TestCase):
         result = asyncio.run(backend.search("provider", 3, types.SimpleNamespace()))
         self.assertEqual(result, [])
 
-    def test_scoped_index_backend_reuses_index_cache(self):
+    def test_scoped_index_backend_releases_index_after_each_sequential_search(self):
         backend = ScopedIndexFileMemoryBackend(_FakeMemoryTool())
         session_context = types.SimpleNamespace(
             sandbox=object(),
@@ -117,12 +121,192 @@ class TestFileMemoryBackend(unittest.TestCase):
 
         with patch("sagents.tool.impl.memory_index.MemoryIndex", _FakeIndex):
             first = asyncio.run(backend.search("provider", 3, session_context))
+            self.assertEqual(ScopedIndexFileMemoryBackend._index_cache, {})
             second = asyncio.run(backend.search("provider", 3, session_context))
 
         self.assertEqual(len(first), 1)
         self.assertEqual(len(second), 1)
-        self.assertEqual(len(_FakeIndex.instances), 1)
-        self.assertEqual(_FakeIndex.update_calls, 1)
+        self.assertEqual(len(_FakeIndex.instances), 2)
+        self.assertEqual(_FakeIndex.update_calls, 2)
+        self.assertEqual(ScopedIndexFileMemoryBackend._index_cache, {})
+
+    def test_scoped_index_backend_shares_only_between_concurrent_searches(self):
+        backend = ScopedIndexFileMemoryBackend(_FakeMemoryTool())
+        session_context = types.SimpleNamespace(
+            sandbox=object(),
+            sandbox_agent_workspace="/workspace",
+            agent_id="agent-a",
+            user_id="alice",
+        )
+
+        async def scenario():
+            update_started = asyncio.Event()
+            allow_update = asyncio.Event()
+
+            class _BlockingIndex(_FakeIndex):
+                async def update_index(self):
+                    _FakeIndex.update_calls += 1
+                    self._has_search_index = True
+                    update_started.set()
+                    await allow_update.wait()
+                    return {"updated": True}
+
+            with patch("sagents.tool.impl.memory_index.MemoryIndex", _BlockingIndex):
+                first_task = asyncio.create_task(
+                    backend.search("first", 3, session_context)
+                )
+                await update_started.wait()
+                second_task = asyncio.create_task(
+                    backend.search("second", 3, session_context)
+                )
+                await asyncio.sleep(0)
+
+                scope_key = backend._build_scope_key("alice", "agent-a", "/workspace")
+                cache_entry = backend._index_cache[scope_key]
+                self.assertEqual(cache_entry.active_searches, 2)
+                self.assertEqual(len(_FakeIndex.instances), 1)
+
+                allow_update.set()
+                results = await asyncio.gather(first_task, second_task)
+
+            self.assertEqual([len(result) for result in results], [1, 1])
+            self.assertEqual(len(_FakeIndex.instances), 1)
+            self.assertEqual(_FakeIndex.update_calls, 1)
+            self.assertEqual(backend._index_cache, {})
+
+        asyncio.run(scenario())
+
+    def test_scoped_index_backend_keeps_different_scopes_isolated(self):
+        backend = ScopedIndexFileMemoryBackend(_FakeMemoryTool())
+        alice_context = types.SimpleNamespace(
+            sandbox=object(),
+            sandbox_agent_workspace="/workspace",
+            agent_id="agent-a",
+            user_id="alice",
+        )
+        bob_context = types.SimpleNamespace(
+            sandbox=object(),
+            sandbox_agent_workspace="/workspace",
+            agent_id="agent-a",
+            user_id="bob",
+        )
+
+        async def scenario():
+            started_count = 0
+            both_started = asyncio.Event()
+            allow_updates = asyncio.Event()
+
+            class _TwoScopeIndex(_FakeIndex):
+                async def update_index(self):
+                    nonlocal started_count
+                    started_count += 1
+                    self._has_search_index = True
+                    if started_count == 2:
+                        both_started.set()
+                    await allow_updates.wait()
+                    return {"updated": True}
+
+            with patch("sagents.tool.impl.memory_index.MemoryIndex", _TwoScopeIndex):
+                alice_task = asyncio.create_task(
+                    backend.search("alice", 3, alice_context)
+                )
+                bob_task = asyncio.create_task(backend.search("bob", 3, bob_context))
+                await both_started.wait()
+
+                self.assertEqual(len(backend._index_cache), 2)
+                self.assertEqual(len(_FakeIndex.instances), 2)
+
+                allow_updates.set()
+                await asyncio.gather(alice_task, bob_task)
+
+            self.assertEqual(backend._index_cache, {})
+
+        asyncio.run(scenario())
+
+    def test_scoped_index_backend_releases_index_after_failures(self):
+        backend = ScopedIndexFileMemoryBackend(_FakeMemoryTool())
+        session_context = types.SimpleNamespace(
+            sandbox=object(),
+            sandbox_agent_workspace="/workspace",
+            agent_id="agent-a",
+            user_id="alice",
+        )
+
+        class _InitializationFailure:
+            def __init__(self, sandbox, workspace_path, index_path):
+                raise RuntimeError("initialization failed")
+
+        class _UpdateFailure(_FakeIndex):
+            async def update_index(self):
+                raise RuntimeError("update failed")
+
+        class _SearchFailure(_FakeIndex):
+            def search(self, query, top_k):
+                raise RuntimeError("search failed")
+
+        for failing_index in (
+            _InitializationFailure,
+            _UpdateFailure,
+            _SearchFailure,
+        ):
+            with self.subTest(failing_index=failing_index.__name__):
+                with patch(
+                    "sagents.tool.impl.memory_index.MemoryIndex", failing_index
+                ):
+                    result = asyncio.run(
+                        backend.search("provider", 3, session_context)
+                    )
+                self.assertEqual(result, [])
+                self.assertEqual(backend._index_cache, {})
+
+    def test_scoped_index_backend_releases_index_after_cancellation(self):
+        backend = ScopedIndexFileMemoryBackend(_FakeMemoryTool())
+        session_context = types.SimpleNamespace(
+            sandbox=object(),
+            sandbox_agent_workspace="/workspace",
+            agent_id="agent-a",
+            user_id="alice",
+        )
+
+        async def scenario():
+            search_started = threading.Event()
+            allow_search = threading.Event()
+
+            class _CancellableIndex(_FakeIndex):
+                def search(self, query, top_k):
+                    search_started.set()
+                    allow_search.wait(timeout=5)
+                    return super().search(query, top_k)
+
+            with patch("sagents.tool.impl.memory_index.MemoryIndex", _CancellableIndex):
+                search_task = asyncio.create_task(
+                    backend.search("provider", 3, session_context)
+                )
+                started = await asyncio.to_thread(search_started.wait, 2)
+                self.assertTrue(started)
+                search_task.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await search_task
+
+                scope_key = backend._build_scope_key("alice", "agent-a", "/workspace")
+                self.assertEqual(backend._index_cache[scope_key].active_searches, 1)
+
+                second_task = asyncio.create_task(
+                    backend.search("second", 3, session_context)
+                )
+                await asyncio.sleep(0)
+                self.assertEqual(backend._index_cache[scope_key].active_searches, 2)
+                self.assertEqual(len(_FakeIndex.instances), 1)
+
+                allow_search.set()
+                second_result = await second_task
+                await asyncio.sleep(0)
+
+            self.assertEqual(len(second_result), 1)
+            self.assertEqual(len(_FakeIndex.instances), 1)
+            self.assertEqual(backend._index_cache, {})
+
+        asyncio.run(scenario())
 
     def test_retriever_uses_agent_config_backend_selection(self):
         retriever = FileMemoryRetriever(_FakeMemoryTool())  # pyright: ignore[reportArgumentType]

--- a/tests/sagents/tool/impl/test_memory_tool.py
+++ b/tests/sagents/tool/impl/test_memory_tool.py
@@ -318,7 +318,7 @@ class TestMemoryTool(unittest.TestCase):
             ],
         )
 
-    def test_file_memory_retriever_reuses_scoped_index_and_refreshes_once(self):
+    def test_file_memory_retriever_releases_scoped_index_after_each_search(self):
         tool = self.MemoryTool()
         session_context = types.SimpleNamespace(
             sandbox=object(),
@@ -335,41 +335,13 @@ class TestMemoryTool(unittest.TestCase):
                 tool.file_memory_retriever.search("provider cli", 3, session_context)
             )
 
-        self.assertEqual(len(_FakeIndex.instances), 1)
-        self.assertEqual(_FakeIndex.update_calls, 1)
+        self.assertEqual(len(_FakeIndex.instances), 2)
+        self.assertEqual(_FakeIndex.update_calls, 2)
+        self.assertEqual(tool.file_memory_retriever._index_cache, {})
         self.assertEqual(len(results1), 1)
         self.assertEqual(len(results2), 1)
         self.assertEqual(results1[0]["path"], "/workspace/app/cli/example.py")
         self.assertEqual(results1[0]["snippets"][0]["line_number"], 3)
-
-    def test_file_memory_retriever_refreshes_again_when_cached_index_is_stale(self):
-        tool = self.MemoryTool()
-        session_context = types.SimpleNamespace(
-            sandbox=object(),
-            sandbox_agent_workspace="/workspace",
-            agent_id="agent-a",
-            user_id="alice",
-        )
-
-        with patch("sagents.tool.impl.memory_index.MemoryIndex", _FakeIndex):
-            asyncio.run(
-                tool.file_memory_retriever.search("provider cli", 3, session_context)
-            )
-
-            scope_key = tool.file_memory_retriever._build_scope_key(
-                user_id="alice",
-                agent_id="agent-a",
-                workspace_path="/workspace",
-            )
-            cache_entry = tool.file_memory_retriever._index_cache[scope_key]
-            cache_entry.last_refresh_at = 0.0
-
-            asyncio.run(
-                tool.file_memory_retriever.search("provider cli", 3, session_context)
-            )
-
-        self.assertEqual(len(_FakeIndex.instances), 1)
-        self.assertEqual(_FakeIndex.update_calls, 2)
 
     def test_search_memory_success_returns_split_results(self):
         tool = self.MemoryTool()

--- a/tests/sagents/utils/test_logger_file_logging.py
+++ b/tests/sagents/utils/test_logger_file_logging.py
@@ -1,5 +1,6 @@
 import importlib
 import logging
+import types
 
 
 def _load_logger_module(monkeypatch):
@@ -54,3 +55,80 @@ def test_logger_keeps_framework_file_handlers_by_default(monkeypatch, tmp_path):
     logger_module.Logger._close_handlers(logger.logger)
     logger_module.Logger._initialized = False
     logger_module.Logger._instance = None
+
+
+def test_session_logger_is_unregistered_and_cannot_be_recreated_after_close(
+    monkeypatch, tmp_path
+):
+    logger_module = _load_logger_module(monkeypatch)
+    monkeypatch.delenv("SAGE_DISABLE_SAGENTS_FILE_LOGGING", raising=False)
+
+    live_sessions = {
+        "finished-session": types.SimpleNamespace(
+            session_context=types.SimpleNamespace(session_workspace=str(tmp_path)),
+            status=types.SimpleNamespace(value="running"),
+        )
+    }
+    fake_manager = types.SimpleNamespace(
+        get_live_session=lambda session_id: live_sessions.get(session_id)
+    )
+
+    import sagents.session_runtime
+
+    monkeypatch.setattr(
+        sagents.session_runtime,
+        "get_global_session_manager",
+        lambda: fake_manager,
+    )
+
+    logger = logger_module.Logger(log_dir=str(tmp_path / "main-logs"))
+    logger_name = "sage_session_finished-session"
+    try:
+        session_logger = logger._get_session_logger("finished-session")
+        assert session_logger is not None
+        assert logger_name in logging.Logger.manager.loggerDict
+
+        live_sessions.clear()
+        logger.cleanup_session_logger("finished-session")
+
+        assert "finished-session" not in logger.session_loggers
+        assert logger_name not in logging.Logger.manager.loggerDict
+        assert logger._get_session_logger("finished-session") is None
+        assert logger_name not in logging.Logger.manager.loggerDict
+    finally:
+        logger.cleanup_session_logger("finished-session")
+        logger.stop_periodic_cleanup()
+        logger_module.Logger._close_handlers(logger.logger)
+        logger_module.Logger._initialized = False
+        logger_module.Logger._instance = None
+
+
+def test_terminal_session_cannot_create_file_logger(monkeypatch, tmp_path):
+    logger_module = _load_logger_module(monkeypatch)
+    monkeypatch.delenv("SAGE_DISABLE_SAGENTS_FILE_LOGGING", raising=False)
+
+    terminal_session = types.SimpleNamespace(
+        session_context=types.SimpleNamespace(session_workspace=str(tmp_path)),
+        status=types.SimpleNamespace(value="completed"),
+    )
+    fake_manager = types.SimpleNamespace(
+        get_live_session=lambda _session_id: terminal_session
+    )
+    import sagents.session_runtime
+
+    monkeypatch.setattr(
+        sagents.session_runtime,
+        "get_global_session_manager",
+        lambda: fake_manager,
+    )
+
+    logger = logger_module.Logger(log_dir=str(tmp_path / "main-logs"))
+    try:
+        assert logger._get_session_logger("terminal-session") is None
+        assert "sage_session_terminal-session" not in logging.Logger.manager.loggerDict
+    finally:
+        logger.cleanup_session_logger("terminal-session")
+        logger.stop_periodic_cleanup()
+        logger_module.Logger._close_handlers(logger.logger)
+        logger_module.Logger._initialized = False
+        logger_module.Logger._instance = None


### PR DESCRIPTION
## Summary

- release `MemoryIndex` after the last concurrent `search_memory` call while keeping its pickle/SQLite persistence intact
- prevent historical sessions, per-session loggers, history caches, shell tasks, and async task results from remaining in process-wide registries
- serialize LLM/MCP diagnostic writes and bound session, shell, stream-worker, and cross-thread shutdown waits
- add TTL/LRU eviction for the server skill cache and lifecycle shutdown hooks for async services

## Root cause

Several user- and session-scoped objects were retained by process-wide dictionaries or background tasks after a request completed. Session shutdown also awaited diagnostic writers and stream workers without a deadline, so an interrupted request could reserve its session ID indefinitely when an I/O adapter or coroutine stalled.

## Behavior and impact

- file-memory indexes are still isolated by user, agent, and workspace, but are reloaded from disk for later searches instead of remaining resident
- concurrent searches for the same scope share one in-flight index and release it only after the final user exits
- historical session reads no longer repopulate the live-session registry
- session shutdown detaches shell state, drains normal log writes, and releases core registries even when a cleanup dependency ignores cancellation
- diagnostic log writes are best-effort during the bounded shutdown window; normal writes remain complete, while a genuinely stalled tail can be dropped to avoid an infinite close
- Prometheus `session_id` metric retention is intentionally unchanged

## Validation

- `python -m pytest -q tests/sagents --ignore=tests/sagents/utils/file_parser/parsers/test_excel_parser.py`
  - 937 passed, 3 skipped, 40 subtests passed
- `python -m pytest -q tests/common/services tests/common/utils --ignore=tests/common/services/test_agent_service_workspace_listing.py`
  - 119 passed, 3 skipped
- targeted lifecycle, log-writer, and stream cancellation tests
  - 15 passed
- Ruff checks passed for the changed lifecycle/logging modules and tests
- `git diff --check` passed

The excluded test files require optional Excel and `argon2` dependencies that are not installed in the local validation environment.
