### PR TITLE
feat(skill): lazily materialize sandbox skills on load instead of eagerly on sync

### DIFF
--- a/sagents/skill/sandbox_skill_manager.py
+++ b/sagents/skill/sandbox_skill_manager.py
@@ -8,6 +8,7 @@
 保证 Agent 工作区里手动改过的 SKILL.md 不会被无脑覆盖。
 """
 
+import asyncio
 import os
 from typing import Any, Dict, List, Optional
 import yaml
@@ -34,7 +35,14 @@ class SandboxSkillManager:
         """
         self.sandbox = sandbox
         self.skills_dir = skills_dir
+        # 已落地：已拷进沙箱并从沙箱 SKILL.md 完整加载的技能（含沙箱路径/文件树）。
         self._skills_cache: Dict[str, SkillSchema] = {}
+        # 已知：宿主声明可用、但尚未落地到沙箱的技能元数据（name/description，
+        # path 为宿主源路径，供 load 时按需拷贝）。用于向模型广告全部技能，
+        # 而不必在会话初始化时把每个技能都拷进（PVC 场景下很慢的）用户工作区。
+        self._known_skills: Dict[str, SkillSchema] = {}
+        # 每技能落地锁：串行化"同一技能"的按需拷贝，避免并行 load_skill 竞态。
+        self._materialize_locks: Dict[str, asyncio.Lock] = {}
         self._cache_valid = False
 
     async def _read_file(self, path: str) -> str:
@@ -155,21 +163,27 @@ class SandboxSkillManager:
 
         return "\n".join(filter(None, lines))
 
+    def _merged_skills(self) -> Dict[str, SkillSchema]:
+        """已知 ∪ 已落地，已落地（沙箱视图）优先。"""
+        merged = dict(self._known_skills)
+        merged.update(self._skills_cache)
+        return merged
+
     def list_skills(self) -> List[str]:
-        """列出所有技能名称"""
-        return list(self._skills_cache.keys())
+        """列出所有技能名称（已落地 + 已知未落地）"""
+        return sorted(set(self._known_skills) | set(self._skills_cache))
 
     def get_skill(self, name: str) -> Optional[SkillSchema]:
-        """获取技能"""
-        return self._skills_cache.get(name)
+        """获取技能（已落地优先，否则返回已知元数据）"""
+        return self._skills_cache.get(name) or self._known_skills.get(name)
 
     @property
     def skills(self) -> Dict[str, SkillSchema]:
-        """获取所有技能字典"""
-        return self._skills_cache.copy()
+        """获取所有技能字典（已知 ∪ 已落地）"""
+        return self._merged_skills()
 
     def get_skill_metadata(self, name: str) -> Optional[Dict[str, Any]]:
-        skill = self._skills_cache.get(name)
+        skill = self._skills_cache.get(name) or self._known_skills.get(name)
         if not skill:
             return None
         return {
@@ -193,87 +207,131 @@ class SandboxSkillManager:
         return lines
 
     def list_skill_info(self) -> List[SkillSchema]:
-        """与 SkillManager.list_skill_info 对齐，供 system prompt 等使用。"""
-        return list(self._skills_cache.values())
+        """与 SkillManager.list_skill_info 对齐，供 system prompt 等使用。
+        返回已知 ∪ 已落地（已落地优先），保证广告到全部可用技能。"""
+        return list(self._merged_skills().values())
 
     async def sync_from_host(self, host_skill_manager) -> None:
         """
-        按宿主 SkillProxy / SkillManager 给出的技能名称对齐沙箱内技能：
+        按宿主 SkillProxy / SkillManager 给出的可用技能对齐沙箱技能视图（懒加载）。
 
-        1. 沙箱 ``skills_dir/<name>/SKILL.md`` 已存在 → 直接以沙箱内容为准加载
-           （保留用户在 Agent workspace 里的手改）。
-        2. 沙箱里没有该技能目录，但宿主有对应 SkillSchema.path → 一次性
-           ``copy_from_host`` 拷到沙箱后再加载（按需补齐，不覆盖已有）。
-        3. 宿主也没有 → 记 warning 跳过。
+        会话初始化时**不**再把技能文件逐个拷进沙箱，只做两件轻量的事：
+
+        1. 登记全部"已知技能"元数据（name/description + 宿主源路径），供向模型
+           广告可用技能；真正把技能拷进 ``<sandbox>/skills/<name>/`` 的动作推迟到
+           ``ensure_materialized``（由 load_skill 在需要读取技能文件时触发）。
+        2. 加载沙箱里**已存在**（用户在 Agent workspace 手动加/改过）的技能，
+           使其优先生效、且手改不被覆盖。
+
+        这样新用户（尤其挂载 PVC 的远端沙箱）不必在启动时逐个拷贝并索引全部
+        系统技能——那是慢的根因；只有真正被 load 的技能才落地到工作区。
 
         Args:
             host_skill_manager: 宿主侧 SkillManager / SkillProxy
         """
         self._skills_cache.clear()
+        self._known_skills.clear()
         allowed_names = list(host_skill_manager.list_skills())
         if not allowed_names:
             logger.debug("沙箱技能：宿主未声明可用技能，跳过加载")
             return
 
-        # 沙箱根目录不存在时主动建一次（首次会话场景）
-        if not await self._file_exists(self.skills_dir):
-            try:
+        host_skills = getattr(host_skill_manager, "skills", {}) or {}
+
+        # 1) 登记"已知技能"元数据（不拷文件）
+        for skill_name in allowed_names:
+            host_skill = host_skills.get(skill_name)
+            if host_skill is not None:
+                self._known_skills[skill_name] = host_skill
+            else:
+                logger.warning(f"宿主未提供技能 '{skill_name}' 的元数据，跳过")
+
+        # 2) 加载沙箱内已存在的技能（用户手改优先，不覆盖）
+        if await self._file_exists(self.skills_dir):
+            for skill_name in allowed_names:
+                skill_path = os.path.join(self.skills_dir, skill_name)
+                skill_md_path = os.path.join(skill_path, "SKILL.md")
+                if await self._file_exists(skill_md_path):
+                    skill = await self._load_skill_from_dir(skill_path)
+                    if skill:
+                        self._skills_cache[skill_name] = skill
+                    else:
+                        logger.warning(
+                            f"沙箱已存在 SKILL.md 但解析失败，保留现状: {skill_md_path}"
+                        )
+
+        logger.debug(
+            f"沙箱技能视图就绪：已知 {len(self._known_skills)} 个，"
+            f"已落地 {list(self._skills_cache.keys())}"
+        )
+
+    async def ensure_materialized(self, skill_name: str) -> Optional[SkillSchema]:
+        """确保技能已落地到沙箱，并返回其（沙箱内的）SkillSchema。
+
+        懒加载的落地点，由 load_skill 在真正需要读取技能文件时调用：
+
+        - 已落地 → 直接返回缓存；
+        - 已知但未落地 → 现在从宿主源路径 ``copy_from_host`` 到
+          ``<sandbox>/skills/<name>/``，再从沙箱加载、缓存后返回；
+        - 未知 → 返回 None。
+        """
+        existing = self._skills_cache.get(skill_name)
+        if existing is not None:
+            return existing
+
+        known = self._known_skills.get(skill_name)
+        if known is None:
+            return None
+
+        host_path = getattr(known, "path", None)
+        if not host_path or not os.path.isdir(host_path):
+            logger.warning(
+                f"技能 '{skill_name}' 无有效宿主源路径，无法落地: {host_path}"
+            )
+            return None
+
+        # 串行化"同一技能"的落地：并行 load_skill 可能对同一目录并发拷贝
+        # （local 的 copy 会先 rmtree 目标），必须避免竞态。dict.setdefault 在
+        # 事件循环里不含 await，可原子地为每个技能创建一把锁。
+        lock = self._materialize_locks.setdefault(skill_name, asyncio.Lock())
+        async with lock:
+            # 双检：等锁期间可能已被其它协程落地
+            existing = self._skills_cache.get(skill_name)
+            if existing is not None:
+                return existing
+
+            # 沙箱根目录按需建一次
+            if not await self._file_exists(self.skills_dir):
                 ensure_dir = getattr(self.sandbox, "ensure_directory", None)
                 if callable(ensure_dir):
                     await ensure_dir(self.skills_dir)  # pyright: ignore[reportGeneralTypeIssues]
-                    logger.info(f"沙箱技能目录已创建: {self.skills_dir}")
                 else:
                     logger.warning(
                         f"沙箱技能目录不存在且无法创建（缺少 ensure_directory）: {self.skills_dir}"
                     )
-                    return
-            except Exception as e:
-                logger.warning(f"沙箱技能目录创建失败 {self.skills_dir}: {e}")
-                return
+                    return None
 
-        host_skills = getattr(host_skill_manager, "skills", {}) or {}
-
-        for skill_name in allowed_names:
             skill_path = os.path.join(self.skills_dir, skill_name)
             skill_md_path = os.path.join(skill_path, "SKILL.md")
-
-            # 1) 沙箱已存在 → 直接加载，不动手
-            if await self._file_exists(skill_md_path):
-                skill = await self._load_skill_from_dir(skill_path)
-                if skill:
-                    self._skills_cache[skill_name] = skill
-                    continue
-                # SKILL.md 存在但解析失败：不再覆盖，只记 warning
+            try:
+                # 各 provider 返回值不统一，用 SKILL.md 是否落地作为最终判定依据。
+                await self.sandbox.copy_from_host(host_path, skill_path)
+            except Exception as e:
                 logger.warning(
-                    f"沙箱已存在 SKILL.md 但解析失败，保留现状: {skill_md_path}"
+                    f"技能按需落地失败 {skill_name}: {host_path} -> {skill_path}: {e}"
                 )
-                continue
+                return None
 
-            # 2) 沙箱缺失 → 尝试从宿主 SkillSchema.path 一次性拷贝
-            host_skill = host_skills.get(skill_name)
-            host_path = getattr(host_skill, "path", None) if host_skill else None
-            if host_path and os.path.isdir(host_path):
-                try:
-                    # 各 provider 返回值不统一（local/remote 返回 bool，passthrough
-                    # 不返回），用 SKILL.md 是否落地作为最终判定依据。
-                    await self.sandbox.copy_from_host(host_path, skill_path)
-                except Exception as e:
-                    logger.warning(
-                        f"沙箱补齐技能失败 {skill_name}: {host_path} -> {skill_path}: {e}"
-                    )
-                    continue
-                if not await self._file_exists(skill_md_path):
-                    logger.warning(f"沙箱补齐后未发现 SKILL.md: {skill_md_path}")
-                    continue
-                logger.info(f"沙箱技能补齐: {skill_name} ({host_path} -> {skill_path})")
-                skill = await self._load_skill_from_dir(skill_path)
-                if skill:
-                    self._skills_cache[skill_name] = skill
-                else:
-                    logger.warning(f"沙箱技能补齐后仍无法加载 SKILL.md: {skill_path}")
-                continue
+            if not await self._file_exists(skill_md_path):
+                logger.warning(f"技能落地后未发现 SKILL.md: {skill_md_path}")
+                return None
 
-            # 3) 宿主也没有该技能
-            logger.warning(f"沙箱与宿主均未提供技能 '{skill_name}'，跳过")
-
-        logger.debug(f"沙箱技能已就绪: {list(self._skills_cache.keys())}")
+            skill = await self._load_skill_from_dir(skill_path)
+            if skill:
+                self._skills_cache[skill_name] = skill
+                logger.info(
+                    f"技能按需落地: {skill_name} ({host_path} -> {skill_path})"
+                )
+            else:
+                logger.warning(f"技能落地后仍无法加载 SKILL.md: {skill_path}")
+            return skill

--- a/sagents/skill/skill_tool.py
+++ b/sagents/skill/skill_tool.py
@@ -21,7 +21,7 @@ class SkillTool:
             }
         },
     )
-    def load_skill(self, skill_name: str, session_id: str = None) -> str:  # pyright: ignore[reportArgumentType]
+    async def load_skill(self, skill_name: str, session_id: str = None) -> str:  # pyright: ignore[reportArgumentType]
         """
         Load a skill into the current context.
         加载一个技能到当前上下文中。
@@ -55,8 +55,15 @@ class SkillTool:
         else:
             raise ValueError(tool_t("skill.error.manager_unavailable"))
 
-        # 检查技能是否存在
-        if skill_name not in skill_manager.skills:
+        # 懒加载：确保技能已落地到沙箱（首次调用会现拷），再读取其文件信息。
+        # 未落地的系统技能不占用启动时间，只有真正 load 的才拷进工作区。
+        ensure = getattr(skill_manager, "ensure_materialized", None)
+        if callable(ensure):
+            skill = await ensure(skill_name)
+        else:
+            # 兼容不支持懒加载的旧管理器
+            skill = skill_manager.skills.get(skill_name)
+        if skill is None:
             return tool_t(
                 "skill.error.not_found",
                 params={
@@ -64,9 +71,6 @@ class SkillTool:
                     "available": ", ".join(skill_manager.list_skills()),
                 },
             )
-
-        # 获取技能信息
-        skill = skill_manager.skills[skill_name]
 
         # 获取沙箱虚拟路径（通过统一接口）
         sandbox_virtual_path = "/sage-workspace"  # 默认值

--- a/tests/sagents/skill/test_sandbox_skill_lazy.py
+++ b/tests/sagents/skill/test_sandbox_skill_lazy.py
@@ -1,0 +1,208 @@
+"""沙箱技能懒加载行为测试。
+
+验证 SandboxSkillManager：
+- 会话初始化（sync_from_host）不再逐个拷贝技能，只登记"已知"元数据；
+- 全部技能仍被广告给模型（list_skills / list_skill_info）；
+- 真正 load 时（ensure_materialized）才把该技能拷进沙箱，且只拷一次；
+- 落地一个技能后，广告列表不会缩水成一个（守护 effective_skill_manager 回归）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from types import SimpleNamespace
+
+from sagents.skill.sandbox_skill_manager import SandboxSkillManager
+from sagents.skill.skill_schema import SkillSchema
+
+
+class FakeSandbox:
+    """带内存文件系统的假沙箱，copy_from_host 从真实宿主目录读入。"""
+
+    def __init__(self):
+        self.files: dict[str, str] = {}
+        self.dirs: set[str] = set()
+        self.copy_calls: list[tuple[str, str]] = []
+
+    async def file_exists(self, path):
+        p = path.rstrip("/")
+        return p in self.files or p in self.dirs
+
+    async def read_file(self, path, encoding="utf-8"):
+        return self.files[path.rstrip("/")]
+
+    async def ensure_directory(self, path):
+        self.dirs.add(path.rstrip("/"))
+
+    async def list_directory(self, path, include_hidden=False):
+        base = path.rstrip("/")
+        entries = []
+        seen = set()
+        for f in list(self.files) + list(self.dirs):
+            if f == base or not f.startswith(base + "/"):
+                continue
+            child = f[len(base) + 1:].split("/")[0]
+            child_path = base + "/" + child
+            if child_path in seen:
+                continue
+            seen.add(child_path)
+            is_dir = child_path in self.dirs or any(
+                x.startswith(child_path + "/") for x in list(self.files) + list(self.dirs)
+            )
+            entries.append(
+                SimpleNamespace(
+                    path=child_path,
+                    is_dir=is_dir,
+                    is_file=not is_dir,
+                    size=0,
+                    modified_time=0.0,
+                )
+            )
+        return entries
+
+    async def copy_from_host(self, host_path, sandbox_path):
+        self.copy_calls.append((host_path, sandbox_path))
+        # 主动让出控制权，逼出并发交错（用于验证落地锁）
+        await asyncio.sleep(0)
+        sp = sandbox_path.rstrip("/")
+        self.dirs.add(sp)
+        for root, subdirs, filenames in os.walk(host_path):
+            rel = os.path.relpath(root, host_path)
+            vbase = sp if rel == "." else sp + "/" + rel.replace(os.sep, "/")
+            self.dirs.add(vbase)
+            for d in subdirs:
+                self.dirs.add(vbase + "/" + d)
+            for fn in filenames:
+                with open(os.path.join(root, fn), "r", encoding="utf-8") as fh:
+                    self.files[vbase + "/" + fn] = fh.read()
+
+
+class FakeHostSkillManager:
+    def __init__(self, skills: dict[str, SkillSchema]):
+        self._skills = skills
+
+    def list_skills(self):
+        return list(self._skills.keys())
+
+    @property
+    def skills(self):
+        return self._skills
+
+
+def _make_host_skill(tmp_path, name, description, extra=None):
+    d = tmp_path / "host_skills" / name
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n# {name}\n",
+        encoding="utf-8",
+    )
+    for fn, content in (extra or {}).items():
+        (d / fn).write_text(content, encoding="utf-8")
+    return SkillSchema(name=name, description=description, path=str(d))
+
+
+def _host_with(tmp_path, *specs):
+    return FakeHostSkillManager(
+        {name: _make_host_skill(tmp_path, name, desc) for name, desc in specs}
+    )
+
+
+SKILLS_DIR = "/sage-workspace/skills"
+
+
+async def test_sync_registers_known_without_copying(tmp_path):
+    host = _host_with(tmp_path, ("alpha", "Alpha skill"), ("beta", "Beta skill"))
+    sandbox = FakeSandbox()
+    mgr = SandboxSkillManager(sandbox, skills_dir=SKILLS_DIR)
+
+    await mgr.sync_from_host(host)
+
+    # 关键：初始化时零拷贝
+    assert sandbox.copy_calls == []
+    # 但全部技能都被广告
+    assert mgr.list_skills() == ["alpha", "beta"]
+    assert {s.name for s in mgr.list_skill_info()} == {"alpha", "beta"}
+    # 没有任何技能落地
+    assert mgr._skills_cache == {}
+
+
+async def test_ensure_materialized_copies_once(tmp_path):
+    host = _host_with(tmp_path, ("alpha", "Alpha skill"), ("beta", "Beta skill"))
+    sandbox = FakeSandbox()
+    mgr = SandboxSkillManager(sandbox, skills_dir=SKILLS_DIR)
+    await mgr.sync_from_host(host)
+
+    skill = await mgr.ensure_materialized("alpha")
+    assert skill is not None
+    assert skill.name == "alpha"
+    assert skill.path == f"{SKILLS_DIR}/alpha"
+    assert len(sandbox.copy_calls) == 1
+    assert "alpha" in mgr._skills_cache
+
+    # 二次调用不重复拷贝，直接返回缓存
+    again = await mgr.ensure_materialized("alpha")
+    assert again is skill or again.name == "alpha"
+    assert len(sandbox.copy_calls) == 1
+
+
+async def test_advertising_stays_complete_after_materializing_one(tmp_path):
+    """落地一个技能后，广告列表仍是全部，不缩水（守护回归）。"""
+    host = _host_with(tmp_path, ("alpha", "Alpha skill"), ("beta", "Beta skill"))
+    sandbox = FakeSandbox()
+    mgr = SandboxSkillManager(sandbox, skills_dir=SKILLS_DIR)
+    await mgr.sync_from_host(host)
+
+    await mgr.ensure_materialized("alpha")
+
+    assert mgr.list_skills() == ["alpha", "beta"]
+    assert {s.name for s in mgr.list_skill_info()} == {"alpha", "beta"}
+
+
+async def test_concurrent_ensure_materialized_copies_once(tmp_path):
+    """两个协程并发落地同一技能，落地锁保证只拷一次。"""
+    host = _host_with(tmp_path, ("alpha", "Alpha skill"))
+    sandbox = FakeSandbox()
+    mgr = SandboxSkillManager(sandbox, skills_dir=SKILLS_DIR)
+    await mgr.sync_from_host(host)
+
+    results = await asyncio.gather(
+        mgr.ensure_materialized("alpha"),
+        mgr.ensure_materialized("alpha"),
+    )
+
+    assert all(r is not None and r.name == "alpha" for r in results)
+    assert len(sandbox.copy_calls) == 1
+
+
+async def test_ensure_materialized_unknown_returns_none(tmp_path):
+    host = _host_with(tmp_path, ("alpha", "Alpha skill"))
+    sandbox = FakeSandbox()
+    mgr = SandboxSkillManager(sandbox, skills_dir=SKILLS_DIR)
+    await mgr.sync_from_host(host)
+
+    assert await mgr.ensure_materialized("missing") is None
+    assert sandbox.copy_calls == []
+
+
+async def test_preexisting_sandbox_skill_loaded_without_copy(tmp_path):
+    """沙箱里已有（用户手加/手改）的技能在 sync 时直接加载，不触发拷贝。"""
+    host = _host_with(tmp_path, ("alpha", "Alpha skill"))
+    sandbox = FakeSandbox()
+    # 预置沙箱内已有 alpha（内容与宿主不同，模拟用户手改）
+    sandbox.dirs.add(SKILLS_DIR)
+    sandbox.dirs.add(f"{SKILLS_DIR}/alpha")
+    sandbox.files[f"{SKILLS_DIR}/alpha/SKILL.md"] = (
+        "---\nname: alpha\ndescription: user edited\n---\n# alpha edited\n"
+    )
+    mgr = SandboxSkillManager(sandbox, skills_dir=SKILLS_DIR)
+
+    await mgr.sync_from_host(host)
+
+    assert sandbox.copy_calls == []
+    assert "alpha" in mgr._skills_cache
+    # 已落地的是沙箱内的手改版
+    assert mgr._skills_cache["alpha"].description == "user edited"
+    # 再 ensure 也不会重新拷贝
+    await mgr.ensure_materialized("alpha")
+    assert sandbox.copy_calls == []

--- a/tests/sagents/tool/test_builtin_tool_i18n.py
+++ b/tests/sagents/tool/test_builtin_tool_i18n.py
@@ -193,7 +193,10 @@ async def test_tool_language_context_is_isolated_between_concurrent_tasks():
     assert get_tool_language() == "en"
 
 
-def test_load_skill_localizes_sage_headings_but_preserves_skill_content(monkeypatch):
+@pytest.mark.asyncio
+async def test_load_skill_localizes_sage_headings_but_preserves_skill_content(
+    monkeypatch,
+):
     skill = SimpleNamespace(
         name="demo-skill",
         file_list="- SKILL.md\n- scripts/run.py",
@@ -213,7 +216,7 @@ def test_load_skill_localizes_sage_headings_but_preserves_skill_content(monkeypa
     )
 
     with tool_language("pt-BR"):
-        result = SkillTool().load_skill("demo-skill", session_id="session-1")
+        result = await SkillTool().load_skill("demo-skill", session_id="session-1")
 
     injected = context.system_context["active_skills"][0]["skill_content"]
     assert "Caminho da pasta do skill" in injected

--- a/tests/sagents/utils/sandbox/test_lifecycle_e2e.py
+++ b/tests/sagents/utils/sandbox/test_lifecycle_e2e.py
@@ -48,7 +48,14 @@ def test_sandbox_lifecycle_syncs_skill_and_executes_python(tmp_path, mode):
                 workdir=sandbox.workspace_path,
             )
 
+            # 懒加载：sync 只登记/广告技能，不把文件落地到工作区
             assert sandbox_skills.list_skills() == ["e2e-skill"]
+            assert not await sandbox.file_exists(
+                f"{sandbox.workspace_path}/skills/e2e-skill/SKILL.md"
+            )
+            # 按需落地（load_skill 触发的动作）后，技能文件才出现在工作区
+            materialized = await sandbox_skills.ensure_materialized("e2e-skill")
+            assert materialized is not None
             assert await sandbox.file_exists(
                 f"{sandbox.workspace_path}/skills/e2e-skill/SKILL.md"
             )


### PR DESCRIPTION
## Summary

Session initialization eagerly copied **every** allowed skill — including all built-in system skills — into the per-session sandbox workspace (`SandboxSkillManager.sync_from_host`). On a workspace backed by a mounted PVC, this per-user bulk copy (and the incremental memory-index scan that then picks the files up) is slow at session start, even though most sessions use few or no skills, and system skills are read-only and identical for every user.

This PR makes skill materialization **lazy**: skills are advertised to the model up front from host metadata, but a skill's files are only copied into the workspace when the agent actually loads that skill.

## The change

`SandboxSkillManager` now separates two views:

- **known** — advertised metadata from the host `SkillManager` (name / description + host source path). Populated at sync with no file I/O.
- **materialized** — copied into `<workspace>/skills/<name>/` and loaded from its `SKILL.md` (sandbox path, instructions, file tree).

Concretely:

1. **`sync_from_host` no longer copies skill files.** It registers all allowed skills as *known*, and additionally loads any skills that already exist in the sandbox — preserving skills a user added or hand-edited in their Agent workspace, which continue to take priority over the host copy.
2. **New `ensure_materialized(name)`** performs the `copy_from_host` on demand, loads the skill from the sandbox, and caches it. It's idempotent (already-materialized → returns cache; unknown → `None`).
3. **`load_skill` is now `async`** and calls `ensure_materialized`, so a skill's files land in the workspace exactly when the agent loads it — and only then. A small compat fallback keeps working with managers that don't expose `ensure_materialized`.
4. **Listing methods** (`list_skills` / `list_skill_info` / `skills` / `get_skill*`) return the **union** of known and materialized skills, so the advertised set stays complete both before and after any materialization.

## Why this is safe

- **The model still sees every skill.** Advertising uses only `name` + `description` (see `agent_base` `available_skills` and `get_skill_description_lines`), which come from host metadata — no files needed. This also avoids a regression where, once one skill materialized, `effective_skill_manager` would switch to the sandbox manager and previously would have advertised only the materialized skill; the union keeps advertising complete (covered by a test).
- **A skill only needs its files present to be *used*** (the agent reads them after `load_skill` returns the folder path). `ensure_materialized` guarantees they're present before that.
- **The memory index is untouched.** It scans the workspace incrementally, so a lazily materialized skill is picked up on the next update automatically; unused skills are never copied and therefore never scanned/indexed per user.
- **User-authored / hand-edited skills** in the sandbox are still loaded at sync and take priority — unchanged.

## Behavior change (please note for review)

`sync_skills` no longer materializes skills on disk. The only observable contract change is timing: after `sync_skills`, skills are advertised but their files are not yet in the workspace; they appear after the first `load_skill` / `ensure_materialized`.

- Updated `tests/sagents/utils/sandbox/test_lifecycle_e2e.py` to assert the lazy contract end-to-end on the real Local/Passthrough providers: after `sync_skills` the skill is advertised (`list_skills()`) but **not** yet on disk, and only present after `ensure_materialized`. (Strengthened, not weakened — it now verifies the full advertise → materialize → present lifecycle.)
- Updated `test_load_skill_localizes_...` to `await` the now-async `load_skill`.

## Tests

- New `tests/sagents/skill/test_sandbox_skill_lazy.py` (5 cases): sync registers known without copying; `ensure_materialized` copies once and is idempotent; advertising stays complete after materializing one skill; unknown skill → `None`; pre-existing sandbox skill loaded at sync without a copy.
- Full `tests/sagents` + `tests/common`: **1415 passed, 3 skipped**. Ruff clean.

## Out of scope

- No change to the memory index / retriever (it follows the workspace incrementally, as above).
- No change to remote-provider infra (no shared read-only skill volume introduced); this keeps everything to the existing copy-into-workspace model, just deferred to load time.
