### PR TITLE
refactor(storage): introduce pluggable session storage abstraction

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -7,6 +7,20 @@ on:
     tags:
       - 'desktop-v*'
   workflow_dispatch:
+    inputs:
+      build_target:
+        description: Desktop target to build
+        required: true
+        default: macos-arm64
+        type: choice
+        options:
+          - macos-arm64
+          - all
+      version:
+        description: Artifact version used for manual builds
+        required: true
+        default: dev
+        type: string
 
 
 jobs:
@@ -16,27 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - runner: macos-latest
-            platform: macos
-            arch: aarch64
-            target: aarch64-apple-darwin
-          - runner: macos-15-intel
-            platform: macos
-            arch: x86_64
-            target: x86_64-apple-darwin
-          - runner: ubuntu-22.04
-            platform: linux
-            arch: x86_64
-            target: x86_64-unknown-linux-gnu
-          - runner: ubuntu-22.04-arm
-            platform: linux
-            arch: aarch64
-            target: aarch64-unknown-linux-gnu
-          - runner: windows-latest
-            platform: windows
-            arch: x86_64
-            target: x86_64-pc-windows-msvc
+        include: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.build_target == 'macos-arm64' && '[{"runner":"macos-latest","platform":"macos","arch":"aarch64","target":"aarch64-apple-darwin"}]' || '[{"runner":"macos-latest","platform":"macos","arch":"aarch64","target":"aarch64-apple-darwin"},{"runner":"macos-15-intel","platform":"macos","arch":"x86_64","target":"x86_64-apple-darwin"},{"runner":"ubuntu-22.04","platform":"linux","arch":"x86_64","target":"x86_64-unknown-linux-gnu"},{"runner":"ubuntu-22.04-arm","platform":"linux","arch":"aarch64","target":"aarch64-unknown-linux-gnu"},{"runner":"windows-latest","platform":"windows","arch":"x86_64","target":"x86_64-pc-windows-msvc"}]') }}
 
     steps:
       - uses: actions/checkout@v4
@@ -165,8 +159,14 @@ jobs:
 
       - name: Rename Artifacts (macOS)
         if: matrix.platform == 'macos'
+        env:
+          MANUAL_VERSION: ${{ inputs.version }}
         run: |
-          VERSION="${GITHUB_REF#refs/tags/desktop-v}"
+          if [[ "$GITHUB_REF" == refs/tags/desktop-v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/desktop-v}"
+          else
+            VERSION="$MANUAL_VERSION"
+          fi
           
           # Rename DMG
           cd app/desktop/tauri/target/release/bundle/dmg/
@@ -182,6 +182,14 @@ jobs:
           for file in *.tar.gz.sig; do
             mv "$file" "Sage-${VERSION}-${{ matrix.arch }}.app.tar.gz.sig"
           done
+
+      - name: Upload Manual Build (macOS)
+        if: github.event_name == 'workflow_dispatch' && matrix.platform == 'macos'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Sage-${{ inputs.version }}-macos-${{ matrix.arch }}
+          path: app/desktop/tauri/target/release/bundle/dmg/*.dmg
+          if-no-files-found: error
 
       - name: Rename Artifacts (Windows)
         if: matrix.platform == 'windows'
@@ -203,7 +211,7 @@ jobs:
           }
 
       - name: Release (macOS)
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/') && matrix.platform == 'macos'
         with:
           files: |
@@ -212,7 +220,7 @@ jobs:
             app/desktop/tauri/target/release/bundle/macos/*.app.tar.gz.sig
 
       - name: Release (Windows)
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/') && matrix.platform == 'windows'
         with:
           files: |
@@ -243,7 +251,7 @@ jobs:
           done
 
       - name: Release (Linux)
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/') && matrix.platform == 'linux'
         with:
           files: |

--- a/app/cli/runtime/stream.py
+++ b/app/cli/runtime/stream.py
@@ -5,7 +5,6 @@ import sys
 import time
 from contextlib import suppress
 from datetime import datetime
-from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
 from app.cli.runtime.contracts import (
@@ -107,36 +106,21 @@ def _install_stdin_control_reader(request) -> Optional[Callable[[], None]]:
     return _cleanup
 
 
-def _resolve_session_log_path(session_id: Optional[str]) -> Optional[Path]:
-    if not session_id:
-        return None
-    session_dir = (
-        os.environ.get("SAGE_SESSION_DIR")
-        or os.environ.get("SAGE_SESSION_DIR_PATH")
-        or None
-    )
-    if not session_dir:
-        from common.core.config import get_local_storage_defaults
-
-        session_dir = get_local_storage_defaults()["session_dir"]
-    return Path(session_dir) / session_id / f"session_{session_id}.log"
-
-
 def _extract_recent_session_issue_notice(
     session_id: Optional[str],
     *,
     request_started_at_epoch: float,
 ) -> Optional[str]:
-    log_path = _resolve_session_log_path(session_id)
-    if not log_path or not log_path.is_file():
+    if not session_id:
         return None
 
     try:
-        with log_path.open("rb") as handle:
-            handle.seek(0, 2)
-            size = handle.tell()
-            handle.seek(max(0, size - SESSION_LOG_SCAN_BYTES))
-            tail = handle.read().decode("utf-8", errors="ignore")
+        from sagents.session_runtime import get_global_session_manager
+
+        manager = get_global_session_manager()
+        tail = manager.storage.read_session_log_tail(
+            session_id, max_bytes=SESSION_LOG_SCAN_BYTES
+        )
     except Exception:  # noqa: BLE001
         return None
 

--- a/app/cli/service.py
+++ b/app/cli/service.py
@@ -163,7 +163,11 @@ def collect_doctor_info() -> Dict[str, Any]:
     env_files = [shared_env_file]
     if os.path.exists(project_env_file):
         env_files.append(project_env_file)
-    session_registry_db = os.path.join(cfg.session_dir, "sessions_index.sqlite")
+    from sagents.storage import create_session_store
+
+    session_storage = dict(
+        create_session_store(session_root=cfg.session_dir, initialize=False).healthcheck()
+    )
     dep_status = _dependency_status()
     issues = _collect_runtime_issues(cfg)
     memory_diagnostics = _collect_memory_runtime_diagnostics()
@@ -198,8 +202,7 @@ def collect_doctor_info() -> Dict[str, Any]:
         "agents_dir_exists": os.path.exists(cfg.agents_dir),
         "session_dir": cfg.session_dir,
         "session_dir_exists": os.path.exists(cfg.session_dir),
-        "session_registry_db": session_registry_db,
-        "session_registry_db_exists": os.path.exists(session_registry_db),
+        "session_storage": session_storage,
         "logs_dir": cfg.logs_dir,
         "logs_dir_exists": os.path.exists(cfg.logs_dir),
         "dependencies": dep_status,
@@ -218,7 +221,11 @@ def collect_config_info() -> Dict[str, Any]:
     env_files = [shared_env_file]
     if os.path.exists(project_env_file):
         env_files.append(project_env_file)
-    session_registry_db = os.path.join(cfg.session_dir, "sessions_index.sqlite")
+    from sagents.storage import create_session_store
+
+    session_storage = dict(
+        create_session_store(session_root=cfg.session_dir, initialize=False).healthcheck()
+    )
     memory_diagnostics = _collect_memory_runtime_diagnostics()
     return {
         "env_file": effective_env_file,
@@ -235,7 +242,7 @@ def collect_config_info() -> Dict[str, Any]:
         "memory_strategies": memory_diagnostics["memory_strategies"],
         "agents_dir": cfg.agents_dir,
         "session_dir": cfg.session_dir,
-        "session_registry_db": session_registry_db,
+        "session_storage": session_storage,
         "logs_dir": cfg.logs_dir,
         "env_sources": {
             "SAGE_HOME": local_defaults["sage_home"],

--- a/app/cli/services/doctor.py
+++ b/app/cli/services/doctor.py
@@ -106,7 +106,11 @@ def collect_doctor_info() -> Dict[str, Any]:
     env_files = [shared_env_file]
     if os.path.exists(project_env_file):
         env_files.append(project_env_file)
-    session_registry_db = os.path.join(cfg.session_dir, "sessions_index.sqlite")
+    from sagents.storage import create_session_store
+
+    session_storage = dict(
+        create_session_store(session_root=cfg.session_dir, initialize=False).healthcheck()
+    )
     dep_status = dependency_status()
     issues = collect_runtime_issues(cfg)
     memory_diagnostics = _collect_memory_runtime_diagnostics()
@@ -141,8 +145,7 @@ def collect_doctor_info() -> Dict[str, Any]:
         "agents_dir_exists": os.path.exists(cfg.agents_dir),
         "session_dir": cfg.session_dir,
         "session_dir_exists": os.path.exists(cfg.session_dir),
-        "session_registry_db": session_registry_db,
-        "session_registry_db_exists": os.path.exists(session_registry_db),
+        "session_storage": session_storage,
         "logs_dir": cfg.logs_dir,
         "logs_dir_exists": os.path.exists(cfg.logs_dir),
         "dependencies": dep_status,
@@ -199,7 +202,11 @@ def collect_config_info() -> Dict[str, Any]:
     env_files = [shared_env_file]
     if os.path.exists(project_env_file):
         env_files.append(project_env_file)
-    session_registry_db = os.path.join(cfg.session_dir, "sessions_index.sqlite")
+    from sagents.storage import create_session_store
+
+    session_storage = dict(
+        create_session_store(session_root=cfg.session_dir, initialize=False).healthcheck()
+    )
     memory_diagnostics = _collect_memory_runtime_diagnostics()
     return {
         "env_file": effective_env_file,
@@ -216,7 +223,7 @@ def collect_config_info() -> Dict[str, Any]:
         "memory_strategies": memory_diagnostics["memory_strategies"],
         "agents_dir": cfg.agents_dir,
         "session_dir": cfg.session_dir,
-        "session_registry_db": session_registry_db,
+        "session_storage": session_storage,
         "logs_dir": cfg.logs_dir,
         "env_sources": {
             "SAGE_HOME": local_defaults["sage_home"],

--- a/app/desktop/sage-desktop.spec
+++ b/app/desktop/sage-desktop.spec
@@ -14,8 +14,9 @@ instead of passing CLI flags. Behaviour is parameterised via env vars:
 
 import os
 import sys
+from importlib.metadata import PackageNotFoundError
 
-from PyInstaller.utils.hooks import collect_all, collect_submodules
+from PyInstaller.utils.hooks import collect_all, collect_submodules, copy_metadata
 
 
 # --- mode ---
@@ -33,6 +34,19 @@ else:
 # --- collect deps that PyInstaller cannot trace statically ---
 datas = []
 binaries = []
+
+# FastMCP resolves its version during import via `importlib.metadata`. The
+# importable module is provided by `fastmcp-slim`, while the `fastmcp`
+# distribution may also be installed as a compatibility/meta package. Module
+# discovery alone does not include either `.dist-info` directory, so a frozen
+# sidecar crashes before startup unless their package metadata is copied.
+for _distribution in ("fastmcp-slim", "fastmcp"):
+    try:
+        datas += copy_metadata(_distribution)
+    except PackageNotFoundError:
+        # Support environments that install only one of the two distributions;
+        # FastMCP itself uses the same fallback order at runtime.
+        pass
 
 # `sagents.tool.impl.__init__` uses lazy `__getattr__` for tool modules,
 # so the static tracer never reaches the @tool decorators. Collect the

--- a/common/services/conversation_service.py
+++ b/common/services/conversation_service.py
@@ -4,8 +4,6 @@ Conversation shared service-layer entry points for server and desktop routers.
 
 import asyncio
 import hashlib
-import json
-import os
 from collections import Counter
 from datetime import timedelta
 from pathlib import Path
@@ -78,6 +76,25 @@ def _build_session_trace_url(session_id: str) -> Optional[str]:
         return f"{base}/trace/{trace_id}"
 
     return f"/jaeger/trace/{trace_id}"
+
+
+def _validate_session_id_for_storage(session_id: str) -> str:
+    value = str(session_id or "")
+    if (
+        not value
+        or value != value.strip()
+        or value in {".", ".."}
+        or Path(value).name != value
+        or "/" in value
+        or "\\" in value
+        or "\x00" in value
+    ):
+        raise SageHTTPException(
+            status_code=400,
+            message_key="conversation.session_id_invalid",
+            error_detail="Invalid session_id",
+        )
+    return value
 
 
 def inject_user_message(
@@ -547,6 +564,8 @@ async def prepare_session_folder_download(
             message_key="conversation.download_admin_required",
             error_detail="admin_required",
         )
+
+    session_id = _validate_session_id_for_storage(session_id)
 
     dao = ConversationDao()
     conversation = await dao.get_by_session_id(session_id)

--- a/common/services/conversation_service.py
+++ b/common/services/conversation_service.py
@@ -6,8 +6,6 @@ import asyncio
 import hashlib
 import json
 import os
-import tempfile
-import zipfile
 from collections import Counter
 from datetime import timedelta
 from pathlib import Path
@@ -538,66 +536,6 @@ async def delete_conversation(
     return conversation_id
 
 
-def _resolve_session_directory(session_id: str) -> Path:
-    safe_session_id = str(session_id or "").strip()
-    if not safe_session_id or Path(safe_session_id).name != safe_session_id:
-        raise SageHTTPException(
-            status_code=400,
-            message_key="conversation.session_id_invalid",
-            error_detail="Invalid session_id",
-        )
-
-    sessions_root = Path(get_sessions_root()).resolve()
-    session_dir = (sessions_root / safe_session_id).resolve()
-    try:
-        session_dir.relative_to(sessions_root)
-    except ValueError:
-        raise SageHTTPException(
-            status_code=400,
-            message_key="conversation.session_id_invalid",
-            error_detail="Session path escapes sessions root",
-        )
-
-    if not session_dir.is_dir():
-        raise SageHTTPException(
-            status_code=404,
-            message_key="conversation.folder_not_found",
-            message_params={"session_id": safe_session_id},
-            error_detail=f"Session directory '{safe_session_id}' not found",
-        )
-    return session_dir
-
-
-def _build_session_archive_sync(session_dir: Path, session_id: str) -> str:
-    tmp_file = tempfile.NamedTemporaryFile(
-        prefix=f"sage-session-{session_id}-",
-        suffix=".zip",
-        delete=False,
-    )
-    tmp_file.close()
-    zip_path = tmp_file.name
-
-    try:
-        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
-            for root, dirs, files in os.walk(session_dir, followlinks=False):
-                root_path = Path(root)
-                dirs[:] = [name for name in dirs if not (root_path / name).is_symlink()]
-                for file_name in files:
-                    file_path = root_path / file_name
-                    if file_path.is_symlink() or not file_path.is_file():
-                        continue
-                    arcname = Path(session_id) / file_path.relative_to(session_dir)
-                    zipf.write(file_path, arcname.as_posix())
-    except Exception:
-        try:
-            os.unlink(zip_path)
-        except OSError:
-            pass
-        raise
-
-    return zip_path
-
-
 async def prepare_session_folder_download(
     session_id: str,
     *,
@@ -620,10 +558,18 @@ async def prepare_session_folder_download(
             error_detail=f"Conversation '{session_id}' not found",
         )
 
-    session_dir = _resolve_session_directory(session_id)
-    archive_path = await asyncio.to_thread(
-        _build_session_archive_sync, session_dir, session_id
-    )
+    manager = get_global_session_manager()
+    try:
+        archive_path = await asyncio.to_thread(
+            manager.storage.export_session_archive, session_id
+        )
+    except FileNotFoundError:
+        raise SageHTTPException(
+            status_code=404,
+            message_key="conversation.folder_not_found",
+            message_params={"session_id": session_id},
+            error_detail=f"Session '{session_id}' not found in storage",
+        )
     return archive_path, f"{session_id}.zip", "application/zip"
 
 
@@ -740,61 +686,29 @@ def _truncate_messages_after_last_user(
     return truncated_messages, last_user_message
 
 
-def _session_workspace_file_paths(
-    session_id: str,
-) -> Tuple[Optional[Path], Path, Path, Path]:
-    sessions_root = Path(get_sessions_root())
-    manager = get_global_session_manager()
-    workspace_path: Optional[Path] = None
-    if manager:
-        found = manager.get_session_workspace(session_id)
-        if found:
-            workspace_path = Path(found)
-    if workspace_path is None:
-        workspace_path = sessions_root / session_id
-
-    messages_path = workspace_path / "messages.json"
-    context_path = workspace_path / "session_context.json"
-    tools_usage_path = workspace_path / "tools_usage.json"
-    return workspace_path, messages_path, context_path, tools_usage_path
-
-
 def _write_session_files(session_id: str, messages: List[Dict[str, Any]]) -> None:
-    workspace_path, messages_path, context_path, tools_usage_path = (
-        _session_workspace_file_paths(session_id)
-    )
-    if not workspace_path:
-        return
-
-    workspace_path.mkdir(parents=True, exist_ok=True)
-
-    with open(messages_path, "w", encoding="utf-8") as f:
-        json.dump(messages, f, ensure_ascii=False, indent=4)
-
-    if context_path.exists():
-        try:
-            with open(context_path, "r", encoding="utf-8") as f:
-                context_data = json.load(f)
-        except Exception as exc:
-            logger.bind(session_id=session_id).warning(
-                f"读取 session_context.json 失败，跳过状态重置: {exc}"
-            )
-            context_data = None
-
-        if isinstance(context_data, dict):
-            context_data["status"] = "idle"
-            context_data["updated_at"] = get_local_now().timestamp()
-            context_data["child_session_ids"] = []
-            context_data["audit_status"] = {}
-            context_data["tokens_usage_info"] = {"total_info": {}, "per_step_info": []}
-            context_data["prompt_token_checkpoints"] = {}
-            system_context = context_data.get("system_context")
-            if isinstance(system_context, dict):
-                system_context.pop("current_time", None)
-                system_context.pop("available_sub_agents", None)
-                system_context.pop("custom_sub_agents", None)
-            with open(context_path, "w", encoding="utf-8") as f:
-                json.dump(context_data, f, ensure_ascii=False, indent=4)
+    manager = get_global_session_manager()
+    storage = getattr(manager, "storage", None) if manager else None
+    if storage is None:
+        raise RuntimeError("session storage is not initialized")
+    storage.save_message_snapshot(session_id, messages)
+    context_data = storage.load_session_snapshot(session_id)
+    if isinstance(context_data, dict):
+        context_data["status"] = "idle"
+        context_data["updated_at"] = get_local_now().timestamp()
+        context_data["child_session_ids"] = []
+        context_data["audit_status"] = {}
+        context_data["tokens_usage_info"] = {
+            "total_info": {},
+            "per_step_info": [],
+        }
+        context_data["prompt_token_checkpoints"] = {}
+        system_context = context_data.get("system_context")
+        if isinstance(system_context, dict):
+            system_context.pop("current_time", None)
+            system_context.pop("available_sub_agents", None)
+            system_context.pop("custom_sub_agents", None)
+        storage.save_session_snapshot(session_id, context_data)
 
     tools_usage: Dict[str, int] = {}
     for message in messages:
@@ -803,8 +717,7 @@ def _write_session_files(session_id: str, messages: List[Dict[str, Any]]) -> Non
             if tool_name:
                 tools_usage[tool_name] = tools_usage.get(tool_name, 0) + 1
 
-    with open(tools_usage_path, "w", encoding="utf-8") as f:
-        json.dump(tools_usage, f, ensure_ascii=False, indent=4)
+    storage.save_tools_usage(session_id, tools_usage)
 
 
 async def edit_last_user_message(
@@ -946,7 +859,7 @@ async def get_rerun_conversation_payload(
 
 def _load_tools_usage_counts_sync(
     conversations: List[Conversation],
-    sessions_root: Path,
+    storage=None,
 ) -> Dict[str, int]:
     usage_counter: Counter[str] = Counter()
 
@@ -955,13 +868,10 @@ def _load_tools_usage_counts_sync(
         if not session_id:
             continue
 
-        tools_usage_path = sessions_root / session_id / "tools_usage.json"
-        if not tools_usage_path.is_file():
-            continue
-
         try:
-            with tools_usage_path.open("r", encoding="utf-8") as f:
-                tools_usage = json.load(f)
+            if storage is None:
+                raise RuntimeError("session storage is not initialized")
+            tools_usage = storage.load_tools_usage(session_id)
             if not isinstance(tools_usage, dict):
                 continue
             for tool_name, count in tools_usage.items():
@@ -989,7 +899,8 @@ async def get_agent_usage_stats(
         agent_id=agent_id,
     )
 
-    sessions_root = Path(get_sessions_root())
+    manager = get_global_session_manager()
+    storage = getattr(manager, "storage", None) if manager else None
     return await asyncio.to_thread(
-        _load_tools_usage_counts_sync, conversations, sessions_root
+        _load_tools_usage_counts_sync, conversations, storage
     )

--- a/common/services/session_log_cleanup.py
+++ b/common/services/session_log_cleanup.py
@@ -1,28 +1,13 @@
 from __future__ import annotations
 
-import os
-import shutil
 import time
 from pathlib import Path
 from typing import Dict
 
 from loguru import logger
+from sagents.storage import create_session_store
 
-
-LLM_REQUEST_DIR_NAME = "llm_request"
 PROACTIVE_EVAL_SESSION_PREFIX = "proactive_eval_"
-
-
-def _latest_tree_mtime(path: Path) -> float:
-    latest = path.stat().st_mtime
-    for child in path.rglob("*"):
-        if child.is_symlink():
-            continue
-        try:
-            latest = max(latest, child.stat().st_mtime)
-        except OSError:
-            continue
-    return latest
 
 
 def cleanup_old_llm_request_logs(
@@ -43,57 +28,17 @@ def cleanup_old_llm_request_logs(
         "errors": 0,
     }
 
-    if not root.exists():
-        logger.info(f"LLM request cleanup skipped, sessions root not found: {root}")
-        return stats
-
-    for session_dir in root.iterdir():
-        if (
-            session_dir.is_symlink()
-            or not session_dir.is_dir()
-            or not session_dir.name.startswith(PROACTIVE_EVAL_SESSION_PREFIX)
-        ):
-            continue
-        stats["scanned_proactive_eval_dirs"] += 1
-        try:
-            if _latest_tree_mtime(session_dir) >= proactive_eval_cutoff:
-                continue
-            shutil.rmtree(session_dir)
-            stats["deleted_session_dirs"] += 1
-        except Exception as exc:
-            stats["errors"] += 1
-            logger.warning(
-                f"Failed to delete old proactive eval session {session_dir}: {exc}"
-            )
-
-    for request_dir in root.glob(f"**/{LLM_REQUEST_DIR_NAME}"):
-        if not request_dir.is_dir():
-            continue
-        stats["scanned_dirs"] += 1
-        try:
-            for path in request_dir.iterdir():
-                if path.is_dir():
-                    continue
-                try:
-                    if path.stat().st_mtime >= cutoff:
-                        continue
-                    path.unlink()
-                    stats["deleted_files"] += 1
-                except Exception as exc:
-                    stats["errors"] += 1
-                    logger.warning(
-                        f"Failed to delete old LLM request log {path}: {exc}"
-                    )
-
-            try:
-                if not any(request_dir.iterdir()):
-                    os.rmdir(request_dir)
-                    stats["deleted_empty_dirs"] += 1
-            except OSError:
-                pass
-        except Exception as exc:
-            stats["errors"] += 1
-            logger.warning(f"Failed to scan LLM request log dir {request_dir}: {exc}")
+    store = create_session_store(session_root=str(root), initialize=False)
+    proactive_stats = store.purge_sessions(
+        before=proactive_eval_cutoff,
+        session_id_prefix=PROACTIVE_EVAL_SESSION_PREFIX,
+    )
+    stats["scanned_proactive_eval_dirs"] = proactive_stats["scanned_dirs"]
+    stats["deleted_session_dirs"] = proactive_stats["deleted_session_dirs"]
+    request_stats = store.purge_llm_requests(before=cutoff)
+    for key in ("scanned_dirs", "deleted_files", "deleted_empty_dirs"):
+        stats[key] = request_stats[key]
+    stats["errors"] = proactive_stats["errors"] + request_stats["errors"]
 
     logger.info(
         "LLM request cleanup finished: "

--- a/docs/zh/architecture/SESSION_STORAGE.md
+++ b/docs/zh/architecture/SESSION_STORAGE.md
@@ -1,0 +1,69 @@
+# Session Storage 抽象
+
+`SessionStore` 是 Agent 会话持久化的统一边界。运行时、会话恢复、消息编辑、
+统计和日志清理不应自行拼接 `session_root` 下的文件名。
+
+对外只公开存储接口、配置模型和 `create_session_store()` 工厂。具体后端类及其
+构造参数属于 storage 包内部实现，业务调用方不应导入。
+
+## 数据语义
+
+- Catalog：Session 定位、存在性和父子关系。
+- Authoritative state：Session snapshot、message snapshot 和 message event。
+- Derived state：compact manifest 和 tools usage。
+- Telemetry：Session log、LLM request、request token usage 和 MCP calls。CLI 只能
+  通过 Store 读取近期 Session log、查询后端健康状态，不得解析日志或 catalog 路径。
+
+Message snapshot 与 event journal 共同构成消息账本。后端必须先持久化 snapshot，
+成功后才能清理已纳入 snapshot 的 event。Filesystem 实现沿用既有的进程内锁，
+保持原有并发行为。
+
+## Filesystem 兼容契约
+
+FilesystemStore 保持已有目录结构、JSON 字段、缩进、文件命名和写入行为：
+
+```text
+<session_root>/sessions_index.sqlite
+<session_root>/<session_id>/messages.json
+<session_root>/<session_id>/messages.journal.jsonl
+<session_root>/<session_id>/session_context.json
+<session_root>/<session_id>/compact_manifest.json
+<session_root>/<session_id>/tools_usage.json
+<session_root>/<session_id>/llm_request/*.json
+<session_root>/<session_id>/tokens_usage/<request_id>.json
+<session_root>/<session_id>/mcp_calls/<request_id>.json
+<session_root>/<session_id>/session_<session_id>.log
+```
+
+子 Session 仍保存在父 Session 的 `sub_sessions/<child_id>` 下。Catalog 中仍存相对
+路径，因此整个 `session_root` 可以移动。
+
+## 注入后端
+
+后端可以注入 `SessionManager`、全局初始化函数或 `SAgent`：
+
+```python
+storage_config = SessionStorageConfig(
+    backend="filesystem",
+    options={"root": "/var/lib/sage/sessions"},
+)
+agent = SAgent(
+    session_root_space="/var/lib/sage/sessions",
+    storage_config=storage_config,
+)
+```
+
+不显式传配置时，工厂读取：
+
+- `SAGE_SESSION_STORAGE_BACKEND`：默认 `filesystem`。
+- `SAGE_SESSION_STORAGE_OPTIONS`：JSON object；filesystem 可配置 `root`。
+
+如果 options 没有指定 `root`，工厂沿用现有的 `session_root_space`，所以旧调用方
+无需修改。
+
+新增后端应实现完整的 `SessionStore`，保证方法幂等性、同一 Session 内的写入顺序，
+并为阻塞 I/O 提供线程安全实现。当前接口为同步接口；原本异步落盘的 LLM/MCP
+调用仍通过工作线程执行，避免改变既有调用和错误处理语义。
+
+`workspace` 相关方法是兼容现有 Session 元数据和运行时工作区的定位能力。非文件
+后端可以返回稳定的逻辑 locator，但业务代码不得自行在 locator 后拼接文件名。

--- a/sagents/agent/fibre/delegate_stream.py
+++ b/sagents/agent/fibre/delegate_stream.py
@@ -18,8 +18,6 @@ There is no wall-clock timeout while the child is still running.
 from __future__ import annotations
 
 import asyncio
-import json
-import os
 import uuid
 from dataclasses import dataclass
 from typing import (
@@ -35,7 +33,7 @@ from typing import (
 
 from sagents.context.messages.message import MessageChunk
 from sagents.context.messages.message_manager import MessageManager
-from sagents.context.session_context import SessionContext, SessionStatus
+from sagents.context.session_context import SessionStatus
 from sagents.utils.logger import logger
 
 StreamPayload = Union[MessageChunk, Dict[str, Any]]
@@ -122,7 +120,7 @@ def resolve_child_workspace(
     session_id: str,
     parent_session_id: Optional[str] = None,
 ) -> Optional[str]:
-    """Locate the child session workspace on disk or via the session registry."""
+    """Return the backend locator registered for a child session."""
 
     if not session_id:
         return None
@@ -131,35 +129,7 @@ def resolve_child_workspace(
         from sagents.session_runtime import get_global_session_manager
 
         manager = get_global_session_manager()
-        workspace = manager.get_session_workspace(session_id)
-        if workspace and os.path.isdir(workspace):
-            return workspace
-
-        live = manager.get_live_session(session_id)
-        if live is not None:
-            live_ws = getattr(live, "session_workspace", None)
-            if live_ws and os.path.isdir(live_ws):
-                return str(live_ws)
-            ctx = getattr(live, "session_context", None)
-            ctx_ws = getattr(ctx, "session_workspace", None) if ctx else None
-            if ctx_ws and os.path.isdir(ctx_ws):
-                return str(ctx_ws)
-
-        if parent_session_id:
-            parent_ws = manager.get_session_workspace(parent_session_id)
-            if parent_ws:
-                candidate = os.path.join(parent_ws, "sub_sessions", session_id)
-                if os.path.isdir(candidate):
-                    return candidate
-                # Nested sub-sessions: walk one level of sub_sessions trees.
-                nested_root = os.path.join(parent_ws, "sub_sessions")
-                if os.path.isdir(nested_root):
-                    for entry in os.scandir(nested_root):
-                        if not entry.is_dir():
-                            continue
-                        nested = os.path.join(entry.path, "sub_sessions", session_id)
-                        if os.path.isdir(nested):
-                            return nested
+        return manager.get_session_workspace(session_id)
     except Exception as exc:
         logger.debug(
             f"resolve_child_workspace: registry lookup failed for {session_id}: {exc}"
@@ -201,15 +171,9 @@ def read_child_session_observation(
             f"read_child_session_status: live lookup failed for {session_id}: {exc}"
         )
 
-    workspace = resolve_child_workspace(session_id, parent_session_id)
-    if not workspace:
-        return ChildSessionObservation(status=live_status, request_id=request_id)
-    context_path = os.path.join(workspace, "session_context.json")
-    if not os.path.exists(context_path):
-        return ChildSessionObservation(status=live_status, request_id=request_id)
     try:
-        with open(context_path, "r", encoding="utf-8") as handle:
-            snapshot = json.load(handle)
+        manager = get_global_session_manager()
+        snapshot = manager.storage.load_session_snapshot(session_id)
         if isinstance(snapshot, dict):
             persisted_status = snapshot.get("status")
             updated_at = snapshot.get("updated_at")
@@ -247,13 +211,12 @@ def load_child_history_fallback(
 ) -> str:
     """Build history beginning at this round's marked input message."""
 
-    workspace = resolve_child_workspace(session_id, parent_session_id)
-    if not workspace:
-        return ""
     try:
-        messages, _, _ = SessionContext.load_persisted_message_ledger(
-            workspace, session_id=session_id
-        )
+        from sagents.session_runtime import get_global_session_manager
+
+        manager = get_global_session_manager()
+        ledger = manager.storage.load_message_ledger(session_id)
+        messages = [MessageChunk.from_dict(item) for item in ledger.messages]
     except Exception as exc:
         logger.warning(
             f"load_child_history_fallback: failed to load ledger for {session_id}: {exc}"

--- a/sagents/context/session_context.py
+++ b/sagents/context/session_context.py
@@ -17,6 +17,7 @@ from sagents.utils.prompt_manager import prompt_manager
 from sagents.context.workflows import WorkflowManager
 
 from sagents.utils.logger import logger
+from sagents.storage import SessionStore, create_session_store
 from sagents.utils.lock_manager import lock_manager, UnifiedLock
 from sagents.utils.serialization import make_serializable
 import json
@@ -65,6 +66,7 @@ class SessionContext:
         tool_manager: Optional[Any] = None,
         skill_manager: Optional[Union[SkillManager, SkillProxy]] = None,
         parent_session_id: Optional[str] = None,
+        storage: Optional[SessionStore] = None,
     ):
         # 基础身份与外部依赖
         self.session_id = session_id
@@ -91,6 +93,9 @@ class SessionContext:
         self.skill_manager = skill_manager
         self.sandbox_skill_manager: Optional[SandboxSkillManager] = None
         self.parent_session_id = parent_session_id
+        self.storage = storage or create_session_store(
+            session_root=session_root_space
+        )
         self._init_runtime_state(context_budget_config=context_budget_config)
         # 注意：init_more 不再在 __init__ 中自动调用，需要调用方显式调用
         self._session_root_space = session_root_space
@@ -436,15 +441,10 @@ class SessionContext:
             "flow_node_timings": flow_node_timings,
         }
 
-    @staticmethod
-    def _message_journal_path_for_workspace(session_workspace: str) -> str:
-        return os.path.join(session_workspace, MESSAGE_JOURNAL_FILE)
-
-    def _message_journal_path(self) -> str:
-        session_workspace = getattr(self, "session_workspace", None)
-        if not session_workspace:
-            return ""
-        return self._message_journal_path_for_workspace(session_workspace)
+    def _bind_storage_workspace(self) -> None:
+        workspace = getattr(self, "session_workspace", None)
+        if workspace:
+            self.storage.bind_session_workspace(self.session_id, workspace)
 
     @staticmethod
     def _upsert_persisted_message(
@@ -464,86 +464,39 @@ class SessionContext:
     def load_persisted_message_ledger(
         session_workspace: str,
         session_id: Optional[str] = None,
+        storage: Optional[SessionStore] = None,
     ) -> tuple[List[MessageChunk], int, int]:
-        messages: List[MessageChunk] = []
-        max_journal_seq = 0
-        journal_records = 0
-
-        messages_path = os.path.join(session_workspace, "messages.json")
+        effective_session_id = session_id or os.path.basename(session_workspace)
+        effective_storage = storage
+        if effective_storage is None:
+            effective_storage = create_session_store(
+                session_root=os.path.dirname(session_workspace),
+                initialize=False,
+            )
+            effective_storage.bind_session_workspace(
+                effective_session_id, session_workspace
+            )
         try:
-            if os.path.exists(messages_path):
-                with open(messages_path, "r", encoding="utf-8") as f:
-                    messages_data = json.load(f)
-                if isinstance(messages_data, list):
-                    messages = [
-                        MessageChunk.from_dict(msg)
-                        for msg in messages_data
-                        if isinstance(msg, dict)
-                    ]
+            ledger = effective_storage.load_message_ledger(effective_session_id)
+            messages = []
+            for message_data in ledger.messages:
+                try:
+                    messages.append(MessageChunk.from_dict(message_data))
+                except Exception as exc:
+                    logger.warning(
+                        "SessionContext: skipped invalid persisted message "
+                        f"session_id={effective_session_id}: {exc}"
+                    )
+            return messages, ledger.max_sequence, ledger.journal_records
         except UnicodeDecodeError:
             logger.warning(
-                "SessionContext: messages.json decode failed, file may be in legacy encoding, will start with empty messages"
+                "SessionContext: message ledger decode failed, file may be "
+                "in legacy encoding, will start with empty messages"
             )
-            messages = []
-        except Exception as e:
-            logger.warning(f"SessionContext: Failed to load messages.json: {e}")
-            messages = []
-
-        journal_path = SessionContext._message_journal_path_for_workspace(
-            session_workspace
-        )
-        if not os.path.exists(journal_path):
-            return messages, max_journal_seq, journal_records
-
-        try:
-            with open(journal_path, "r", encoding="utf-8") as f:
-                for line_number, line in enumerate(f, start=1):
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        record = json.loads(line)
-                    except json.JSONDecodeError as exc:
-                        logger.warning(
-                            "SessionContext: skipped invalid message journal record "
-                            f"session_id={session_id} line={line_number}: {exc}"
-                        )
-                        continue
-                    if not isinstance(record, dict):
-                        continue
-                    if record.get("op") != "put_message":
-                        continue
-                    record_session_id = record.get("session_id")
-                    if (
-                        session_id
-                        and record_session_id
-                        and record_session_id != session_id
-                    ):
-                        continue
-                    seq = record.get("seq")
-                    if isinstance(seq, int):
-                        max_journal_seq = max(max_journal_seq, seq)
-                    message_data = record.get("message")
-                    if not isinstance(message_data, dict):
-                        continue
-                    try:
-                        message = MessageChunk.from_dict(message_data)
-                    except Exception as exc:
-                        logger.warning(
-                            "SessionContext: skipped invalid message journal message "
-                            f"session_id={session_id} line={line_number}: {exc}"
-                        )
-                        continue
-                    messages = SessionContext._upsert_persisted_message(
-                        messages, message
-                    )
-                    journal_records += 1
-        except Exception as e:
-            logger.warning(
-                f"SessionContext: Failed to replay {MESSAGE_JOURNAL_FILE}: {e}"
-            )
-
-        return messages, max_journal_seq, journal_records
+            return [], 0, 0
+        except Exception as exc:
+            logger.warning(f"SessionContext: Failed to load message ledger: {exc}")
+            return [], 0, 0
 
     def _get_message_by_id(self, message_id: Optional[str]) -> Optional[MessageChunk]:
         if not message_id:
@@ -563,7 +516,7 @@ class SessionContext:
         if not session_workspace:
             return False
         try:
-            os.makedirs(session_workspace, exist_ok=True)
+            self._bind_storage_workspace()
             with self._message_journal_lock:
                 message = self._get_message_by_id(message_id)
                 if message is None:
@@ -591,9 +544,7 @@ class SessionContext:
                     "reason": reason,
                     "message": message_data,
                 }
-                with open(self._message_journal_path(), "a", encoding="utf-8") as f:
-                    f.write(json.dumps(record, ensure_ascii=False) + "\n")
-                    f.flush()
+                self.storage.append_message_event(self.session_id, record)
                 if message.message_id:
                     self._message_journal_flushed_signatures[message.message_id] = (
                         message_signature
@@ -628,15 +579,10 @@ class SessionContext:
         )
 
     def _clear_message_journal_after_snapshot(self) -> None:
-        journal_path = self._message_journal_path()
-        if not journal_path:
-            return
-        if not os.path.exists(journal_path):
-            return
         try:
+            self._bind_storage_workspace()
             with self._message_journal_lock:
-                if os.path.exists(journal_path):
-                    open(journal_path, "w", encoding="utf-8").close()
+                self.storage.clear_message_events(self.session_id)
             logger.info(
                 f"SessionContext: cleared {MESSAGE_JOURNAL_FILE} "
                 f"session_id={self.session_id}"
@@ -649,8 +595,8 @@ class SessionContext:
 
     def _message_journal_has_records(self) -> bool:
         try:
-            journal_path = self._message_journal_path()
-            return bool(journal_path) and os.path.getsize(journal_path) > 0
+            self._bind_storage_workspace()
+            return self.storage.message_events_have_records(self.session_id)
         except OSError:
             return False
 
@@ -1370,12 +1316,12 @@ class SessionContext:
         Args:
             session_root_space: 会话根空间路径（宿主机）
         """
-        if not session_root_space or not os.path.exists(session_root_space):
+        if not session_root_space:
             raise ValueError(
                 f"SessionContext 初始化需要传入有效的 session_root_space: {session_root_space}"
             )
 
-        self.session_root_space = os.path.abspath(session_root_space)
+        self.session_root_space = str(session_root_space)
 
         # 确定 session_workspace（会话数据，始终在宿主机）
         parent_session_id = self.parent_session_id or self.system_context.get(
@@ -1389,10 +1335,9 @@ class SessionContext:
                 manager = get_global_session_manager()
                 parent_session = manager.get(parent_session_id)
                 if parent_session and parent_session.session_context:
-                    self.session_workspace = os.path.join(
-                        parent_session.session_context.session_workspace,
-                        "sub_sessions",
+                    self.session_workspace = self.storage.create_session_workspace(
                         self.session_id,
+                        parent_workspace=parent_session.session_context.session_workspace,
                     )
                 else:
                     raise ValueError(
@@ -1411,11 +1356,16 @@ class SessionContext:
                     f"Failed to resolve parent session workspace for {parent_session_id}: {e}"
                 )
         else:
-            self.session_workspace = os.path.join(
-                self.session_root_space, self.session_id
+            self.session_workspace = self.storage.create_session_workspace(
+                self.session_id
             )
 
-        os.makedirs(self.session_workspace, exist_ok=True)
+        self.storage.bind_session_workspace(self.session_id, self.session_workspace)
+        self.storage.register_session(
+            self.session_id,
+            self.session_workspace,
+            parent_session_id=parent_session_id,
+        )
 
     async def _prepare_workspace_bootstrap_files(self):
         """
@@ -1661,6 +1611,7 @@ class SessionContext:
         messages, max_journal_seq, journal_records = self.load_persisted_message_ledger(
             self.session_workspace,
             session_id=self.session_id,
+            storage=self.storage,
         )
         self.message_manager.messages = messages
         self.message_manager.stats["total_messages"] = len(messages)
@@ -1675,29 +1626,9 @@ class SessionContext:
             f"journal_records={journal_records}"
         )
 
-    def _prepare_llm_request_file_path(self, llm_request: Dict[str, Any]) -> str:
-        llm_request_folder = os.path.join(self.session_workspace, "llm_request")
-        os.makedirs(llm_request_folder, exist_ok=True)
-
-        existing_files = os.listdir(llm_request_folder)
-        max_index = -1
-        for file in existing_files:
-            if file.endswith(".json"):
-                try:
-                    index = int(file.split("_")[0])
-                    max_index = max(max_index, index)
-                except ValueError:
-                    continue
-
-        file_name = (
-            f"{max_index + 1}_{llm_request['request'].get('step_name', 'unknown')}_"
-            f"{time.strftime('%Y%m%d%H%M%S', time.localtime(llm_request['timestamp']))}.json"
-        )
-        return os.path.join(llm_request_folder, file_name)
-
     def _save_llm_request_sync(self, llm_request: Dict[str, Any]) -> str:
         with self._llm_request_save_lock:
-            file_path = self._prepare_llm_request_file_path(llm_request)
+            self._bind_storage_workspace()
             internal_request = llm_request["request"]
             provider_attempts = internal_request.get("_provider_request_attempts", [])
             actual_request = (
@@ -1738,16 +1669,13 @@ class SessionContext:
                 serializable_request["request_attempts"] = make_serializable(
                     provider_attempts
                 )
-            with open(file_path, "w", encoding="utf-8") as f:
-                json.dump(serializable_request, f, ensure_ascii=False, indent=4)
-            return file_path
+            return self.storage.append_llm_request(
+                self.session_id, serializable_request
+            )
 
     def _save_mcp_calls_sync(self, request_id: str) -> str:
         with self._mcp_calls_save_lock:
-            target_dir = os.path.join(self.session_workspace, "mcp_calls")
-            os.makedirs(target_dir, exist_ok=True)
-            file_path = os.path.join(target_dir, f"{request_id}.json")
-
+            self._bind_storage_workspace()
             with self._mcp_calls_lock:
                 calls = [
                     make_serializable(call)
@@ -1761,9 +1689,9 @@ class SessionContext:
                 "call_count": len(calls),
                 "calls": calls,
             }
-            with open(file_path, "w", encoding="utf-8") as f:
-                json.dump(payload, f, ensure_ascii=False, indent=2)
-            return file_path
+            return self.storage.save_mcp_calls(
+                self.session_id, request_id, payload
+            )
 
     def _has_mcp_calls_for_request(self, request_id: str) -> bool:
         with self._mcp_calls_lock:
@@ -2402,12 +2330,11 @@ class SessionContext:
         cur["duration_sec"] = max(0.0, cur["ended_at"] - cur["started_at"])
         cur["status"] = status
         try:
-            target_dir = os.path.join(self.session_workspace, "tokens_usage")
-            os.makedirs(target_dir, exist_ok=True)
-            file_path = os.path.join(target_dir, f"{cur['request_id']}.json")
+            self._bind_storage_workspace()
             payload = make_serializable(cur)
-            with open(file_path, "w", encoding="utf-8") as f:
-                json.dump(payload, f, ensure_ascii=False, indent=2)
+            file_path = self.storage.save_request_usage(
+                self.session_id, cur["request_id"], payload
+            )
             logger.info(
                 f"SessionContext: tokens_usage saved request_id={cur['request_id']} "
                 f"calls={len(cur['per_call'])} total_tokens={cur['total_usage'].get('total_tokens')}"
@@ -2672,12 +2599,11 @@ class SessionContext:
                 self._last_save_signature = signature
                 self._last_save_time = now
                 return
+            self.storage.bind_session_workspace(self.session_id, session_workspace)
 
             # 1. 保存 messages 到 messages.json
             # 始终覆盖，保存完整历史
             messages_saved = False
-            messages_path = os.path.join(session_workspace, "messages.json")
-            messages_tmp_path = f"{messages_path}.tmp"
             with self._message_journal_lock:
                 self.flush_message_journal_current(reason="before_session_save")
                 logger.info(
@@ -2689,17 +2615,12 @@ class SessionContext:
                     f"last_messages={self._debug_last_message_snapshots()}"
                 )
                 try:
-                    with open(messages_tmp_path, "w", encoding="utf-8") as f:
-                        serializable_messages = make_serializable(
-                            self.message_manager.messages
-                        )
-                        json.dump(
-                            serializable_messages,
-                            f,
-                            ensure_ascii=False,
-                            indent=4,
-                        )
-                    os.replace(messages_tmp_path, messages_path)
+                    serializable_messages = make_serializable(
+                        self.message_manager.messages
+                    )
+                    messages_path = self.storage.save_message_snapshot(
+                        self.session_id, serializable_messages
+                    )
                     messages_saved = True
                     logger.info(
                         "SessionContext: saved messages.json "
@@ -2709,11 +2630,6 @@ class SessionContext:
                     )
                 except Exception as e:
                     logger.error(f"SessionContext: Failed to save messages.json: {e}")
-                    try:
-                        if os.path.exists(messages_tmp_path):
-                            os.remove(messages_tmp_path)
-                    except Exception:
-                        pass
 
                 if messages_saved:
                     self._clear_message_journal_after_snapshot()
@@ -2721,17 +2637,9 @@ class SessionContext:
             # 2. 保存 compact_manifest.json（派生索引，仅用于审计/调试）
             try:
                 compact_manifest = self.message_manager.get_compact_manifest()
-                with open(
-                    os.path.join(self.session_workspace, "compact_manifest.json"),
-                    "w",
-                    encoding="utf-8",
-                ) as f:
-                    json.dump(
-                        make_serializable(compact_manifest),
-                        f,
-                        ensure_ascii=False,
-                        indent=4,
-                    )
+                self.storage.save_compact_manifest(
+                    self.session_id, make_serializable(compact_manifest)
+                )
             except Exception as e:
                 logger.error(
                     f"SessionContext: Failed to save compact_manifest.json: {e}"
@@ -2771,12 +2679,7 @@ class SessionContext:
                     "agent_config": make_serializable(self.agent_config),
                 }
 
-                with open(
-                    os.path.join(self.session_workspace, "session_context.json"),
-                    "w",
-                    encoding="utf-8",
-                ) as f:
-                    json.dump(context_data, f, ensure_ascii=False, indent=4)
+                self.storage.save_session_snapshot(self.session_id, context_data)
 
             except Exception as e:
                 logger.error(
@@ -2795,12 +2698,7 @@ class SessionContext:
                                     tools_usage.get(tool_name, 0) + 1
                                 )
 
-                with open(
-                    os.path.join(self.session_workspace, "tools_usage.json"),
-                    "w",
-                    encoding="utf-8",
-                ) as f:
-                    json.dump(tools_usage, f, ensure_ascii=False, indent=4)
+                self.storage.save_tools_usage(self.session_id, tools_usage)
             except Exception as e:
                 logger.error(f"SessionContext: Failed to save tools_usage.json: {e}")
 

--- a/sagents/sagents.py
+++ b/sagents/sagents.py
@@ -26,6 +26,7 @@ from sagents.flow.schema import (
 )
 from sagents.session_runtime import get_global_session_manager
 from sagents.utils.sandbox.config import VolumeMount
+from sagents.storage import SessionStorageConfigInput
 from sagents.observability.prometheus_handler import record_agent_first_token
 
 
@@ -157,13 +158,16 @@ class SAgent:
         session_root_space: str,
         enable_obs: bool = True,
         sandbox_type: Optional[str] = None,
+        storage_config: SessionStorageConfigInput = None,
     ):
         self.session_root_space = str(session_root_space)
         self.enable_obs = enable_obs
         # 优先使用传入的参数，其次从环境变量读取，默认使用 local
         self.sandbox_type = sandbox_type or os.environ.get("SAGE_SANDBOX_MODE", "local")
         self.session_manager = get_global_session_manager(
-            session_root_space=self.session_root_space, enable_obs=enable_obs
+            session_root_space=self.session_root_space,
+            enable_obs=enable_obs,
+            storage_config=storage_config,
         )
 
     async def run_stream(

--- a/sagents/session_runtime.py
+++ b/sagents/session_runtime.py
@@ -48,6 +48,11 @@ from sagents.flow.executor import FlowExecutor
 from sagents.utils.sandbox.config import VolumeMount
 from sagents.utils.message_control_flags import extract_control_flags_from_messages
 from sagents.utils.i18n import normalize_language, t
+from sagents.storage import (
+    SessionStorageConfigInput,
+    SessionStore,
+    create_session_store,
+)
 
 
 _session_id_var: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
@@ -131,11 +136,6 @@ async def _flush_session_logs_with_timeout(
         )
 
 
-def _load_json_file_sync(file_path: str) -> Optional[Any]:
-    with open(file_path, "r", encoding="utf-8") as f:
-        return json.load(f)
-
-
 @contextmanager
 def session_scope(session_id: Optional[str]):
     token = _session_id_var.set(session_id)
@@ -197,11 +197,16 @@ def _context_budget_config_from_model(
 
 class Session:
     def __init__(
-        self, session_id: str, enable_obs: bool = True, sandbox_type: str = "local"
+        self,
+        session_id: str,
+        enable_obs: bool = True,
+        sandbox_type: str = "local",
+        storage: Optional[SessionStore] = None,
     ):
         self.session_id = session_id
         self.enable_obs = enable_obs
         self.sandbox_type = sandbox_type
+        self.storage = storage
         self.session_context: Optional[SessionContext] = None
         self.session_workspace: Optional[str] = None
         self.status: SessionStatus = SessionStatus.IDLE
@@ -254,6 +259,14 @@ class Session:
     def set_workspace(self, session_workspace: Optional[str]) -> None:
         if session_workspace:
             self.session_workspace = str(session_workspace)
+            if self.storage is None:
+                self.storage = create_session_store(
+                    session_root=os.path.dirname(self.session_workspace),
+                    initialize=False,
+                )
+            self.storage.bind_session_workspace(
+                self.session_id, self.session_workspace
+            )
 
     def get_context(self) -> Optional[SessionContext]:
         return self.session_context
@@ -348,12 +361,8 @@ class Session:
         if not self.session_workspace:
             return None
 
-        context_path = os.path.join(self.session_workspace, "session_context.json")
-        if not os.path.exists(context_path):
-            return None
-
         try:
-            snapshot = _load_json_file_sync(context_path)
+            snapshot = self.storage.load_session_snapshot(self.session_id)
             if isinstance(snapshot, dict):
                 self._persisted_snapshot = snapshot
                 return snapshot
@@ -373,6 +382,7 @@ class Session:
             self._persisted_messages = SessionContext.load_persisted_message_ledger(
                 self.session_workspace,
                 session_id=self.session_id,
+                storage=self.storage,
             )[0]
         except Exception as exc:
             logger.debug(
@@ -436,6 +446,7 @@ class Session:
                     tool_manager=None,
                     skill_manager=None,
                     parent_session_id=snapshot.get("parent_session_id"),
+                    storage=self.storage,
                 )
                 self.session_context.prompt_budget_manager.restore(
                     snapshot.get("prompt_token_checkpoints") or {}
@@ -597,41 +608,10 @@ class Session:
             self.model = ObservableAsyncOpenAI(self.model, self.observability_manager)
 
     def _load_saved_system_context(self, session_id: str) -> Optional[Dict[str, Any]]:
-        # 尝试从 SessionManager 获取已知的 session_workspace
-        # 如果是第一次创建，可能还不知道路径，返回 None
-        # 如果 SessionManager 已经扫描到，则直接使用
-
-        # 我们需要访问全局 SessionManager 吗？
-        # Session 实例本身不知道自己属于哪个 Manager，除非传入。
-        # 但我们有 get_global_session_manager。
-
-        # 更好的方式：Session 初始化时，应该尝试定位自己的 workspace
-
-        # 假设我们通过全局 Manager 查找
         try:
-            manager = get_global_session_manager()
-            if manager:
-                session_workspace = manager.get_session_workspace(
-                    session_id, only_all_session_paths=True
-                )
-                if session_workspace:
-                    context_path = os.path.join(
-                        session_workspace, "session_context.json"
-                    )
-                    if os.path.exists(context_path):
-                        data = _load_json_file_sync(context_path)
-                        return (
-                            data.get("system_context")
-                            if isinstance(data, dict)
-                            else None
-                        )
-
-            default_path = os.path.join(
-                self.session_root_space, session_id, "session_context.json"
-            )
-            if os.path.exists(default_path):
-                data = _load_json_file_sync(default_path)
-                return data.get("system_context") if isinstance(data, dict) else None
+            storage = self.storage or get_global_session_manager().storage
+            data = storage.load_session_snapshot(session_id)
+            return data.get("system_context") if isinstance(data, dict) else None
 
         except UnicodeDecodeError:
             logger.warning(
@@ -721,6 +701,7 @@ class Session:
             tool_manager=tool_manager,
             skill_manager=skill_manager,
             parent_session_id=parent_session_id,
+            storage=self.storage,
         )
 
         # 异步初始化 SessionContext
@@ -1381,7 +1362,12 @@ class Session:
 
 
 class SessionManager:
-    def __init__(self, session_root_space: str, enable_obs: bool = True):
+    def __init__(
+        self,
+        session_root_space: str,
+        enable_obs: bool = True,
+        storage_config: SessionStorageConfigInput = None,
+    ):
         self.session_root_space = str(session_root_space)
         self.enable_obs = enable_obs
         self._sessions: Dict[str, Session] = {}
@@ -1389,15 +1375,14 @@ class SessionManager:
         self._session_close_lock = threading.RLock()
         self._session_close_futures: Dict[str, concurrent.futures.Future[None]] = {}
         self._shutdown = False
-
-        from sagents.session_registry import SessionRegistry
-
-        db_path = os.path.join(self.session_root_space, "sessions_index.sqlite")
-        need_migrate = not os.path.exists(db_path)
-        os.makedirs(self.session_root_space, exist_ok=True)
-        self._registry = SessionRegistry(db_path, root_dir=self.session_root_space)
+        self.storage = create_session_store(
+            storage_config,
+            session_root=self.session_root_space,
+        )
+        self.storage.initialize()
+        need_migrate = not self.storage.list_sessions()
         if need_migrate:
-            self._migrate_from_filesystem()
+            self._migrate_legacy_sessions()
 
     def _track_cleanup_task(self, task: asyncio.Task) -> None:
         self._session_cleanup_tasks.add(task)
@@ -1415,71 +1400,25 @@ class SessionManager:
 
         task.add_done_callback(cleanup_done)
 
-    def _migrate_from_filesystem(self):
-        """One-time migration: scan existing directories and populate the SQLite registry."""
-        if not os.path.exists(self.session_root_space):
-            logger.info(
-                f"SessionManager: Session root space does not exist: {self.session_root_space}"
-            )
-            return
-
-        logger.info(
-            f"SessionManager: Migrating existing sessions from {self.session_root_space} into SQLite registry"
-        )
-        entries = []
+    def _migrate_legacy_sessions(self):
+        """Ask the selected backend to import any legacy session records."""
         try:
-            with os.scandir(self.session_root_space) as root_entries:
-                for entry in root_entries:
-                    if not entry.is_dir():
-                        continue
-                    entry_path = entry.path
-                    if os.path.exists(
-                        os.path.join(entry_path, "session_context.json")
-                    ) or os.path.exists(os.path.join(entry_path, "messages.json")):
-                        entries.append((entry.name, entry_path, None))
-                        logger.debug(f"Migrating root session: {entry.name}")
-
-                    sub_sessions_dir = os.path.join(entry_path, "sub_sessions")
-                    if not os.path.isdir(sub_sessions_dir):
-                        continue
-                    with os.scandir(sub_sessions_dir) as sub_entries:
-                        for sub_entry in sub_entries:
-                            if not sub_entry.is_dir():
-                                continue
-                            sub_entry_path = sub_entry.path
-                            if os.path.exists(
-                                os.path.join(sub_entry_path, "session_context.json")
-                            ) or os.path.exists(
-                                os.path.join(sub_entry_path, "messages.json")
-                            ):
-                                entries.append(
-                                    (sub_entry.name, sub_entry_path, entry.name)
-                                )
-                                logger.debug(f"Migrating sub session: {sub_entry.name}")
+            migrated = self.storage.migrate_legacy_sessions()
         except FileNotFoundError:
-            logger.info(
-                f"SessionManager: Session root space disappeared during migration: {self.session_root_space}"
-            )
+            logger.info("SessionManager: Legacy session source is unavailable")
             return
         except Exception as e:
-            logger.warning(
-                f"SessionManager: Failed to scan sessions in {self.session_root_space}: {e}"
-            )
+            logger.warning(f"SessionManager: Failed to migrate legacy sessions: {e}")
             return
-
-        if entries:
-            self._registry.register_batch(entries)
-        logger.info(
-            f"SessionManager: Migrated {len(entries)} sessions into SQLite registry"
-        )
+        logger.info(f"SessionManager: Migrated {migrated} legacy sessions")
 
     def _is_sub_session(self, session_id: str) -> bool:
         """判断是否为子会话"""
-        return self._registry.is_sub_session(session_id)
+        return self.storage.get_parent_session_id(session_id) is not None
 
     def get_parent_session_id(self, session_id: str) -> Optional[str]:
         """获取父会话 ID"""
-        return self._registry.get_parent_session_id(session_id)
+        return self.storage.get_parent_session_id(session_id)
 
     def get_session_workspace(
         self, session_id: str, only_all_session_paths: bool = False
@@ -1494,7 +1433,7 @@ class SessionManager:
         Returns:
             工作区路径，找不到则返回 None
         """
-        return self._registry.get_workspace(session_id)
+        return self.storage.get_session_workspace(session_id)
 
     def cache_session_workspace(
         self,
@@ -1504,7 +1443,7 @@ class SessionManager:
     ):
         if not session_id or not session_workspace:
             return
-        self._registry.register(
+        self.storage.register_session(
             session_id, session_workspace, parent_session_id=parent_session_id
         )
 
@@ -1538,6 +1477,7 @@ class SessionManager:
                     session_id=session_id,
                     enable_obs=self.enable_obs,
                     sandbox_type=sandbox_type,
+                    storage=self.storage,
                 )
             else:
                 self._sessions[session_id].sandbox_type = sandbox_type
@@ -1568,6 +1508,7 @@ class SessionManager:
         session = Session(
             session_id=session_id,
             enable_obs=self.enable_obs,
+            storage=self.storage,
         )
         session.set_workspace(workspace)
         loaded = session.load_persisted_state(workspace)
@@ -1784,7 +1725,7 @@ class SessionManager:
             if pending:
                 await asyncio.gather(*pending, return_exceptions=True)
         finally:
-            self._registry.close()
+            self.storage.close()
 
     def interrupt_session(
         self, session_id: str, message: str = "User requested interruption"
@@ -1805,13 +1746,10 @@ class SessionManager:
         session = self.get_live_session(session_id)
         if session:
             return {"status": session.get_status().value}
-        workspace = self.get_session_workspace(session_id)
-        if not workspace:
+        if not self.storage.session_exists(session_id):
             return None
         try:
-            snapshot = _load_json_file_sync(
-                os.path.join(workspace, "session_context.json")
-            )
+            snapshot = self.storage.load_session_snapshot(session_id)
             if isinstance(snapshot, dict) and snapshot.get("status"):
                 return {"status": str(snapshot["status"])}
         except FileNotFoundError:
@@ -1850,12 +1788,9 @@ class SessionManager:
             logger.warning(f"SessionManager: 无法找到会话 {session_id} 的路径")
             return []
 
-        messages_path = os.path.join(session_workspace_path, "messages.json")
-        if not os.path.exists(messages_path):
-            return []
-
         try:
-            raw_messages = _load_json_file_sync(messages_path)
+            ledger = self.storage.load_message_ledger(session_id)
+            raw_messages = ledger.messages
         except json.JSONDecodeError as e:
             logger.error(
                 f"SessionManager: Failed to decode messages.json for session {session_id}: {e}"
@@ -1888,13 +1823,10 @@ class SessionManager:
         session = self.get_live_session(session_id)
         if session:
             return session.get_tasks_status()
-        workspace = self.get_session_workspace(session_id)
-        if not workspace:
+        if not self.storage.session_exists(session_id):
             return None
         try:
-            snapshot = _load_json_file_sync(
-                os.path.join(workspace, "session_context.json")
-            )
+            snapshot = self.storage.load_session_snapshot(session_id)
             if isinstance(snapshot, dict):
                 return snapshot.get("tasks_status") or {"tasks": []}
         except FileNotFoundError:
@@ -2003,10 +1935,18 @@ def build_conversation_messages_view(session_id: str) -> Dict[str, Any]:
 _global_session_manager: Optional[SessionManager] = None
 
 
-def initialize_global_session_manager(session_root_space: str, enable_obs: bool = True):
+def initialize_global_session_manager(
+    session_root_space: str,
+    enable_obs: bool = True,
+    storage_config: SessionStorageConfigInput = None,
+):
     """初始化全局 SessionManager"""
     global _global_session_manager
-    _global_session_manager = SessionManager(session_root_space, enable_obs)
+    _global_session_manager = SessionManager(
+        session_root_space,
+        enable_obs,
+        storage_config=storage_config,
+    )
     return _global_session_manager
 
 
@@ -2021,7 +1961,9 @@ async def shutdown_global_session_manager() -> None:
 
 
 def get_global_session_manager(
-    session_root_space: Optional[str] = None, enable_obs: bool = True
+    session_root_space: Optional[str] = None,
+    enable_obs: bool = True,
+    storage_config: SessionStorageConfigInput = None,
 ) -> SessionManager:
     """
     获取全局 SessionManager 实例
@@ -2037,7 +1979,11 @@ def get_global_session_manager(
     if _global_session_manager is None:
         if session_root_space is None:
             raise ValueError("session_root_space is required for first initialization")
-        _global_session_manager = SessionManager(session_root_space, enable_obs)
+        _global_session_manager = SessionManager(
+            session_root_space,
+            enable_obs,
+            storage_config=storage_config,
+        )
     return _global_session_manager
 
 

--- a/sagents/storage/__init__.py
+++ b/sagents/storage/__init__.py
@@ -1,0 +1,27 @@
+"""Extensible persistence backends for Sage sessions."""
+
+from sagents.storage.base import (
+    MessageLedger,
+    SessionNotFoundError,
+    SessionStore,
+    StorageConflictError,
+    StorageError,
+)
+from sagents.storage.factory import (
+    SessionStorageConfig,
+    SessionStorageConfigInput,
+    create_session_store,
+    normalize_session_storage_config,
+)
+
+__all__ = [
+    "MessageLedger",
+    "SessionNotFoundError",
+    "SessionStore",
+    "StorageConflictError",
+    "StorageError",
+    "SessionStorageConfig",
+    "SessionStorageConfigInput",
+    "create_session_store",
+    "normalize_session_storage_config",
+]

--- a/sagents/storage/base.py
+++ b/sagents/storage/base.py
@@ -1,0 +1,184 @@
+"""Storage contracts for durable agent session data.
+
+The methods describe domain operations rather than filesystem operations so a
+backend does not need to emulate directories, renames, or JSON files.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Optional, Sequence
+
+
+class StorageError(RuntimeError):
+    """Base error raised by a session persistence backend."""
+
+
+class StorageConflictError(StorageError):
+    """A conditional update lost a race with another writer."""
+
+
+class SessionNotFoundError(StorageError):
+    """The requested session has no durable record in the backend."""
+
+
+@dataclass(frozen=True)
+class MessageLedger:
+    messages: list[dict[str, Any]]
+    max_sequence: int = 0
+    journal_records: int = 0
+
+
+class SessionStore(ABC):
+    """Synchronous persistence contract used by the session runtime.
+
+    Runtime callers that must not block the event loop execute these methods in
+    a worker thread. Implementations must be safe for concurrent sessions.
+    """
+
+    @property
+    @abstractmethod
+    def root(self) -> str:
+        """Backend namespace used for this set of sessions."""
+
+    @abstractmethod
+    def initialize(self) -> None: ...
+
+    @abstractmethod
+    def close(self) -> None: ...
+
+    @abstractmethod
+    def healthcheck(self) -> Mapping[str, Any]: ...
+
+    # Session catalog -------------------------------------------------
+    @abstractmethod
+    def register_session(
+        self,
+        session_id: str,
+        workspace: str,
+        parent_session_id: Optional[str] = None,
+    ) -> None: ...
+
+    @abstractmethod
+    def register_sessions(
+        self, entries: Iterable[tuple[str, str, Optional[str]]]
+    ) -> None: ...
+
+    @abstractmethod
+    def get_session_workspace(self, session_id: str) -> Optional[str]: ...
+
+    @abstractmethod
+    def session_exists(self, session_id: str) -> bool: ...
+
+    @abstractmethod
+    def get_parent_session_id(self, session_id: str) -> Optional[str]: ...
+
+    @abstractmethod
+    def remove_session(self, session_id: str) -> None: ...
+
+    @abstractmethod
+    def list_sessions(self) -> Mapping[str, str]: ...
+
+    @abstractmethod
+    def migrate_legacy_sessions(self) -> int:
+        """Import records from this backend's legacy representation, if any."""
+        ...
+
+    # Authoritative state --------------------------------------------
+    @abstractmethod
+    def create_session_workspace(
+        self,
+        session_id: str,
+        *,
+        parent_workspace: Optional[str] = None,
+    ) -> str: ...
+
+    @abstractmethod
+    def bind_session_workspace(self, session_id: str, workspace: str) -> None:
+        """Bind an already resolved physical workspace for this process.
+
+        This preserves compatibility for restored and embedded sessions while
+        keeping path resolution inside the filesystem backend.
+        """
+        ...
+
+    @abstractmethod
+    def load_session_snapshot(self, session_id: str) -> Optional[dict[str, Any]]: ...
+
+    @abstractmethod
+    def save_session_snapshot(
+        self, session_id: str, snapshot: Mapping[str, Any]
+    ) -> str: ...
+
+    @abstractmethod
+    def load_message_ledger(self, session_id: str) -> MessageLedger: ...
+
+    @abstractmethod
+    def append_message_event(
+        self, session_id: str, event: Mapping[str, Any]
+    ) -> str: ...
+
+    @abstractmethod
+    def save_message_snapshot(
+        self, session_id: str, messages: Sequence[Mapping[str, Any]]
+    ) -> str: ...
+
+    @abstractmethod
+    def clear_message_events(self, session_id: str) -> None: ...
+
+    @abstractmethod
+    def message_events_have_records(self, session_id: str) -> bool: ...
+
+    # Derived state ---------------------------------------------------
+    @abstractmethod
+    def save_compact_manifest(
+        self, session_id: str, manifest: Mapping[str, Any]
+    ) -> str: ...
+
+    @abstractmethod
+    def save_tools_usage(
+        self, session_id: str, usage: Mapping[str, int]
+    ) -> str: ...
+
+    @abstractmethod
+    def load_tools_usage(self, session_id: str) -> Mapping[str, int]: ...
+
+    @abstractmethod
+    def append_session_log(self, session_id: str, text: str) -> str:
+        """Append already formatted diagnostic text for one session."""
+        ...
+
+    @abstractmethod
+    def read_session_log_tail(self, session_id: str, *, max_bytes: int) -> str:
+        """Return up to the most recent ``max_bytes`` of diagnostic text."""
+        ...
+
+    # Audit / telemetry ----------------------------------------------
+    @abstractmethod
+    def append_llm_request(
+        self, session_id: str, record: Mapping[str, Any]
+    ) -> str: ...
+
+    @abstractmethod
+    def save_request_usage(
+        self, session_id: str, request_id: str, usage: Mapping[str, Any]
+    ) -> str: ...
+
+    @abstractmethod
+    def save_mcp_calls(
+        self, session_id: str, request_id: str, payload: Mapping[str, Any]
+    ) -> str: ...
+
+    @abstractmethod
+    def purge_llm_requests(self, *, before: float) -> Mapping[str, int]: ...
+
+    @abstractmethod
+    def purge_sessions(
+        self, *, before: float, session_id_prefix: str
+    ) -> Mapping[str, int]: ...
+
+    @abstractmethod
+    def export_session_archive(self, session_id: str) -> str:
+        """Export one session into a backend-produced local archive."""
+        ...

--- a/sagents/storage/factory.py
+++ b/sagents/storage/factory.py
@@ -1,0 +1,107 @@
+"""Configuration-driven construction of session storage backends."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional, Union
+
+from sagents.storage.base import SessionStore, StorageError
+
+
+SESSION_STORAGE_BACKEND_ENV = "SAGE_SESSION_STORAGE_BACKEND"
+SESSION_STORAGE_OPTIONS_ENV = "SAGE_SESSION_STORAGE_OPTIONS"
+
+
+@dataclass(frozen=True)
+class SessionStorageConfig:
+    """Backend-neutral configuration accepted by the public factory."""
+
+    backend: str = "filesystem"
+    options: Mapping[str, Any] = field(default_factory=dict)
+
+
+SessionStorageConfigInput = Optional[
+    Union[SessionStorageConfig, Mapping[str, Any], str]
+]
+
+
+def _environment_config() -> SessionStorageConfig:
+    backend = os.environ.get(SESSION_STORAGE_BACKEND_ENV, "filesystem")
+    raw_options = os.environ.get(SESSION_STORAGE_OPTIONS_ENV, "").strip()
+    options: Mapping[str, Any] = {}
+    if raw_options:
+        try:
+            parsed = json.loads(raw_options)
+        except json.JSONDecodeError as exc:
+            raise StorageError(
+                f"{SESSION_STORAGE_OPTIONS_ENV} must contain a JSON object"
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise StorageError(
+                f"{SESSION_STORAGE_OPTIONS_ENV} must contain a JSON object"
+            )
+        options = parsed
+    return SessionStorageConfig(backend=backend, options=options)
+
+
+def normalize_session_storage_config(
+    config: SessionStorageConfigInput = None,
+    *,
+    session_root: Optional[str] = None,
+) -> SessionStorageConfig:
+    if config is None:
+        normalized = _environment_config()
+    elif isinstance(config, SessionStorageConfig):
+        normalized = config
+    elif isinstance(config, str):
+        normalized = SessionStorageConfig(backend=config)
+    elif isinstance(config, Mapping):
+        backend = str(config.get("backend") or "filesystem")
+        raw_options = config.get("options") or {}
+        if not isinstance(raw_options, Mapping):
+            raise StorageError("session storage options must be a mapping")
+        normalized = SessionStorageConfig(backend=backend, options=dict(raw_options))
+    else:
+        raise StorageError(
+            f"unsupported session storage config type: {type(config).__name__}"
+        )
+
+    options = dict(normalized.options)
+    if session_root and "root" not in options:
+        options["root"] = session_root
+    return SessionStorageConfig(
+        backend=normalized.backend.strip().lower(),
+        options=options,
+    )
+
+
+def create_session_store(
+    config: SessionStorageConfigInput = None,
+    *,
+    session_root: Optional[str] = None,
+    initialize: bool = True,
+) -> SessionStore:
+    """Create the configured backend without exposing implementation classes."""
+
+    normalized = normalize_session_storage_config(
+        config, session_root=session_root
+    )
+    if normalized.backend == "filesystem":
+        from sagents.storage.filesystem import _FilesystemSessionStore
+
+        root = normalized.options.get("root")
+        if not root:
+            raise StorageError("filesystem session storage requires options.root")
+        unknown = set(normalized.options) - {"root"}
+        if unknown:
+            names = ", ".join(sorted(unknown))
+            raise StorageError(f"unknown filesystem storage options: {names}")
+        return _FilesystemSessionStore(
+            str(root), auto_initialize=initialize
+        )
+
+    raise StorageError(
+        f"unsupported session storage backend: {normalized.backend!r}"
+    )

--- a/sagents/storage/filesystem.py
+++ b/sagents/storage/filesystem.py
@@ -1,0 +1,447 @@
+"""Filesystem implementation preserving Sage's historical file contract."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import threading
+import time
+import zipfile
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from sagents.session_registry import SessionRegistry
+from sagents.storage.base import MessageLedger, SessionStore
+
+
+MESSAGE_SNAPSHOT_FILE = "messages.json"
+MESSAGE_JOURNAL_FILE = "messages.journal.jsonl"
+SESSION_SNAPSHOT_FILE = "session_context.json"
+
+
+class _FilesystemSessionStore(SessionStore):
+    """SQLite catalog plus JSON/JSONL session payloads on local disk."""
+
+    def __init__(self, root: str, *, auto_initialize: bool = True):
+        self._root = os.path.abspath(str(root))
+        self._registry: Optional[SessionRegistry] = None
+        self._workspace_hints: dict[str, str] = {}
+        self._llm_locks: defaultdict[str, threading.Lock] = defaultdict(threading.Lock)
+        if auto_initialize:
+            self.initialize()
+
+    @property
+    def root(self) -> str:
+        return self._root
+
+    @property
+    def registry_path(self) -> str:
+        return os.path.join(self._root, "sessions_index.sqlite")
+
+    def initialize(self) -> None:
+        os.makedirs(self._root, exist_ok=True)
+        if self._registry is None:
+            self._registry = SessionRegistry(self.registry_path, root_dir=self._root)
+
+    def close(self) -> None:
+        if self._registry is not None:
+            self._registry.close()
+            self._registry = None
+
+    def healthcheck(self) -> Mapping[str, Any]:
+        root_exists = os.path.isdir(self._root)
+        writable = os.access(self._root, os.W_OK) if root_exists else os.access(
+            os.path.dirname(self._root) or ".", os.W_OK
+        )
+        return {
+            "backend": "filesystem",
+            "initialized": self._registry is not None,
+            "healthy": root_exists and writable,
+            "available": root_exists,
+            "writable": writable,
+            "catalog_ready": os.path.isfile(self.registry_path),
+        }
+
+    def _catalog(self) -> SessionRegistry:
+        self.initialize()
+        assert self._registry is not None
+        return self._registry
+
+    def register_session(self, session_id, workspace, parent_session_id=None) -> None:
+        self._catalog().register(session_id, workspace, parent_session_id)
+
+    def register_sessions(self, entries) -> None:
+        self._catalog().register_batch(list(entries))
+
+    def get_session_workspace(self, session_id: str) -> Optional[str]:
+        return self._catalog().get_workspace(session_id)
+
+    def session_exists(self, session_id: str) -> bool:
+        return self._catalog().exists(session_id)
+
+    def get_parent_session_id(self, session_id: str) -> Optional[str]:
+        return self._catalog().get_parent_session_id(session_id)
+
+    def remove_session(self, session_id: str) -> None:
+        self._catalog().remove(session_id)
+
+    def list_sessions(self) -> Mapping[str, str]:
+        return self._catalog().list_all()
+
+    def migrate_legacy_sessions(self) -> int:
+        entries = self._discover_legacy_sessions()
+        if entries:
+            self.register_sessions(entries)
+        return len(entries)
+
+    def _discover_legacy_sessions(self):
+        entries: list[tuple[str, str, Optional[str]]] = []
+        if not os.path.isdir(self._root):
+            return entries
+        with os.scandir(self._root) as roots:
+            for entry in roots:
+                if not entry.is_dir():
+                    continue
+                if self._has_session_payload(entry.path):
+                    entries.append((entry.name, entry.path, None))
+                children = os.path.join(entry.path, "sub_sessions")
+                if not os.path.isdir(children):
+                    continue
+                with os.scandir(children) as child_entries:
+                    for child in child_entries:
+                        if child.is_dir() and self._has_session_payload(child.path):
+                            entries.append((child.name, child.path, entry.name))
+        return entries
+
+    @staticmethod
+    def _has_session_payload(workspace: str) -> bool:
+        return any(
+            os.path.exists(os.path.join(workspace, filename))
+            for filename in (SESSION_SNAPSHOT_FILE, MESSAGE_SNAPSHOT_FILE)
+        )
+
+    def create_session_workspace(self, session_id, *, parent_workspace=None) -> str:
+        if parent_workspace:
+            workspace = os.path.join(parent_workspace, "sub_sessions", session_id)
+        else:
+            workspace = os.path.join(self._root, session_id)
+        os.makedirs(workspace, exist_ok=True)
+        self.bind_session_workspace(session_id, workspace)
+        return workspace
+
+    def bind_session_workspace(self, session_id: str, workspace: str) -> None:
+        self._workspace_hints[session_id] = os.path.abspath(str(workspace))
+
+    def _workspace(self, session_id: str) -> str:
+        hinted = self._workspace_hints.get(session_id)
+        if hinted:
+            return hinted
+        workspace = self.get_session_workspace(session_id)
+        if workspace:
+            return workspace
+        return os.path.join(self._root, session_id)
+
+    @staticmethod
+    def _read_json(path: str) -> Optional[Any]:
+        if not os.path.exists(path):
+            return None
+        with open(path, "r", encoding="utf-8") as stream:
+            return json.load(stream)
+
+    @staticmethod
+    def _write_json(path: str, value: Any, *, indent: int) -> str:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as stream:
+            json.dump(value, stream, ensure_ascii=False, indent=indent)
+        return path
+
+    def load_session_snapshot(self, session_id):
+        value = self._read_json(
+            os.path.join(self._workspace(session_id), SESSION_SNAPSHOT_FILE)
+        )
+        return value if isinstance(value, dict) else None
+
+    def save_session_snapshot(self, session_id, snapshot):
+        return self._write_json(
+            os.path.join(self._workspace(session_id), SESSION_SNAPSHOT_FILE),
+            dict(snapshot),
+            indent=4,
+        )
+
+    def load_message_ledger(self, session_id):
+        workspace = self._workspace(session_id)
+        try:
+            raw_messages = self._read_json(
+                os.path.join(workspace, MESSAGE_SNAPSHOT_FILE)
+            )
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            # The append-only journal remains recoverable when a snapshot is
+            # truncated or uses an unreadable legacy encoding.
+            raw_messages = []
+        messages = [dict(item) for item in raw_messages or [] if isinstance(item, dict)]
+        max_sequence = 0
+        count = 0
+        journal = os.path.join(workspace, MESSAGE_JOURNAL_FILE)
+        if os.path.exists(journal):
+            with open(journal, "r", encoding="utf-8") as stream:
+                for line in stream:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if (
+                        not isinstance(record, dict)
+                        or record.get("op") != "put_message"
+                    ):
+                        continue
+                    owner = record.get("session_id")
+                    if owner and owner != session_id:
+                        continue
+                    sequence = record.get("seq")
+                    if isinstance(sequence, int):
+                        max_sequence = max(max_sequence, sequence)
+                    message = record.get("message")
+                    if not isinstance(message, dict):
+                        continue
+                    message_id = message.get("message_id")
+                    replaced = False
+                    if message_id:
+                        for index, existing in enumerate(messages):
+                            if existing.get("message_id") == message_id:
+                                messages[index] = message
+                                replaced = True
+                                break
+                    if not replaced:
+                        messages.append(message)
+                    count += 1
+        return MessageLedger(messages, max_sequence, count)
+
+    def append_message_event(self, session_id, event):
+        path = os.path.join(self._workspace(session_id), MESSAGE_JOURNAL_FILE)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "a", encoding="utf-8") as stream:
+            stream.write(json.dumps(dict(event), ensure_ascii=False) + "\n")
+            stream.flush()
+        return path
+
+    def save_message_snapshot(self, session_id, messages):
+        path = os.path.join(self._workspace(session_id), MESSAGE_SNAPSHOT_FILE)
+        temporary = f"{path}.tmp"
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        try:
+            with open(temporary, "w", encoding="utf-8") as stream:
+                json.dump(list(messages), stream, ensure_ascii=False, indent=4)
+            os.replace(temporary, path)
+        except Exception:
+            try:
+                if os.path.exists(temporary):
+                    os.remove(temporary)
+            except Exception:
+                pass
+            raise
+        return path
+
+    def clear_message_events(self, session_id):
+        path = os.path.join(self._workspace(session_id), MESSAGE_JOURNAL_FILE)
+        if os.path.exists(path):
+            open(path, "w", encoding="utf-8").close()
+
+    def message_events_have_records(self, session_id):
+        try:
+            path = os.path.join(
+                self._workspace(session_id), MESSAGE_JOURNAL_FILE
+            )
+            return os.path.getsize(path) > 0
+        except OSError:
+            return False
+
+    def save_compact_manifest(self, session_id, manifest):
+        return self._write_json(
+            os.path.join(self._workspace(session_id), "compact_manifest.json"),
+            dict(manifest),
+            indent=4,
+        )
+
+    def save_tools_usage(self, session_id, usage):
+        return self._write_json(
+            os.path.join(self._workspace(session_id), "tools_usage.json"),
+            dict(usage),
+            indent=4,
+        )
+
+    def load_tools_usage(self, session_id):
+        value = self._read_json(
+            os.path.join(self._workspace(session_id), "tools_usage.json")
+        )
+        return value if isinstance(value, dict) else {}
+
+    def append_session_log(self, session_id: str, text: str) -> str:
+        path = os.path.join(self._workspace(session_id), f"session_{session_id}.log")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "a", encoding="utf-8") as stream:
+            stream.write(text)
+        return path
+
+    def read_session_log_tail(self, session_id: str, *, max_bytes: int) -> str:
+        if max_bytes <= 0:
+            return ""
+        path = os.path.join(self._workspace(session_id), f"session_{session_id}.log")
+        try:
+            with open(path, "rb") as handle:
+                handle.seek(0, os.SEEK_END)
+                size = handle.tell()
+                handle.seek(max(0, size - max_bytes))
+                return handle.read().decode("utf-8", errors="ignore")
+        except FileNotFoundError:
+            return ""
+
+    def append_llm_request(self, session_id, record):
+        directory = os.path.join(self._workspace(session_id), "llm_request")
+        os.makedirs(directory, exist_ok=True)
+        with self._llm_locks[session_id]:
+            maximum = -1
+            for filename in os.listdir(directory):
+                if filename.endswith(".json"):
+                    try:
+                        maximum = max(maximum, int(filename.split("_", 1)[0]))
+                    except ValueError:
+                        pass
+            timestamp = float(record["timestamp"])
+            step = record.get("request", {}).get("step_name", "unknown")
+            date = time.strftime(
+                "%Y%m%d%H%M%S", time.localtime(timestamp)
+            )
+            filename = f"{maximum + 1}_{step}_{date}.json"
+            payload = dict(record)
+            payload["timestamp"] = timestamp
+            return self._write_json(
+                os.path.join(directory, filename), payload, indent=4
+            )
+
+    def save_request_usage(self, session_id, request_id, usage):
+        return self._write_json(
+            os.path.join(
+                self._workspace(session_id),
+                "tokens_usage",
+                f"{request_id}.json",
+            ),
+            dict(usage),
+            indent=2,
+        )
+
+    def save_mcp_calls(self, session_id, request_id, payload):
+        return self._write_json(
+            os.path.join(
+                self._workspace(session_id),
+                "mcp_calls",
+                f"{request_id}.json",
+            ),
+            dict(payload),
+            indent=2,
+        )
+
+    def purge_llm_requests(self, *, before):
+        stats = {
+            "scanned_dirs": 0,
+            "deleted_files": 0,
+            "deleted_empty_dirs": 0,
+            "errors": 0,
+        }
+        for directory in Path(self._root).glob("**/llm_request"):
+            if not directory.is_dir():
+                continue
+            stats["scanned_dirs"] += 1
+            try:
+                for path in directory.iterdir():
+                    if path.is_dir():
+                        continue
+                    try:
+                        if path.stat().st_mtime < before:
+                            path.unlink()
+                            stats["deleted_files"] += 1
+                    except Exception:
+                        stats["errors"] += 1
+                try:
+                    if not any(directory.iterdir()):
+                        os.rmdir(directory)
+                        stats["deleted_empty_dirs"] += 1
+                except OSError:
+                    pass
+            except Exception:
+                stats["errors"] += 1
+        return stats
+
+    def purge_sessions(self, *, before, session_id_prefix):
+        stats = {"scanned_dirs": 0, "deleted_session_dirs": 0, "errors": 0}
+        root = Path(self._root)
+        if not root.exists():
+            return stats
+        for session_dir in root.iterdir():
+            if (
+                session_dir.is_symlink()
+                or not session_dir.is_dir()
+                or not session_dir.name.startswith(session_id_prefix)
+            ):
+                continue
+            stats["scanned_dirs"] += 1
+            try:
+                latest = session_dir.stat().st_mtime
+                for child in session_dir.rglob("*"):
+                    if child.is_symlink():
+                        continue
+                    try:
+                        latest = max(latest, child.stat().st_mtime)
+                    except OSError:
+                        continue
+                if latest >= before:
+                    continue
+                shutil.rmtree(session_dir)
+                stats["deleted_session_dirs"] += 1
+            except Exception:
+                stats["errors"] += 1
+        return stats
+
+    def export_session_archive(self, session_id: str) -> str:
+        if not self.session_exists(session_id):
+            raise FileNotFoundError(session_id)
+        session_dir = Path(self._workspace(session_id)).resolve()
+        if not session_dir.is_dir():
+            raise FileNotFoundError(session_id)
+        tmp_file = tempfile.NamedTemporaryFile(
+            prefix=f"sage-session-{session_id}-",
+            suffix=".zip",
+            delete=False,
+        )
+        tmp_file.close()
+        try:
+            with zipfile.ZipFile(
+                tmp_file.name, "w", zipfile.ZIP_DEFLATED
+            ) as archive:
+                for root, dirs, files in os.walk(
+                    session_dir, followlinks=False
+                ):
+                    root_path = Path(root)
+                    dirs[:] = [
+                        name
+                        for name in dirs
+                        if not (root_path / name).is_symlink()
+                    ]
+                    for filename in files:
+                        path = root_path / filename
+                        if path.is_symlink() or not path.is_file():
+                            continue
+                        arcname = Path(session_id) / path.relative_to(session_dir)
+                        archive.write(path, arcname.as_posix())
+            return tmp_file.name
+        except Exception:
+            try:
+                os.unlink(tmp_file.name)
+            except OSError:
+                pass
+            raise

--- a/sagents/storage/filesystem.py
+++ b/sagents/storage/filesystem.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any, Mapping, Optional
 
 from sagents.session_registry import SessionRegistry
-from sagents.storage.base import MessageLedger, SessionStore
+from sagents.storage.base import MessageLedger, SessionStore, StorageError
 
 
 MESSAGE_SNAPSHOT_FILE = "messages.json"
@@ -40,6 +40,20 @@ class _FilesystemSessionStore(SessionStore):
     @property
     def registry_path(self) -> str:
         return os.path.join(self._root, "sessions_index.sqlite")
+
+    @staticmethod
+    def _validate_session_id(session_id: str) -> str:
+        value = str(session_id or "")
+        if (
+            not value
+            or value != value.strip()
+            or value in {".", ".."}
+            or "/" in value
+            or "\\" in value
+            or "\x00" in value
+        ):
+            raise StorageError("invalid session_id")
+        return value
 
     def initialize(self) -> None:
         os.makedirs(self._root, exist_ok=True)
@@ -71,22 +85,39 @@ class _FilesystemSessionStore(SessionStore):
         return self._registry
 
     def register_session(self, session_id, workspace, parent_session_id=None) -> None:
-        self._catalog().register(session_id, workspace, parent_session_id)
+        safe_session_id = self._validate_session_id(session_id)
+        safe_parent_id = (
+            self._validate_session_id(parent_session_id)
+            if parent_session_id is not None
+            else None
+        )
+        self._catalog().register(safe_session_id, workspace, safe_parent_id)
 
     def register_sessions(self, entries) -> None:
-        self._catalog().register_batch(list(entries))
+        normalized = []
+        for session_id, workspace, parent_session_id in entries:
+            safe_session_id = self._validate_session_id(session_id)
+            safe_parent_id = (
+                self._validate_session_id(parent_session_id)
+                if parent_session_id is not None
+                else None
+            )
+            normalized.append((safe_session_id, workspace, safe_parent_id))
+        self._catalog().register_batch(normalized)
 
     def get_session_workspace(self, session_id: str) -> Optional[str]:
-        return self._catalog().get_workspace(session_id)
+        return self._catalog().get_workspace(self._validate_session_id(session_id))
 
     def session_exists(self, session_id: str) -> bool:
-        return self._catalog().exists(session_id)
+        return self._catalog().exists(self._validate_session_id(session_id))
 
     def get_parent_session_id(self, session_id: str) -> Optional[str]:
-        return self._catalog().get_parent_session_id(session_id)
+        return self._catalog().get_parent_session_id(
+            self._validate_session_id(session_id)
+        )
 
     def remove_session(self, session_id: str) -> None:
-        self._catalog().remove(session_id)
+        self._catalog().remove(self._validate_session_id(session_id))
 
     def list_sessions(self) -> Mapping[str, str]:
         return self._catalog().list_all()
@@ -124,25 +155,28 @@ class _FilesystemSessionStore(SessionStore):
         )
 
     def create_session_workspace(self, session_id, *, parent_workspace=None) -> str:
+        safe_session_id = self._validate_session_id(session_id)
         if parent_workspace:
-            workspace = os.path.join(parent_workspace, "sub_sessions", session_id)
+            workspace = os.path.join(parent_workspace, "sub_sessions", safe_session_id)
         else:
-            workspace = os.path.join(self._root, session_id)
+            workspace = os.path.join(self._root, safe_session_id)
         os.makedirs(workspace, exist_ok=True)
-        self.bind_session_workspace(session_id, workspace)
+        self.bind_session_workspace(safe_session_id, workspace)
         return workspace
 
     def bind_session_workspace(self, session_id: str, workspace: str) -> None:
-        self._workspace_hints[session_id] = os.path.abspath(str(workspace))
+        safe_session_id = self._validate_session_id(session_id)
+        self._workspace_hints[safe_session_id] = os.path.abspath(str(workspace))
 
     def _workspace(self, session_id: str) -> str:
-        hinted = self._workspace_hints.get(session_id)
+        safe_session_id = self._validate_session_id(session_id)
+        hinted = self._workspace_hints.get(safe_session_id)
         if hinted:
             return hinted
-        workspace = self.get_session_workspace(session_id)
+        workspace = self.get_session_workspace(safe_session_id)
         if workspace:
             return workspace
-        return os.path.join(self._root, session_id)
+        return os.path.join(self._root, safe_session_id)
 
     @staticmethod
     def _read_json(path: str) -> Optional[Any]:
@@ -409,13 +443,22 @@ class _FilesystemSessionStore(SessionStore):
         return stats
 
     def export_session_archive(self, session_id: str) -> str:
-        if not self.session_exists(session_id):
+        safe_session_id = self._validate_session_id(session_id)
+        if not self.session_exists(safe_session_id):
             raise FileNotFoundError(session_id)
-        session_dir = Path(self._workspace(session_id)).resolve()
+        registered_workspace = self.get_session_workspace(safe_session_id)
+        if not registered_workspace:
+            raise FileNotFoundError(session_id)
+        session_dir = Path(registered_workspace).resolve()
+        storage_root = Path(self._root).resolve()
+        try:
+            session_dir.relative_to(storage_root)
+        except ValueError as exc:
+            raise StorageError("session workspace escapes storage root") from exc
         if not session_dir.is_dir():
             raise FileNotFoundError(session_id)
         tmp_file = tempfile.NamedTemporaryFile(
-            prefix=f"sage-session-{session_id}-",
+            prefix=f"sage-session-{safe_session_id}-",
             suffix=".zip",
             delete=False,
         )
@@ -437,7 +480,7 @@ class _FilesystemSessionStore(SessionStore):
                         path = root_path / filename
                         if path.is_symlink() or not path.is_file():
                             continue
-                        arcname = Path(session_id) / path.relative_to(session_dir)
+                        arcname = Path(safe_session_id) / path.relative_to(session_dir)
                         archive.write(path, arcname.as_posix())
             return tmp_file.name
         except Exception:

--- a/sagents/storage/filesystem.py
+++ b/sagents/storage/filesystem.py
@@ -402,6 +402,7 @@ class _FilesystemSessionStore(SessionStore):
                 if latest >= before:
                     continue
                 shutil.rmtree(session_dir)
+                self.remove_session(session_dir.name)
                 stats["deleted_session_dirs"] += 1
             except Exception:
                 stats["errors"] += 1

--- a/sagents/utils/logger.py
+++ b/sagents/utils/logger.py
@@ -13,6 +13,23 @@ _DISABLE_FILE_LOGGING_ENV = "SAGE_DISABLE_SAGENTS_FILE_LOGGING"
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 
 
+class _SessionStoreLogHandler(logging.Handler):
+    """Logging handler that delegates session logs to the configured store."""
+
+    def __init__(self, storage, session_id: str):
+        super().__init__()
+        self.storage = storage
+        self.session_id = session_id
+
+    def emit(self, record):
+        try:
+            self.storage.append_session_log(
+                self.session_id, self.format(record) + "\n"
+            )
+        except Exception:
+            self.handleError(record)
+
+
 def _file_logging_disabled() -> bool:
     return os.getenv(_DISABLE_FILE_LOGGING_ENV, "").strip().lower() in _TRUE_VALUES
 
@@ -349,22 +366,15 @@ class Logger:
                 if status_value not in {"idle", "running"}:
                     self.cleanup_session_logger(session_id)
                     return None
-                session_workspace = getattr(
-                    session_context, "session_workspace", None
-                )
-                if not session_workspace:
+                storage = getattr(session_context, "storage", None)
+                if storage is None:
                     return None
 
                 cached_logger = self.session_loggers.get(session_id)
                 if cached_logger is not None:
                     return cached_logger
-
-                session_log_file = os.path.join(
-                    session_workspace, f"session_{session_id}.log"
-                )
-                session_file_handler = logging.FileHandler(
-                    session_log_file, mode="a", encoding="utf-8"
-                )
+                storage.append_session_log(session_id, "")
+                session_file_handler = _SessionStoreLogHandler(storage, session_id)
                 session_file_handler.setLevel(logging.DEBUG)
                 session_file_handler.setFormatter(
                     logging.Formatter(

--- a/tests/app/cli/test_doctor_memory_backends.py
+++ b/tests/app/cli/test_doctor_memory_backends.py
@@ -95,6 +95,8 @@ class TestDoctorMemoryBackends(unittest.TestCase):
             info = cli_service.collect_doctor_info()
 
         self.assertIn("memory_backends", info)
+        self.assertEqual(info["session_storage"]["backend"], "filesystem")
+        self.assertNotIn("session_registry_db", info)
         self.assertEqual(info["memory_backends"]["session_history"]["status"], "ok")
         self.assertEqual(info["memory_backends"]["file_memory"]["status"], "ok")
         self.assertEqual(info["memory_backends"]["session_history"]["resolved"], "noop")
@@ -131,6 +133,8 @@ class TestDoctorMemoryBackends(unittest.TestCase):
             info = cli_service.collect_config_info()
 
         self.assertIn("memory_backends", info)
+        self.assertEqual(info["session_storage"]["backend"], "filesystem")
+        self.assertNotIn("session_registry_db", info)
         self.assertEqual(info["memory_backends"]["session_history"]["status"], "ok")
         self.assertEqual(info["memory_backends"]["file_memory"]["status"], "ok")
         self.assertEqual(info["memory_backends"]["session_history"]["resolved"], "noop")

--- a/tests/app/cli/test_stats_tool_detection.py
+++ b/tests/app/cli/test_stats_tool_detection.py
@@ -954,8 +954,7 @@ class TestStreamRequestIdlePolling(unittest.IsolatedAsyncioTestCase):
         from datetime import datetime
         from io import StringIO
         import json
-        import os
-        import tempfile
+        from types import SimpleNamespace
 
         original_wait_for = asyncio.wait_for
         first_poll = {"value": True}
@@ -966,33 +965,33 @@ class TestStreamRequestIdlePolling(unittest.IsolatedAsyncioTestCase):
                 raise asyncio.TimeoutError
             return await original_wait_for(awaitable, timeout)
 
-        with tempfile.TemporaryDirectory() as tempdir:
-            session_dir = os.path.join(tempdir, request.session_id)  # pyright: ignore[reportAttributeAccessIssue]
-            os.makedirs(session_dir, exist_ok=True)
-            session_log = os.path.join(session_dir, f"session_{request.session_id}.log")  # pyright: ignore[reportAttributeAccessIssue]
-            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")[:-3]
-            with open(session_log, "w", encoding="utf-8") as handle:
-                handle.write(
-                    f"{timestamp} - WARNING - [agent/agent_base.py:425] - ToolSuggestionAgent: 遇到网络连接错误，等待 2 秒后重试 (1/8): Connection error.\n"
-                )
-
-            stdout = StringIO()
-            with (
-                patch("app.cli.service.run_request_stream", fake_run_request_stream),
-                patch("sys.stdout", stdout),
-                patch("sys.stderr", StringIO()),
-                patch("app.cli.runtime.stream.asyncio.wait_for", fake_wait_for),
-                patch("app.cli.runtime.stream.STREAM_IDLE_NOTICE_SECONDS", 0.0),
-                patch("app.cli.runtime.stream.STREAM_IDLE_REPEAT_SECONDS", 0.0),
-                patch.dict("os.environ", {"SAGE_SESSION_DIR": tempdir}, clear=False),
-            ):
-                result = await _stream_request(
-                    request,
-                    json_output=True,
-                    stats_output=False,
-                    workspace=None,
-                    command_mode="chat",
-                )
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")[:-3]
+        log_tail = f"{timestamp} - WARNING - [agent/agent_base.py:425] - ToolSuggestionAgent: 遇到网络连接错误，等待 2 秒后重试 (1/8): Connection error.\n"
+        store = type(
+            "Store",
+            (),
+            {"read_session_log_tail": lambda self, session_id, max_bytes: log_tail},
+        )()
+        stdout = StringIO()
+        with (
+            patch("app.cli.service.run_request_stream", fake_run_request_stream),
+            patch("sys.stdout", stdout),
+            patch("sys.stderr", StringIO()),
+            patch("app.cli.runtime.stream.asyncio.wait_for", fake_wait_for),
+            patch("app.cli.runtime.stream.STREAM_IDLE_NOTICE_SECONDS", 0.0),
+            patch("app.cli.runtime.stream.STREAM_IDLE_REPEAT_SECONDS", 0.0),
+            patch(
+                "sagents.session_runtime.get_global_session_manager",
+                return_value=SimpleNamespace(storage=store),
+            ),
+        ):
+            result = await _stream_request(
+                request,
+                json_output=True,
+                stats_output=False,
+                workspace=None,
+                command_mode="chat",
+            )
 
         self.assertEqual(result, 0)
         events = [

--- a/tests/sagents/agent/test_delegate_stream.py
+++ b/tests/sagents/agent/test_delegate_stream.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -10,6 +11,7 @@ from sagents.agent.fibre.delegate_stream import (
     merge_history_with_fallback,
 )
 from sagents.context.messages.message import MessageChunk
+from sagents.storage import create_session_store
 
 
 class _HangingBackendClient:
@@ -292,9 +294,11 @@ def test_load_child_history_fallback_from_messages_json(tmp_path, monkeypatch):
         json.dumps(messages, ensure_ascii=False), encoding="utf-8"
     )
 
+    store = create_session_store(session_root=str(tmp_path))
+    store.bind_session_workspace(session_id, str(workspace))
     monkeypatch.setattr(
-        "sagents.agent.fibre.delegate_stream.resolve_child_workspace",
-        lambda sid, parent_session_id=None: str(workspace),
+        "sagents.session_runtime.get_global_session_manager",
+        lambda: SimpleNamespace(storage=store),
     )
 
     history = load_child_history_fallback(session_id, parent_session_id="parent")

--- a/tests/sagents/storage/test_filesystem_session_store.py
+++ b/tests/sagents/storage/test_filesystem_session_store.py
@@ -1,10 +1,11 @@
 import json
 import os
+import pytest
 import time
 import zipfile
 
 from sagents.session_runtime import SessionManager
-from sagents.storage import SessionStore, create_session_store
+from sagents.storage import SessionStore, StorageError, create_session_store
 
 
 def test_filesystem_store_implements_session_store_contract(tmp_path):
@@ -127,3 +128,22 @@ def test_purge_sessions_removes_expired_directory_and_registry_entry(tmp_path):
     assert not os.path.exists(workspace)
     assert not store.session_exists(session_id)
     assert session_id not in store.list_sessions()
+
+
+@pytest.mark.parametrize("session_id", ["..", "../outside", "nested/session", "nested\\session"])
+def test_filesystem_store_rejects_path_traversal_session_ids(tmp_path, session_id):
+    store = create_session_store(session_root=str(tmp_path))
+
+    with pytest.raises(StorageError, match="invalid session_id"):
+        store.create_session_workspace(session_id)
+
+
+def test_export_session_archive_rejects_workspace_outside_storage_root(tmp_path):
+    store = create_session_store(session_root=str(tmp_path))
+    session_id = "safe-session"
+    outside_workspace = tmp_path.parent / "sage-outside-session"
+    outside_workspace.mkdir()
+    store.register_session(session_id, str(outside_workspace))
+
+    with pytest.raises(StorageError, match="escapes storage root"):
+        store.export_session_archive(session_id)

--- a/tests/sagents/storage/test_filesystem_session_store.py
+++ b/tests/sagents/storage/test_filesystem_session_store.py
@@ -1,5 +1,6 @@
 import json
 import os
+import time
 import zipfile
 
 from sagents.session_runtime import SessionManager
@@ -106,3 +107,23 @@ def test_filesystem_store_exports_session_without_exposing_directory_walk(tmp_pa
 
     with zipfile.ZipFile(archive_path) as archive:
         assert "session-a/session_context.json" in archive.namelist()
+
+
+def test_purge_sessions_removes_expired_directory_and_registry_entry(tmp_path):
+    store = create_session_store(session_root=str(tmp_path))
+    session_id = "proactive_eval_expired"
+    workspace = store.create_session_workspace(session_id)
+    store.register_session(session_id, workspace)
+
+    expired_at = time.time() - 10 * 24 * 60 * 60
+    os.utime(workspace, (expired_at, expired_at))
+
+    stats = store.purge_sessions(
+        before=time.time() - 3 * 24 * 60 * 60,
+        session_id_prefix="proactive_eval_",
+    )
+
+    assert stats["deleted_session_dirs"] == 1
+    assert not os.path.exists(workspace)
+    assert not store.session_exists(session_id)
+    assert session_id not in store.list_sessions()

--- a/tests/sagents/storage/test_filesystem_session_store.py
+++ b/tests/sagents/storage/test_filesystem_session_store.py
@@ -1,0 +1,108 @@
+import json
+import os
+import zipfile
+
+from sagents.session_runtime import SessionManager
+from sagents.storage import SessionStore, create_session_store
+
+
+def test_filesystem_store_implements_session_store_contract(tmp_path):
+    store = create_session_store(session_root=str(tmp_path))
+    assert isinstance(store, SessionStore)
+
+    workspace = store.create_session_workspace("root-session")
+    store.register_session("root-session", workspace)
+    child_workspace = store.create_session_workspace(
+        "child-session", parent_workspace=workspace
+    )
+    store.register_session(
+        "child-session", child_workspace, parent_session_id="root-session"
+    )
+
+    assert store.get_session_workspace("root-session") == workspace
+    assert store.get_session_workspace("child-session") == child_workspace
+    assert store.get_parent_session_id("child-session") == "root-session"
+    assert store.session_exists("child-session")
+
+    store.save_session_snapshot("root-session", {"session_id": "root-session"})
+    assert store.load_session_snapshot("root-session") == {
+        "session_id": "root-session"
+    }
+
+    health = store.healthcheck()
+    assert health["backend"] == "filesystem"
+    assert health["healthy"] is True
+    assert health["available"] is True
+    assert health["writable"] is True
+    assert health["catalog_ready"] is True
+
+
+def test_filesystem_store_message_and_telemetry_operations_keep_legacy_layout(
+    tmp_path,
+):
+    store = create_session_store(session_root=str(tmp_path))
+    workspace = store.create_session_workspace("session-a")
+    store.register_session("session-a", workspace)
+
+    store.save_message_snapshot(
+        "session-a", [{"message_id": "m1", "role": "user", "content": "old"}]
+    )
+    store.append_message_event(
+        "session-a",
+        {
+            "op": "put_message",
+            "session_id": "session-a",
+            "message_id": "m1",
+            "seq": 1,
+            "message": {"message_id": "m1", "role": "user", "content": "new"},
+        },
+    )
+    ledger = store.load_message_ledger("session-a")
+    assert ledger.messages[0]["content"] == "new"
+    assert ledger.max_sequence == 1
+    assert ledger.journal_records == 1
+
+    store.save_compact_manifest("session-a", {"version": 1})
+    store.save_tools_usage("session-a", {"search": 2})
+    store.append_session_log("session-a", "first line\n")
+    store.append_session_log("session-a", "second line\n")
+    store.save_request_usage("session-a", "request-1", {"total_tokens": 3})
+    store.save_mcp_calls("session-a", "request-1", {"calls": []})
+
+    assert json.loads(
+        open(os.path.join(workspace, "tools_usage.json"), encoding="utf-8").read()
+    ) == {"search": 2}
+    assert os.path.isfile(
+        os.path.join(workspace, "tokens_usage", "request-1.json")
+    )
+    assert os.path.isfile(os.path.join(workspace, "mcp_calls", "request-1.json"))
+    assert open(
+        os.path.join(workspace, "session_session-a.log"), encoding="utf-8"
+    ).read() == "first line\nsecond line\n"
+    assert store.read_session_log_tail("session-a", max_bytes=12) == "second line\n"
+    assert store.read_session_log_tail("missing", max_bytes=100) == ""
+
+
+def test_session_manager_uses_injected_store_and_migrates_legacy_sessions(tmp_path):
+    legacy_workspace = tmp_path / "legacy-session"
+    legacy_workspace.mkdir()
+    (legacy_workspace / "messages.json").write_text("[]", encoding="utf-8")
+    manager = SessionManager(
+        str(tmp_path),
+        enable_obs=False,
+        storage_config={"backend": "filesystem"},
+    )
+
+    assert manager.get_session_workspace("legacy-session") == str(legacy_workspace)
+
+
+def test_filesystem_store_exports_session_without_exposing_directory_walk(tmp_path):
+    store = create_session_store(session_root=str(tmp_path))
+    workspace = store.create_session_workspace("session-a")
+    store.register_session("session-a", workspace)
+    store.save_session_snapshot("session-a", {"session_id": "session-a"})
+
+    archive_path = store.export_session_archive("session-a")
+
+    with zipfile.ZipFile(archive_path) as archive:
+        assert "session-a/session_context.json" in archive.namelist()

--- a/tests/sagents/storage/test_filesystem_storage_contract.py
+++ b/tests/sagents/storage/test_filesystem_storage_contract.py
@@ -8,6 +8,7 @@ continue to produce and consume this layout and payload shape.
 import json
 import os
 import sqlite3
+import time
 
 from sagents.context.messages.message import MessageChunk, MessageRole
 from sagents.context.session_context import MESSAGE_JOURNAL_FILE, SessionContext
@@ -189,8 +190,10 @@ def test_llm_request_files_remain_numbered_json_records(tmp_path):
         {"request": {"step_name": "execute"}, "response": {"ok": 2}, "timestamp": 2.0}
     )
 
-    assert os.path.basename(first) == "0_plan_19700101000001.json"
-    assert os.path.basename(second) == "1_execute_19700101000002.json"
+    first_stamp = time.strftime("%Y%m%d%H%M%S", time.localtime(1.0))
+    second_stamp = time.strftime("%Y%m%d%H%M%S", time.localtime(2.0))
+    assert os.path.basename(first) == f"0_plan_{first_stamp}.json"
+    assert os.path.basename(second) == f"1_execute_{second_stamp}.json"
     payload = json.loads(open(second, encoding="utf-8").read())
     assert payload == {
         "schema_version": 2,

--- a/tests/sagents/storage/test_filesystem_storage_contract.py
+++ b/tests/sagents/storage/test_filesystem_storage_contract.py
@@ -1,0 +1,204 @@
+"""Characterization tests for the legacy session-root filesystem contract.
+
+These tests intentionally exercise the pre-abstraction public behaviour.  A
+storage implementation may change internally, but the filesystem backend must
+continue to produce and consume this layout and payload shape.
+"""
+
+import json
+import os
+import sqlite3
+
+from sagents.context.messages.message import MessageChunk, MessageRole
+from sagents.context.session_context import MESSAGE_JOURNAL_FILE, SessionContext
+from sagents.session_registry import SessionRegistry
+
+
+def _context(root, session_id="session-a"):
+    context = SessionContext(
+        session_id=session_id,
+        user_id="user-a",
+        agent_id="agent-a",
+        session_root_space=str(root),
+    )
+    context.session_workspace = os.path.join(str(root), session_id)
+    os.makedirs(context.session_workspace, exist_ok=True)
+    return context
+
+
+def test_session_save_preserves_filesystem_layout_and_payloads(tmp_path):
+    context = _context(tmp_path)
+    context.add_messages(
+        MessageChunk(
+            role=MessageRole.USER.value,
+            content="hello",
+            message_id="message-1",
+            tool_calls=[
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        )
+    )
+
+    context.save()
+
+    workspace = tmp_path / "session-a"
+    assert {path.name for path in workspace.iterdir()} == {
+        "messages.json",
+        MESSAGE_JOURNAL_FILE,
+        "compact_manifest.json",
+        "session_context.json",
+        "tools_usage.json",
+    }
+    assert not (workspace / "messages.json.tmp").exists()
+
+    messages = json.loads((workspace / "messages.json").read_text("utf-8"))
+    snapshot = json.loads((workspace / "session_context.json").read_text("utf-8"))
+    tools_usage = json.loads((workspace / "tools_usage.json").read_text("utf-8"))
+
+    assert messages[0]["message_id"] == "message-1"
+    assert snapshot["session_id"] == "session-a"
+    assert snapshot["session_root_space"] == str(tmp_path)
+    assert snapshot["session_workspace"] == str(workspace)
+    assert tools_usage == {"search": 1}
+    assert (workspace / MESSAGE_JOURNAL_FILE).read_text("utf-8") == ""
+
+
+def test_message_ledger_loads_snapshot_then_replays_journal(tmp_path):
+    context = _context(tmp_path)
+    workspace = tmp_path / "session-a"
+    original = MessageChunk(
+        role=MessageRole.USER.value,
+        content="old",
+        message_id="message-1",
+    ).to_dict()
+    updated = {**original, "content": "new"}
+    appended = MessageChunk(
+        role=MessageRole.ASSISTANT.value,
+        content="answer",
+        message_id="message-2",
+    ).to_dict()
+    (workspace / "messages.json").write_text(json.dumps([original]), "utf-8")
+    records = [
+        {
+            "schema_version": 1,
+            "op": "put_message",
+            "session_id": context.session_id,
+            "message_id": "message-1",
+            "seq": 4,
+            "timestamp": 1.0,
+            "reason": "update",
+            "message": updated,
+        },
+        {
+            "schema_version": 1,
+            "op": "put_message",
+            "session_id": context.session_id,
+            "message_id": "message-2",
+            "seq": 5,
+            "timestamp": 2.0,
+            "reason": "append",
+            "message": appended,
+        },
+    ]
+    (workspace / MESSAGE_JOURNAL_FILE).write_text(
+        "".join(json.dumps(record) + "\n" for record in records), "utf-8"
+    )
+
+    messages, max_sequence, journal_count = (
+        SessionContext.load_persisted_message_ledger(
+            str(workspace), session_id=context.session_id
+        )
+    )
+
+    assert [(message.message_id, message.content) for message in messages] == [
+        ("message-1", "new"),
+        ("message-2", "answer"),
+    ]
+    assert max_sequence == 5
+    assert journal_count == 2
+
+
+def test_message_ledger_replays_journal_when_snapshot_is_corrupt(tmp_path):
+    context = _context(tmp_path)
+    workspace = tmp_path / "session-a"
+    (workspace / "messages.json").write_text("{truncated", "utf-8")
+    message = MessageChunk(
+        role=MessageRole.USER.value,
+        content="recovered",
+        message_id="message-1",
+    ).to_dict()
+    record = {
+        "schema_version": 1,
+        "op": "put_message",
+        "session_id": context.session_id,
+        "message_id": "message-1",
+        "seq": 1,
+        "timestamp": 1.0,
+        "reason": "recovery",
+        "message": message,
+    }
+    (workspace / MESSAGE_JOURNAL_FILE).write_text(
+        json.dumps(record) + "\n", "utf-8"
+    )
+
+    messages, max_sequence, journal_count = (
+        SessionContext.load_persisted_message_ledger(
+            str(workspace), session_id=context.session_id
+        )
+    )
+
+    assert [item.content for item in messages] == ["recovered"]
+    assert max_sequence == 1
+    assert journal_count == 1
+
+
+def test_registry_stores_relative_workspace_and_preserves_parent_relation(tmp_path):
+    root = tmp_path / "sessions"
+    db_path = root / "sessions_index.sqlite"
+    workspace = root / "parent" / "sub_sessions" / "child"
+    registry = SessionRegistry(str(db_path), root_dir=str(root))
+    try:
+        registry.register("child", str(workspace), parent_session_id="parent")
+        assert registry.get_workspace("child") == str(workspace)
+        assert registry.is_sub_session("child") is True
+        assert registry.get_parent_session_id("child") == "parent"
+    finally:
+        registry.close()
+
+    connection = sqlite3.connect(db_path)
+    try:
+        stored_workspace = connection.execute(
+            "SELECT workspace FROM sessions WHERE session_id = ?", ("child",)
+        ).fetchone()[0]
+    finally:
+        connection.close()
+
+    assert stored_workspace == os.path.join("parent", "sub_sessions", "child")
+
+
+def test_llm_request_files_remain_numbered_json_records(tmp_path):
+    context = _context(tmp_path)
+    first = context._save_llm_request_sync(
+        {"request": {"step_name": "plan"}, "response": {"ok": 1}, "timestamp": 1.0}
+    )
+    second = context._save_llm_request_sync(
+        {"request": {"step_name": "execute"}, "response": {"ok": 2}, "timestamp": 2.0}
+    )
+
+    assert os.path.basename(first) == "0_plan_19700101000001.json"
+    assert os.path.basename(second) == "1_execute_19700101000002.json"
+    payload = json.loads(open(second, encoding="utf-8").read())
+    assert payload == {
+        "schema_version": 2,
+        "request": {"step_name": "execute"},
+        "response": {"ok": 2},
+        "metadata": {
+            "step_name": "execute",
+            "request_view": "pre_adapter_fallback",
+        },
+        "timestamp": 2.0,
+    }

--- a/tests/sagents/storage/test_session_store_factory.py
+++ b/tests/sagents/storage/test_session_store_factory.py
@@ -1,0 +1,43 @@
+import pytest
+
+from sagents.storage import (
+    SessionStorageConfig,
+    StorageError,
+    create_session_store,
+)
+
+
+def test_factory_builds_default_backend_from_session_root(tmp_path):
+    store = create_session_store(session_root=str(tmp_path))
+
+    assert store.healthcheck()["backend"] == "filesystem"
+    assert store.root == str(tmp_path)
+
+
+def test_factory_accepts_backend_neutral_config(tmp_path):
+    store = create_session_store(
+        SessionStorageConfig(
+            backend="filesystem",
+            options={"root": str(tmp_path)},
+        )
+    )
+
+    assert store.root == str(tmp_path)
+
+
+def test_factory_reads_environment_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("SAGE_SESSION_STORAGE_BACKEND", "filesystem")
+    monkeypatch.setenv(
+        "SAGE_SESSION_STORAGE_OPTIONS", f'{{"root": "{tmp_path}"}}'
+    )
+
+    store = create_session_store()
+
+    assert store.root == str(tmp_path)
+
+
+def test_factory_rejects_unknown_backend(tmp_path):
+    with pytest.raises(StorageError, match="unsupported session storage backend"):
+        create_session_store(
+            {"backend": "unknown", "options": {"root": str(tmp_path)}}
+        )

--- a/tests/sagents/test_session_runtime_lifecycle.py
+++ b/tests/sagents/test_session_runtime_lifecycle.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-import sqlite3
 
 import pytest
 
@@ -203,11 +202,10 @@ async def test_sync_cross_thread_close_has_bounded_wait(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_shutdown_closes_session_registry_connection(tmp_path):
+async def test_shutdown_closes_session_storage(tmp_path):
     manager = SessionManager(str(tmp_path), enable_obs=False)
-    assert manager._registry._conn.execute("SELECT 1").fetchone() == (1,)
+    assert manager.storage.healthcheck()["catalog_ready"] is True
 
     await manager.shutdown()
 
-    with pytest.raises(sqlite3.ProgrammingError):
-        manager._registry._conn.execute("SELECT 1")
+    assert manager.storage.healthcheck()["initialized"] is False

--- a/tests/sagents/utils/test_logger_file_logging.py
+++ b/tests/sagents/utils/test_logger_file_logging.py
@@ -63,9 +63,13 @@ def test_session_logger_is_unregistered_and_cannot_be_recreated_after_close(
     logger_module = _load_logger_module(monkeypatch)
     monkeypatch.delenv("SAGE_DISABLE_SAGENTS_FILE_LOGGING", raising=False)
 
+    class FakeStore:
+        def append_session_log(self, _session_id, _text):
+            return ""
+
     live_sessions = {
         "finished-session": types.SimpleNamespace(
-            session_context=types.SimpleNamespace(session_workspace=str(tmp_path)),
+            session_context=types.SimpleNamespace(storage=FakeStore()),
             status=types.SimpleNamespace(value="running"),
         )
     }


### PR DESCRIPTION
## 背景

Agent 运行期间会在 `session_root` 下持久化 Session 状态、消息账本、日志、LLM 请求记录及派生数据。此前这些读写逻辑分散在运行时、服务层和 CLI 中，并直接依赖具体文件路径，不利于扩展其他存储后端。

## 主要改动

- 新增统一的 `SessionStore` 抽象，覆盖：
  - Session catalog 与父子关系
  - Session snapshot
  - Message snapshot 与 event journal
  - Tools usage 与 compact manifest
  - Session 日志
  - LLM request、token usage 与 MCP calls
  - 清理、归档和健康检查
- 新增配置驱动的 `create_session_store()` 工厂：
  - 外部不感知具体实现类
  - 根据配置选择存储后端
  - 当前仅实现 `filesystem` 后端
- 将 SessionManager、SessionContext、子 Agent 恢复、会话编辑、统计、清理和归档统一接入 Store。
- 将 CLI doctor 和近期 Session 日志读取接入 Store：
  - 不再直接识别 `sessions_index.sqlite`
  - 不再拼接或读取 `session_<id>.log`
- 将 legacy filesystem migration 下沉到 filesystemStore。
- 移除 logger 绕过 Store 的 FileHandler fallback。
- 保留原有 filesystem 文件布局、数据格式和功能行为。
- 修复损坏的 `messages.json` 阻断 journal 回放的问题。

## 兼容性

本次只提供抽象接口、工厂和 filesystemStore，不引入其他后端。

FilesystemStore 保持现有文件契约，包括：

- 文件及目录命名
- JSON/JSONL 数据格式
- 父子 Session 目录结构
- 消息 snapshot/journal 合并行为
- LLM request v2 与 provider attempts
- Session 日志与异步关闭生命周期