### PR TITLE
fix: support MiniMax structured reasoning

### DIFF
--- a/common/services/model_invocation_service.py
+++ b/common/services/model_invocation_service.py
@@ -24,6 +24,7 @@ from sagents.llm.model_capabilities import (
     resolve_reasoning_effort,
     uses_aliyun_model_studio_protocol,
     uses_deepseek_native_protocol,
+    uses_minimax_native_protocol,
     uses_zhipu_native_protocol,
 )
 from sagents.utils.llm_request_utils import (
@@ -241,6 +242,16 @@ def _build_thinking_extra_body(
                 env_value=None,
                 default_off="medium",
             )
+        return extra_body
+
+    if uses_minimax_native_protocol(model, base_url):
+        extra_body["reasoning_split"] = True
+        if model.strip().lower().startswith("minimax-m3") and (
+            deep_thinking is not None or thinking_level is not None
+        ):
+            extra_body["thinking"] = {
+                "type": "adaptive" if enable_thinking else "disabled"
+            }
         return extra_body
 
     if deep_thinking is None and thinking_level is None:

--- a/sagents/agent/agent_base.py
+++ b/sagents/agent/agent_base.py
@@ -43,7 +43,11 @@ from sagents.context.messages.token_accounting import (
 )
 from sagents.llm.sage_openai import SageAsyncOpenAI
 from sagents.llm.capabilities import create_chat_completion_with_fallback
-from sagents.llm.model_capabilities import build_llm_extra_body
+from sagents.llm.minimax import MiniMaxStreamNormalizer
+from sagents.llm.model_capabilities import (
+    build_llm_extra_body,
+    uses_minimax_native_protocol,
+)
 from sagents.utils.llm_request_utils import (
     coalesce_reasoning_content_messages,
     format_api_error_details,
@@ -1781,6 +1785,7 @@ class AgentBase(ABC):
                                 "tool_calls",
                                 "tool_call_id",
                                 "reasoning_content",
+                                "reasoning_details",
                                 "_sage_message_id",
                                 "_sage_llm_response_id",
                                 "_sage_context_protected",
@@ -2015,7 +2020,14 @@ class AgentBase(ABC):
                     extra_body=extra_body,
                     **final_config,
                 )
+                minimax_stream_normalizer = (
+                    MiniMaxStreamNormalizer()
+                    if uses_minimax_native_protocol(model_name, active_base_url)
+                    else None
+                )
                 async for chunk in stream:
+                    if minimax_stream_normalizer is not None:
+                        chunk = minimax_stream_normalizer.normalize(chunk)
                     # print(chunk)
                     # 记录首token时间
                     if first_token_time is None:

--- a/sagents/agent/common_agent.py
+++ b/sagents/agent/common_agent.py
@@ -8,6 +8,7 @@ from sagents.utils.logger import logger
 from sagents.context.messages.message import MessageChunk, MessageRole, MessageType
 from sagents.context.session_context import SessionContext
 from sagents.tool.tool_manager import ToolManager
+from sagents.llm.minimax import serialize_reasoning_details
 
 # 通用可自定义agent
 
@@ -149,6 +150,9 @@ class CommonAgent(AgentBase):
             # print(chunk)
             if len(chunk.choices) == 0:
                 continue
+            reasoning_details = serialize_reasoning_details(
+                getattr(chunk.choices[0].delta, "reasoning_details", None)
+            )
             if chunk.choices[0].delta.tool_calls:
                 self._handle_tool_calls_chunk(chunk, tool_calls, last_tool_call_id)  # pyright: ignore[reportArgumentType]
                 # 更新last_tool_call_id
@@ -164,6 +168,7 @@ class CommonAgent(AgentBase):
                         MessageChunk(
                             role=MessageRole.ASSISTANT.value,
                             tool_calls=chunk.choices[0].delta.tool_calls,
+                            reasoning_details=reasoning_details,
                             message_id=response_message_id,
                             message_type=MessageType.TOOL_CALL.value,
                         )
@@ -181,6 +186,7 @@ class CommonAgent(AgentBase):
                         MessageChunk(
                             role=MessageRole.ASSISTANT.value,
                             content=chunk.choices[0].delta.content,
+                            reasoning_details=reasoning_details,
                             message_id=response_message_id,
                             message_type=MessageType.DO_SUBTASK_RESULT.value,
                         )
@@ -196,6 +202,7 @@ class CommonAgent(AgentBase):
                         MessageChunk(
                             role=MessageRole.ASSISTANT.value,
                             reasoning_content=chunk.choices[0].delta.reasoning_content,
+                            reasoning_details=reasoning_details,
                             message_id=response_message_id,
                             message_type=MessageType.REASONING_CONTENT.value,
                         )

--- a/sagents/agent/simple_agent.py
+++ b/sagents/agent/simple_agent.py
@@ -30,6 +30,7 @@ from sagents.utils.completion_mode import (
     is_turn_status_mode,
 )
 from sagents.utils.llm_request_utils import redact_base64_data_urls_in_value
+from sagents.llm.minimax import serialize_reasoning_details
 from sagents.utils.i18n import t
 import json
 import yaml
@@ -1990,6 +1991,9 @@ class SimpleAgent(AgentBase):
 
                 # 由于 AgentBase._call_llm_streaming 已经处理了 asyncio.sleep(0) 的让权
                 # 这里不需要重复让权，减少不必要的调度开销
+                reasoning_details = serialize_reasoning_details(
+                    getattr(chunk.choices[0].delta, "reasoning_details", None)
+                )
 
                 if chunk.choices[0].delta.tool_calls:
                     self._handle_tool_calls_chunk(
@@ -2015,6 +2019,7 @@ class SimpleAgent(AgentBase):
                                 MessageChunk(
                                     role=MessageRole.ASSISTANT.value,
                                     tool_calls=chunk.choices[0].delta.tool_calls,
+                                    reasoning_details=reasoning_details,
                                     message_id=response_message_id,
                                     message_type=MessageType.TOOL_CALL.value,
                                     agent_name=self.agent_name,
@@ -2034,6 +2039,7 @@ class SimpleAgent(AgentBase):
                             MessageChunk(
                                 role="assistant",
                                 content=content_piece,
+                                reasoning_details=reasoning_details,
                                 message_id=response_message_id,
                                 message_type=MessageType.DO_SUBTASK_RESULT.value,
                                 agent_name=self.agent_name,
@@ -2052,6 +2058,7 @@ class SimpleAgent(AgentBase):
                                 reasoning_content=chunk.choices[
                                     0
                                 ].delta.reasoning_content,
+                                reasoning_details=reasoning_details,
                                 message_id=response_message_id,
                                 message_type=MessageType.REASONING_CONTENT.value,
                                 agent_name=self.agent_name,

--- a/sagents/context/messages/message.py
+++ b/sagents/context/messages/message.py
@@ -113,6 +113,9 @@ class MessageChunk:
     content: Optional[Union[str, List[Dict[str, Any]]]] = None  # 消息内容
     # 模型原生 thinking 内容。它与 content 同级，不能降级为普通 assistant 文本。
     reasoning_content: Optional[str] = None
+    # MiniMax 等供应商返回的结构化 reasoning 数据。保留原始结构用于工具调用回放；
+    # reasoning_content 仍是 Sage 对展示/状态层提供的统一文本视图。
+    reasoning_details: Optional[List[Dict[str, Any]]] = None
     tool_calls: Optional[List[Dict[str, Any]]] = None  # 工具调用列表（OpenAI格式）
 
     # 消息标识

--- a/sagents/context/messages/message_manager.py
+++ b/sagents/context/messages/message_manager.py
@@ -850,6 +850,14 @@ class MessageManager:
                     existing_message.reasoning_content or ""
                 ) + new_message.reasoning_content
 
+            if new_message.reasoning_details is not None:
+                # MiniMax streams cumulative reasoning snapshots. The latest
+                # structured value replaces the previous one; the normalized
+                # reasoning_content above remains incremental.
+                existing_message.reasoning_details = deepcopy(
+                    new_message.reasoning_details
+                )
+
             # reasoning/content/tool_calls are fields of one assistant response.
             # The first streamed chunk may be reasoning-only; once visible content
             # or tool calls arrive, keep the same message and promote its display
@@ -2400,6 +2408,7 @@ class MessageManager:
             "role": msg.role,
             "content": MessageManager._wrap_runtime_error_content_for_request(msg),
             "reasoning_content": msg.reasoning_content,
+            "reasoning_details": msg.reasoning_details,
             "tool_call_id": msg.tool_call_id,
             "tool_calls": tool_calls_dict,
         }

--- a/sagents/llm/minimax.py
+++ b/sagents/llm/minimax.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, List, Optional
+
+
+def serialize_reasoning_details(value: Any) -> Optional[List[Dict[str, Any]]]:
+    """Convert MiniMax reasoning details to durable JSON-compatible dictionaries."""
+    if not isinstance(value, (list, tuple)):
+        return None
+
+    details: List[Dict[str, Any]] = []
+    for item in value:
+        if isinstance(item, dict):
+            details.append(deepcopy(item))
+            continue
+        model_dump = getattr(item, "model_dump", None)
+        if callable(model_dump):
+            dumped = model_dump(exclude_none=True)
+            if isinstance(dumped, dict):
+                details.append(dumped)
+                continue
+        text = getattr(item, "text", None)
+        if isinstance(text, str):
+            details.append({"text": text})
+    return details or None
+
+
+def reasoning_text_from_details(value: Any) -> Optional[str]:
+    details = serialize_reasoning_details(value)
+    if not details:
+        return None
+    texts = [detail.get("text") for detail in details]
+    joined = "".join(text for text in texts if isinstance(text, str))
+    return joined or None
+
+
+class MiniMaxStreamNormalizer:
+    """Turn MiniMax cumulative streaming snapshots into OpenAI-style deltas."""
+
+    def __init__(self) -> None:
+        self._content = ""
+        self._reasoning = ""
+
+    @staticmethod
+    def _delta(previous: str, current: str) -> tuple[str, str]:
+        if not previous:
+            return current, current
+        if current.startswith(previous):
+            return current[len(previous) :], current
+        if previous.startswith(current):
+            return "", previous
+        # Be permissive with gateways that already emit token deltas.
+        return current, previous + current
+
+    def normalize(self, chunk: Any) -> Any:
+        choices = getattr(chunk, "choices", None)
+        if not choices:
+            return chunk
+        delta = getattr(choices[0], "delta", None)
+        if delta is None:
+            return chunk
+
+        content = getattr(delta, "content", None)
+        if isinstance(content, str) and content:
+            content_delta, self._content = self._delta(self._content, content)
+            delta.content = content_delta or None
+
+        reasoning_snapshot = reasoning_text_from_details(
+            getattr(delta, "reasoning_details", None)
+        )
+        if reasoning_snapshot is None:
+            raw_reasoning = getattr(delta, "reasoning_content", None)
+            if isinstance(raw_reasoning, str) and raw_reasoning:
+                reasoning_snapshot = raw_reasoning
+        if reasoning_snapshot is not None:
+            reasoning_delta, self._reasoning = self._delta(
+                self._reasoning, reasoning_snapshot
+            )
+            delta.reasoning_content = reasoning_delta or None
+        return chunk

--- a/sagents/llm/model_capabilities.py
+++ b/sagents/llm/model_capabilities.py
@@ -82,6 +82,24 @@ def uses_deepseek_native_protocol(
     return is_deepseek_model(model_name) and is_official_deepseek_endpoint(base_url)
 
 
+def is_minimax_model(model_name: str) -> bool:
+    """Return whether the provider-facing model slug is a MiniMax model."""
+    return str(model_name or "").strip().lower().startswith("minimax-")
+
+
+def is_official_minimax_endpoint(base_url: Optional[str]) -> bool:
+    """Return whether ``base_url`` is a MiniMax first-party API endpoint."""
+    hostname = _endpoint_hostname(base_url)
+    return hostname in {"api.minimaxi.com", "api.minimax.io"}
+
+
+def uses_minimax_native_protocol(
+    model_name: str, base_url: Optional[str]
+) -> bool:
+    """Whether the request should use MiniMax's native OpenAI extensions."""
+    return is_minimax_model(model_name) and is_official_minimax_endpoint(base_url)
+
+
 def _endpoint_hostname(base_url: Optional[str]) -> str:
     if not base_url:
         return ""
@@ -255,6 +273,15 @@ def build_llm_extra_body(
                 default_off=default_off,
             )
         )
+    elif uses_minimax_native_protocol(model_name, base_url):
+        # MiniMax's OpenAI-compatible API otherwise embeds thinking inside
+        # content as <think>...</think>. Split it into structured fields so Sage
+        # can keep private reasoning separate from the visible answer.
+        extra_body["reasoning_split"] = True
+        if str(model_name or "").strip().lower().startswith("minimax-m3"):
+            extra_body["thinking"] = {
+                "type": "adaptive" if enable_thinking else "disabled"
+            }
     elif uses_deepseek_native_protocol(model_name, base_url):
         # The first-party Chat Completions API only documents these native
         # fields. Do not mix in local-engine compatibility switches such as

--- a/sagents/sagents.py
+++ b/sagents/sagents.py
@@ -456,6 +456,11 @@ class SAgent:
                     )
                     if redacted is None:
                         continue
+                    # Provider-specific structured reasoning is durable replay
+                    # state, not a client-facing stream field. Ling consumes the
+                    # normalized reasoning_content signal instead.
+                    if redacted.reasoning_details is not None:
+                        redacted = replace(redacted, reasoning_details=None)
                     if _should_suppress_chunk_from_client_stream(redacted):
                         logger.info(
                             "SAgent: suppressed hidden runtime context chunk "

--- a/sagents/utils/llm_request_utils.py
+++ b/sagents/utils/llm_request_utils.py
@@ -51,6 +51,10 @@ def _is_deepseek_model_name(model: Optional[str]) -> bool:
     )
 
 
+def _is_minimax_model_name(model: Optional[str]) -> bool:
+    return str(model or "").strip().lower().startswith("minimax-")
+
+
 def _provider_base_url(
     client: Any = None,
     model_config: Optional[Mapping[str, Any]] = None,
@@ -85,6 +89,24 @@ def _uses_deepseek_native_protocol(
         return False
     parsed = urlparse(base_url if "://" in base_url else f"https://{base_url}")
     return (parsed.hostname or "").lower() == "api.deepseek.com"
+
+
+def _uses_minimax_native_protocol(
+    model: Optional[str],
+    *,
+    client: Any = None,
+    model_config: Optional[Mapping[str, Any]] = None,
+) -> bool:
+    if not _is_minimax_model_name(model):
+        return False
+    base_url = _provider_base_url(client=client, model_config=model_config)
+    if not base_url:
+        return False
+    parsed = urlparse(base_url if "://" in base_url else f"https://{base_url}")
+    return (parsed.hostname or "").lower() in {
+        "api.minimaxi.com",
+        "api.minimax.io",
+    }
 
 
 def normalize_chat_completions_model(
@@ -472,6 +494,7 @@ def coalesce_reasoning_content_messages(
     messages: Any,
     *,
     preserve_tool_reasoning: bool,
+    preserve_tool_reasoning_details: bool = False,
 ) -> Any:
     """Fold legacy streamed assistant chunks into provider-facing messages.
 
@@ -486,6 +509,7 @@ def coalesce_reasoning_content_messages(
 
     output: list[Any] = []
     pending_reasoning: list[str] = []
+    pending_reasoning_details: Optional[list[Any]] = None
     pending_assistant_messages: list[dict[str, Any]] = []
     pending_response_id: Optional[str] = None
 
@@ -500,10 +524,11 @@ def coalesce_reasoning_content_messages(
         return pending_response_id == current_response_id
 
     def flush_pending_assistant_messages() -> None:
-        nonlocal pending_response_id
+        nonlocal pending_reasoning_details, pending_response_id
         output.extend(pending_assistant_messages)
         pending_assistant_messages.clear()
         pending_reasoning.clear()
+        pending_reasoning_details = None
         pending_response_id = None
 
     def pending_visible_content() -> str:
@@ -537,6 +562,9 @@ def coalesce_reasoning_content_messages(
                 flush_pending_assistant_messages()
             pending_response_id = response_id(message)
             pending_reasoning.append(reasoning)
+            details = message.get("reasoning_details")
+            if isinstance(details, list) and details:
+                pending_reasoning_details = deepcopy(details)
             continue
 
         if message.get("role") == "assistant":
@@ -566,7 +594,15 @@ def coalesce_reasoning_content_messages(
                 message["reasoning_content"] = "".join(pending_reasoning) + (
                     existing if isinstance(existing, str) else ""
                 )
+            if (
+                preserve_tool_reasoning_details
+                and has_tool_calls
+                and pending_reasoning_details
+                and not message.get("reasoning_details")
+            ):
+                message["reasoning_details"] = deepcopy(pending_reasoning_details)
             pending_reasoning = []
+            pending_reasoning_details = None
             pending_response_id = None
             if (
                 not preserve_tool_reasoning
@@ -580,6 +616,10 @@ def coalesce_reasoning_content_messages(
 
         if not (preserve_tool_reasoning and message.get("tool_calls")):
             message.pop("reasoning_content", None)
+        if not (
+            preserve_tool_reasoning_details and message.get("tool_calls")
+        ):
+            message.pop("reasoning_details", None)
         output.append(message)
 
     flush_pending_assistant_messages()
@@ -602,9 +642,13 @@ def prepare_chat_completion_messages(
     use_deepseek_protocol = _uses_deepseek_native_protocol(
         model, client=client, model_config=model_config
     )
+    use_minimax_protocol = _uses_minimax_native_protocol(
+        model, client=client, model_config=model_config
+    )
     prepared = coalesce_reasoning_content_messages(
         messages,
-        preserve_tool_reasoning=use_deepseek_protocol,
+        preserve_tool_reasoning=use_deepseek_protocol or use_minimax_protocol,
+        preserve_tool_reasoning_details=use_minimax_protocol,
     )
     if use_deepseek_protocol:
         return sanitize_deepseek_tool_history(
@@ -615,6 +659,27 @@ def prepare_chat_completion_messages(
             model_config=model_config,
         )
 
+    if use_minimax_protocol:
+        if not isinstance(prepared, list):
+            return prepared
+        minimax_messages: list[Any] = []
+        for raw in prepared:
+            if not isinstance(raw, Mapping):
+                minimax_messages.append(raw)
+                continue
+            message = dict(raw)
+            is_tool_turn = (
+                message.get("role") == "assistant" and message.get("tool_calls")
+            )
+            if is_tool_turn:
+                if message.get("content") is None:
+                    message["content"] = ""
+            else:
+                message.pop("reasoning_content", None)
+                message.pop("reasoning_details", None)
+            minimax_messages.append(message)
+        return minimax_messages
+
     if not isinstance(prepared, list):
         return prepared
     generic_messages: list[Any] = []
@@ -624,6 +689,7 @@ def prepare_chat_completion_messages(
             continue
         message = dict(raw)
         message.pop("reasoning_content", None)
+        message.pop("reasoning_details", None)
         if message.get("role") == "assistant" and message.get("tool_calls"):
             message.pop("content", None)
         generic_messages.append(message)

--- a/sagents/utils/stream_merger.py
+++ b/sagents/utils/stream_merger.py
@@ -92,9 +92,14 @@ def merge_chat_completion_chunks(chunks: Iterable) -> ChatCompletion:
                 "role",
                 "tool_calls",
             }:
-                message_extras[key] = merge_stream_value(
-                    message_extras.get(key), value
-                )
+                if key == "reasoning_details":
+                    # MiniMax emits cumulative structured snapshots; retain the
+                    # latest complete value instead of concatenating snapshots.
+                    message_extras[key] = deepcopy(value)
+                else:
+                    message_extras[key] = merge_stream_value(
+                        message_extras.get(key), value
+                    )
 
         for tc in delta.tool_calls or []:
             idx = tc.index

--- a/tests/common/services/test_model_invocation_service.py
+++ b/tests/common/services/test_model_invocation_service.py
@@ -129,6 +129,19 @@ def _patch_common(monkeypatch, providers):
     return captured, fake_client
 
 
+def test_direct_minimax_request_always_enables_reasoning_split() -> None:
+    body = service._build_thinking_extra_body(
+        existing_extra_body=None,
+        model="MiniMax-M2.7",
+        base_url="https://api.minimaxi.com/v1",
+        task="direct_test",
+        deep_thinking=None,
+        thinking_level=None,
+    )
+
+    assert body == {"_step_name": "direct_test", "reasoning_split": True}
+
+
 @pytest.mark.asyncio
 async def test_provider_id_takes_priority_and_request_stays_openai_shaped(monkeypatch):
     providers = {

--- a/tests/sagents/llm/test_minimax.py
+++ b/tests/sagents/llm/test_minimax.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+
+from sagents.llm.minimax import MiniMaxStreamNormalizer
+
+
+def _chunk(*, content=None, reasoning_details=None, reasoning_content=None):
+    delta = SimpleNamespace(
+        content=content,
+        reasoning_details=reasoning_details,
+        reasoning_content=reasoning_content,
+    )
+    return SimpleNamespace(choices=[SimpleNamespace(delta=delta)])
+
+
+def test_minimax_stream_normalizer_converts_cumulative_snapshots_to_deltas() -> None:
+    normalizer = MiniMaxStreamNormalizer()
+
+    first_reasoning = normalizer.normalize(
+        _chunk(reasoning_details=[{"type": "reasoning.text", "text": "先分析"}])
+    )
+    second_reasoning = normalizer.normalize(
+        _chunk(reasoning_details=[{"type": "reasoning.text", "text": "先分析，再回答"}])
+    )
+    first_content = normalizer.normalize(_chunk(content="答"))
+    second_content = normalizer.normalize(_chunk(content="答案"))
+
+    assert first_reasoning.choices[0].delta.reasoning_content == "先分析"
+    assert second_reasoning.choices[0].delta.reasoning_content == "，再回答"
+    assert first_content.choices[0].delta.content == "答"
+    assert second_content.choices[0].delta.content == "案"
+
+
+def test_minimax_stream_normalizer_accepts_already_incremental_gateway_chunks() -> None:
+    normalizer = MiniMaxStreamNormalizer()
+
+    first = normalizer.normalize(_chunk(content="Hello"))
+    second = normalizer.normalize(_chunk(content=" world"))
+
+    assert first.choices[0].delta.content == "Hello"
+    assert second.choices[0].delta.content == " world"

--- a/tests/sagents/llm/test_model_capabilities.py
+++ b/tests/sagents/llm/test_model_capabilities.py
@@ -6,6 +6,8 @@ from sagents.llm.model_capabilities import (
     get_default_thinking_level,
     get_supported_thinking_levels,
     is_deepseek_model,
+    is_official_minimax_endpoint,
+    is_minimax_model,
     is_openai_reasoning_model,
     normalize_reasoning_effort,
     resolve_reasoning_effort,
@@ -156,6 +158,33 @@ class TestBuildLlmExtraBody(unittest.TestCase):
         self.assertEqual(body["thinking"], {"type": "enabled"})
         self.assertNotIn("enable_thinking", body)
         self.assertNotIn("chat_template_kwargs", body)
+
+    def test_minimax_native_api_splits_reasoning_without_generic_flags(self):
+        body = build_llm_extra_body(
+            "MiniMax-M2.7",
+            base_url="https://api.minimaxi.com/v1",
+            enable_thinking=False,
+            step_name="task_execution",
+        )
+
+        self.assertTrue(is_minimax_model("MiniMax-M2.7-highspeed"))
+        self.assertTrue(
+            is_official_minimax_endpoint("https://api.minimax.io/v1")
+        )
+        self.assertEqual(
+            body,
+            {"_step_name": "task_execution", "reasoning_split": True},
+        )
+
+    def test_minimax_slug_on_third_party_endpoint_stays_generic(self):
+        body = build_llm_extra_body(
+            "MiniMax-M2.7",
+            base_url="https://gateway.example/v1",
+            enable_thinking=False,
+        )
+
+        self.assertNotIn("reasoning_split", body)
+        self.assertFalse(body["enable_thinking"])
 
     def test_deepseek_uses_accepted_low_high_max_levels(self):
         self.assertTrue(is_deepseek_model("DeepSeek-V4-Pro"))

--- a/tests/sagents/messages/test_reasoning_content.py
+++ b/tests/sagents/messages/test_reasoning_content.py
@@ -16,6 +16,38 @@ def test_reasoning_only_message_chunk_round_trips() -> None:
     assert restored.reasoning_content == "先分析，再行动。"
 
 
+def test_minimax_reasoning_details_round_trip_and_keep_latest_snapshot() -> None:
+    message_id = "minimax-response"
+    manager = MessageManager()
+    manager.add_messages(
+        MessageChunk(
+            role="assistant",
+            reasoning_content="先分析",
+            reasoning_details=[{"type": "reasoning.text", "text": "先分析"}],
+            message_id=message_id,
+            message_type=MessageType.REASONING_CONTENT.value,
+        )
+    )
+    manager.add_messages(
+        MessageChunk(
+            role="assistant",
+            reasoning_content="，再回答",
+            reasoning_details=[
+                {"type": "reasoning.text", "text": "先分析，再回答"}
+            ],
+            message_id=message_id,
+            message_type=MessageType.REASONING_CONTENT.value,
+        )
+    )
+
+    restored = MessageChunk.from_dict(manager.messages[0].to_dict())
+
+    assert restored.reasoning_content == "先分析，再回答"
+    assert restored.reasoning_details == [
+        {"type": "reasoning.text", "text": "先分析，再回答"}
+    ]
+
+
 def test_token_estimate_counts_content_and_reasoning_content(monkeypatch) -> None:
     monkeypatch.setattr(
         MessageManager,

--- a/tests/sagents/utils/test_llm_request_utils.py
+++ b/tests/sagents/utils/test_llm_request_utils.py
@@ -432,6 +432,46 @@ def test_prepare_generic_view_strips_reasoning_and_keeps_visible_tool_text_once(
     assert messages[0]["reasoning_content"] == "need weather"
 
 
+def test_prepare_minimax_view_replays_structured_reasoning_with_tool_turn() -> None:
+    reasoning_details = [
+        {"type": "reasoning.text", "text": "need weather"}
+    ]
+    messages = [
+        {
+            "role": "assistant",
+            "reasoning_content": "need weather",
+            "reasoning_details": reasoning_details,
+        },
+        {"role": "assistant", "content": "Checking."},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "weather", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "content": "sunny"},
+    ]
+
+    out = prepare_chat_completion_messages(
+        messages,
+        request_kwargs={"extra_body": {"reasoning_split": True}},
+        model="MiniMax-M2.7",
+        model_config={"base_url": "https://api.minimaxi.com/v1"},
+    )
+
+    assert len(out) == 2
+    assert out[0]["content"] == "Checking."
+    assert out[0]["reasoning_content"] == "need weather"
+    assert out[0]["reasoning_details"] == reasoning_details
+    assert out[0]["tool_calls"][0]["id"] == "call-1"
+    assert messages[0]["reasoning_details"] == reasoning_details
+
+
 def test_sanitize_keeps_reasoning_effort_when_tool_choice_auto() -> None:
     out = sanitize_model_request_kwargs(
         {


### PR DESCRIPTION
Summary:
- enable reasoning_split for first-party MiniMax OpenAI-compatible endpoints
- normalize cumulative MiniMax streaming snapshots into Sage reasoning/content deltas
- preserve structured reasoning_details for tool-call replay while keeping client output clean
- avoid undocumented generic thinking flags for MiniMax M2.x

Validation:
- 160 passed, 38 subtests passed
- Ruff checks passed
- git diff --check passed

Reference:
- https://platform.minimaxi.com/docs/api-reference/text-openai-api