### PR TITLE
fix(examples/sage_cli): drop the stray config["memory_type"] argument that breaks every CLI run

### DIFF
--- a/examples/sage_cli.py
+++ b/examples/sage_cli.py
@@ -1315,11 +1315,10 @@ if __name__ == "__main__":
                     model_config,
                     config["system_prefix"],
                     config["workspace"],
-                    config["memory_type"],
                     tool_proxy,
                     skill_manager,
                     config,
-                    context_budget_config,  # pyright: ignore[reportCallIssue]
+                    context_budget_config,
                 )
             else:
                 await chat_fibre(
@@ -1328,11 +1327,10 @@ if __name__ == "__main__":
                     model_config,
                     config["system_prefix"],
                     config["workspace"],
-                    config["memory_type"],
                     tool_proxy,
                     skill_manager,
                     config,
-                    context_budget_config,  # pyright: ignore[reportCallIssue]
+                    context_budget_config,
                 )
         else:
             await chat_simple(
@@ -1341,11 +1339,10 @@ if __name__ == "__main__":
                 model_config,
                 config["system_prefix"],
                 config["workspace"],
-                config["memory_type"],
                 tool_proxy,
                 skill_manager,
                 config,
-                context_budget_config,  # pyright: ignore[reportCallIssue]
+                context_budget_config,
             )
 
     asyncio.run(main_async())


### PR DESCRIPTION
## Problem

`examples/sage_cli.py` cannot start. All three chat entry points in `main_async()` pass **10** positional arguments to functions that take **9**:

```python
await chat_simple(
    sagent,
    client,
    model_config,
    config["system_prefix"],
    config["workspace"],
    config["memory_type"],        # <-- no longer a parameter
    tool_proxy,
    skill_manager,
    config,
    context_budget_config,  # pyright: ignore[reportCallIssue]
)
```

```
TypeError: chat_simple() takes from 8 to 9 positional arguments but 10 were given
```

`examples/README.md` documents `python3 examples/sage_cli.py ...` as the way to run the CLI, and `main_async()` ends in `asyncio.run(main_async())`, so this is hit on **every** run, in all three branches (`--agent_mode fibre` + `simple_ui`, `fibre`, and the default `simple` path).

## Root cause

Commit [`a0fe3b2`](https://github.com/ZHangZHengEric/Sage/commit/a0fe3b29) — *"refactor: 移除不再使用的 default_memory_type 参数"* — removed the parameter from all three signatures and from every internal forwarding site:

```diff
@@ async def chat_simple(
     model_config: Dict[str, Any],
     system_prefix: str,
     host_workspace: str,
-    default_memory_type: str,
     tool_manager: Union[ToolManager, ToolProxy],
     skill_manager: Optional[Union[SkillManager, SkillProxy]],
     config: Dict[str, Any],
```

…but the three call sites in `main_async()` were not updated. Later, `becff9b` ("refactor: pyright 修订") added `# pyright: ignore[reportCallIssue]` on exactly those three calls, which silenced the type checker rather than fixing the call.

## Fix

Drop the stray positional argument. None of the three functions declares a `memory*` parameter any more, and all three already receive the full `config` dict (which carries `memory_type`, set at line 1185 from `--memory_type`), so nothing is lost. The three now-unnecessary `# pyright: ignore[reportCallIssue]` suppressions are removed with it.

Net diff: **+3 / −6**, one file, `examples/` only — no test or runtime code touched.

## Verification

The three signatures were lifted out of `examples/sage_cli.py` at the current `main` tip via `ast`, stubbed (annotations stripped, defaults replaced with `None`) and replayed with `inspect.Signature.bind`, using the exact argument list each call site passes:

```
--- chat_simple(agent, model, model_config, system_prefix, host_workspace,
                tool_manager, skill_manager, config, context_budget_config=None)
    CURRENT (10 pos)  -> TypeError: too many positional arguments
    PROPOSED  (9 pos) -> OK

--- chat_fibre_simple(...)
    CURRENT (10 pos)  -> TypeError: too many positional arguments
    PROPOSED  (9 pos) -> OK

--- chat_fibre(...)
    CURRENT (10 pos)  -> TypeError: too many positional arguments
    PROPOSED  (9 pos) -> OK

chat_simple       params: [agent, model, model_config, system_prefix, host_workspace,
                           tool_manager, skill_manager, config, context_budget_config]
chat_fibre_simple params: [ ... identical ... ]
chat_fibre        params: [ ... identical ... ]
No chat_* function declares any memory* parameter.
```

Note this was not only an arity error — it was also a silent argument shift. Under the old call, `tool_proxy` landed in `skill_manager`, `skill_manager` in `config`, and `config` in `context_budget_config`. After the fix every argument binds to the parameter it was named for (verified in the `bind()` output above).

`git grep memory_type` over `examples/sage_cli.py` now shows it only at its definition sites (`--memory_type` at line 184, `config["memory_type"]` at line 1185) — no remaining call-site use.

CI is unaffected: `ci-tests.yml` runs `pytest tests/{app,common,sagents}` plus the web/desktop i18n jobs, none of which import `examples/`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
