### PR TITLE
feat(cli): in-process sage v2 run/chat/resume/sessions on the SAgents v2 runtime

### DIFF
--- a/app/cli/commands/v2.py
+++ b/app/cli/commands/v2.py
@@ -1,0 +1,560 @@
+"""``sage v2 run|chat|resume|sessions``：在进程内用 SAgents v2 运行任务并管理会话。"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from sagents.v2 import SAgent, SAgentApplication
+from sagents.v2.contracts.errors import SageV2Error
+from sagents.v2.contracts.principals import ActorRef, PrincipalType, RequestContext
+from sagents.v2.contracts.run_state import TERMINAL_RUN_STATES, RunState
+from sagents.v2.package.manifest.root import SageManifest
+
+from app.cli.services.base import CLIError
+from app.cli.v2.host import (
+    LocalWorkspaceBindingProvider,
+    WorkspaceSandboxSettings,
+    build_cli_application,
+)
+from app.cli.v2.interaction import (
+    InteractionDecider,
+    JsonLineInteractionDecider,
+    PromptInteractionDecider,
+    StaticInteractionDecider,
+)
+from app.cli.v2.package import (
+    DEFAULT_CREDENTIAL_ENV,
+    CliModelSettings,
+    build_preset_package,
+    load_package,
+    with_cli_job_runtime,
+    without_filesystem_scheduler,
+)
+from app.cli.v2.render import EventRenderer, JsonRenderer, PlainRenderer
+from app.cli.v2.runner import (
+    RunOutcome,
+    build_start_run,
+    resume_run,
+    run_task,
+    wait_for_pending_run_settlement,
+)
+from app.cli.v2.sessions import (
+    format_sessions_table,
+    format_transcript,
+    inspect_session,
+    list_sessions,
+    sessions_json,
+)
+from app.cli.v2.signals import (
+    EXIT_INTERRUPTED,
+    InterruptController,
+    StdinLineReader,
+    interrupt_scope,
+    read_line_or_interrupt,
+)
+
+AgentFactory = Callable[..., Any]
+
+CHAT_INPUT_PROMPT = "Sage> "
+CHAT_HELP = (
+    "built-in commands:\n"
+    "  /help     show this help\n"
+    "  /session  print the current session id\n"
+    "  /exit     leave the session\n"
+    "  /quit     leave the session\n"
+    "\n"
+    "Ctrl-C during a run cancels that run; Ctrl-C at the prompt leaves the session.\n"
+    "resume later with: sage v2 resume <session_id>"
+)
+
+
+def resolve_workspace(value: str | None) -> Path:
+    workspace = Path(value or os.getcwd()).expanduser()
+    if not workspace.is_dir():
+        raise CLIError(
+            f"workspace is not a directory: {workspace}",
+            next_steps=["Pass an existing directory with --workspace."],
+        )
+    return workspace.resolve()
+
+
+def resolve_session_root(value: str | None) -> Path:
+    if value:
+        return Path(value).expanduser().resolve()
+    from common.core import config
+
+    return Path(config.get_local_storage_defaults()["sage_home"]) / "v2" / "runtime"
+
+
+def resolve_package(
+    args: argparse.Namespace,
+    cfg: Any,
+    *,
+    scheduler_root: Path | None = None,
+) -> SageManifest:
+    package_path = getattr(args, "package", None)
+    if package_path:
+        # 用户自带的 package 原样尊重（含 scheduler 选择）；只在它没选 job runtime 时补 CLI 的。
+        return with_cli_job_runtime(load_package(package_path))
+    model = (cfg.default_llm_model_name or "").strip()
+    base_url = (cfg.default_llm_api_base_url or "").strip()
+    api_key = (os.environ.get(DEFAULT_CREDENTIAL_ENV) or "").strip()
+    next_steps = []
+    if not model:
+        next_steps.append(
+            "Set SAGE_DEFAULT_LLM_MODEL_NAME in your shell, ~/.sage/.sage_env, or local .env."
+        )
+    if not base_url:
+        next_steps.append(
+            "Set SAGE_DEFAULT_LLM_API_BASE_URL in your shell, ~/.sage/.sage_env, or local .env."
+        )
+    if not api_key:
+        next_steps.append(
+            f"Set {DEFAULT_CREDENTIAL_ENV} in your shell, ~/.sage/.sage_env, or local .env."
+        )
+    if next_steps:
+        raise CLIError(
+            "Model configuration is incomplete for `sage v2`.",
+            next_steps=next_steps + ["Or pass --package path/to/sage.yaml."],
+        )
+    return build_preset_package(
+        args.preset,
+        CliModelSettings(model=model, base_url=base_url),
+        scheduler_root=scheduler_root,
+    )
+
+
+def select_decider(
+    args: argparse.Namespace,
+    renderer: EventRenderer,
+    stdin: StdinLineReader,
+) -> InteractionDecider:
+    if isinstance(renderer, JsonRenderer):
+        return JsonLineInteractionDecider(renderer, stdin.read_line)
+    mode = getattr(args, "approval_mode", None)
+    if mode == "approve-all":
+        return StaticInteractionDecider("approve_once", notice=renderer.notice)
+    if mode == "deny-all":
+        return StaticInteractionDecider("deny", notice=renderer.notice)
+    if stdin.isatty():
+        return PromptInteractionDecider(stdin.read_line)
+    renderer.notice(
+        "stdin is not a terminal; tool approvals will be denied and questions "
+        "cancel the run (use --approval-mode approve-all|deny-all to choose explicitly)"
+    )
+    return StaticInteractionDecider("deny", notice=renderer.notice)
+
+
+async def read_prompt(
+    stdin: StdinLineReader,
+    prompt_text: str,
+    interrupt: asyncio.Event | None,
+) -> str | None:
+    """读一行用户输入；EOF 或 Ctrl-C 返回 None。非 TTY（管道）下不打印提示符。"""
+
+    echo = bool(prompt_text) and stdin.isatty()
+    if echo:
+        sys.stdout.write(prompt_text)
+        sys.stdout.flush()
+    line = await read_line_or_interrupt(stdin, interrupt)
+    if line is None and echo:
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+    return line
+
+
+def _force_quit(controller: InterruptController, renderer: EventRenderer) -> int:
+    """第二次 Ctrl-C：吞掉任务取消，干净地以 130 退出而不是打印 traceback。"""
+
+    task = asyncio.current_task()
+    if task is not None:
+        task.uncancel()
+    renderer.notice("force quit")
+    return EXIT_INTERRUPTED
+
+
+@dataclass
+class CliSession:
+    """一次 CLI 调用共享的运行时资源：同一个 ``SAgent`` 跑多轮 Run。"""
+
+    application: SAgentApplication
+    agent: SAgent
+    stdin: StdinLineReader
+    bindings: LocalWorkspaceBindingProvider
+    package: SageManifest
+    spec_hash: str
+    agent_id: str
+    context: RequestContext
+    renderer: EventRenderer
+    decider: InteractionDecider
+    workspace: Path
+    session_root: Path
+    invocation_mode: str | None = None
+    # Run 进行中读到的 stdin 行是否作为 SteerRun 追加：TTY 交互和 --json 驱动时开启，
+    # 管道喂入的纯文本脚本关闭（那些行是后续提示词，不是对当前 Run 的补充）。
+    steer_enabled: bool = False
+
+    def origin(self) -> dict[str, str]:
+        """随 StartRun 落盘的来源信息，`sage v2 sessions` 据此展示。"""
+
+        return {
+            "workspace": str(self.workspace),
+            "package_id": self.package.metadata.id,
+        }
+
+    async def run(
+        self,
+        task: str,
+        *,
+        session_id: str | None,
+        interrupt,
+    ) -> RunOutcome:
+        return await run_task(
+            self.agent,
+            build_start_run(
+                agent_id=self.agent_id,
+                task=task,
+                resolved_spec_hash=self.spec_hash,
+                session_id=session_id,
+                metadata=self.origin(),
+                invocation_mode=self.invocation_mode,
+            ),
+            self.context,
+            renderer=self.renderer,
+            decider=self.decider,
+            session_frame={
+                **self.origin(),
+                "session_root": str(self.session_root),
+            },
+            interrupt=interrupt,
+            **self._steer_kwargs(),
+        )
+
+    def _steer_kwargs(self) -> dict[str, Any]:
+        if not self.steer_enabled:
+            return {}
+        return {
+            "steer_source": self.stdin.read_line,
+            "steer_json": isinstance(self.renderer, JsonRenderer),
+        }
+
+    async def settle_session(self, session_id: str, interrupt) -> RunOutcome | None:
+        """接管上一个进程留在会话里的非终态 Run，否则 SERIAL 会话无法开始新 Run。
+
+        - SUSPENDED（崩溃发生在等审批时）：回答其交互并续跑到终态；
+        - RUNNING/QUEUED（崩溃发生在执行中）：等本进程 dispatcher 的启动恢复把它结算为
+          ``execution.worker_restarted``；没有 filesystem scheduler 时无法自动恢复，报错说明。
+        """
+
+        runs = await self.agent.runtime.session_store.list_session_runs(session_id)
+        if not runs:
+            return None
+        last = runs[-1]
+        if last.state in TERMINAL_RUN_STATES:
+            return None
+        if last.state != RunState.SUSPENDED:
+            self.renderer.notice(
+                f"waiting for run {last.run_id} ({last.state.value}) left by a "
+                "previous process to settle"
+            )
+            last = await wait_for_pending_run_settlement(self.agent, last, self.context)
+        if last.state == RunState.SUSPENDED:
+            self.renderer.notice(f"resuming suspended run {last.run_id}")
+            return await resume_run(
+                self.agent,
+                last.run_id,
+                self.context,
+                renderer=self.renderer,
+                decider=self.decider,
+                session_frame={
+                    **self.origin(),
+                    "session_root": str(self.session_root),
+                },
+                interrupt=interrupt,
+                **self._steer_kwargs(),
+            )
+        if last.state in TERMINAL_RUN_STATES:
+            self.renderer.notice(
+                f"run {last.run_id} was settled as {last.state.value}"
+            )
+            return None
+        raise CLIError(
+            f"session {session_id} still has an active run {last.run_id} "
+            f"({last.state.value})",
+            next_steps=[
+                "If another sage v2 process is using this session, wait for it "
+                "or stop it first.",
+                "Orphaned runs are recovered automatically only with the "
+                "filesystem scheduler; it was unavailable in this process.",
+            ],
+        )
+
+    async def ensure_session_exists(self, session_id: str) -> None:
+        try:
+            await self.agent.runtime.session_store.get_session(session_id)
+        except SageV2Error as exc:
+            if exc.info.code != "session.not_found":
+                raise
+            raise CLIError(
+                f"v2 session {session_id!r} was not found under {self.session_root}",
+                next_steps=[
+                    "Check the session id, or pass the --session-root it was created with."
+                ],
+            ) from exc
+
+    async def close(self) -> None:
+        try:
+            await self.application.close()
+        except RuntimeError as exc:
+            # SAgentApplication 把内部关闭错误包成 RuntimeError；只容忍"被取消的 Run
+            # 其 driver 仍在收尾"这一种，其余照常抛出。
+            if not _is_active_run_close_error(exc):
+                raise
+            self.renderer.notice(
+                "a cancelled run's driver is still finishing; it is abandoned on exit"
+            )
+        await self.bindings.close()
+        self.stdin.close()
+
+
+def _has_error_code(exc: BaseException, code: str) -> bool:
+    cause: BaseException | None = exc
+    while cause is not None:
+        if isinstance(cause, SageV2Error) and cause.info.code == code:
+            return True
+        cause = cause.__cause__
+    return False
+
+
+def _is_active_run_close_error(exc: BaseException) -> bool:
+    return _has_error_code(exc, "agent.close_active_runs")
+
+
+async def open_cli_session(
+    args: argparse.Namespace,
+    *,
+    build_agent_fn: AgentFactory = build_cli_application,
+    stdin: StdinLineReader | None = None,
+) -> CliSession:
+    from app.cli.service import configure_cli_logging
+
+    cfg = configure_cli_logging(verbose=args.verbose)
+    workspace = resolve_workspace(getattr(args, "workspace", None))
+    session_root = resolve_session_root(getattr(args, "session_root", None))
+    scheduler_root = session_root / "scheduler"
+    package = resolve_package(args, cfg, scheduler_root=scheduler_root)
+    agent_id = package.entrypoint.agent
+    if agent_id is None:
+        raise CLIError("the selected package has no agent entrypoint")
+
+    stdin = stdin if stdin is not None else StdinLineReader()
+    renderer = JsonRenderer() if args.json else PlainRenderer(verbose=args.verbose)
+    decider = select_decider(args, renderer, stdin)
+    mode = getattr(args, "mode", None) or "normal"
+    if mode not in {"normal", "plan", "goal"}:
+        raise CLIError(f"unknown invocation mode {mode!r}")
+    # plan 模式只做检查与提案：沙箱退到只读，写类工具会以类型化错误返回给模型。
+    read_only = bool(getattr(args, "read_only", False)) or mode == "plan"
+    bindings = LocalWorkspaceBindingProvider(
+        workspace, settings=WorkspaceSandboxSettings(read_only=read_only)
+    )
+    try:
+        application = await build_agent_fn(
+            package=package, session_root=session_root, bindings=bindings
+        )
+    except SageV2Error as exc:
+        if _has_error_code(exc, "session_store.in_use"):
+            raise CLIError(
+                f"another sage v2 process is using the session root {session_root}",
+                next_steps=[
+                    "Wait for that process to finish, or stop it.",
+                    "Or run with a different --session-root.",
+                ],
+            ) from exc
+        if not _has_error_code(exc, "scheduler.in_use"):
+            raise
+        fallback = without_filesystem_scheduler(package)
+        if fallback is package:
+            raise
+        renderer.notice(
+            f"another sage v2 process owns the scheduler at {scheduler_root}; "
+            "running without restart recovery for this process"
+        )
+        package = fallback
+        application = await build_agent_fn(
+            package=package, session_root=session_root, bindings=bindings
+        )
+    context = RequestContext(
+        actor=ActorRef(principal_id=args.user_id, principal_type=PrincipalType.USER)
+    )
+    return CliSession(
+        application=application,
+        agent=application.entrypoint(),
+        stdin=stdin,
+        bindings=bindings,
+        package=package,
+        spec_hash=application.composition_hash,
+        agent_id=agent_id,
+        context=context,
+        renderer=renderer,
+        decider=decider,
+        workspace=workspace,
+        session_root=session_root,
+        invocation_mode=None if mode == "normal" else mode,
+        steer_enabled=bool(args.json) or stdin.isatty(),
+    )
+
+
+async def v2_run_command(
+    args: argparse.Namespace,
+    *,
+    build_agent_fn: AgentFactory = build_cli_application,
+    stdin: StdinLineReader | None = None,
+) -> int:
+    session = await open_cli_session(args, build_agent_fn=build_agent_fn, stdin=stdin)
+    try:
+        with interrupt_scope() as controller:
+            try:
+                session_id = getattr(args, "session_id", None)
+                if session_id:
+                    await session.ensure_session_exists(session_id)
+                    settled = await session.settle_session(session_id, controller.event)
+                    if settled is not None and settled.interrupted:
+                        return settled.exit_code
+                    controller.reset()
+                outcome = await session.run(
+                    args.task,
+                    session_id=session_id,
+                    interrupt=controller.event,
+                )
+            except asyncio.CancelledError:
+                if not controller.forced:
+                    raise
+                return _force_quit(controller, session.renderer)
+    finally:
+        await session.close()
+    return outcome.exit_code
+
+
+async def v2_chat_command(
+    args: argparse.Namespace,
+    *,
+    command_mode: str = "chat",
+    build_agent_fn: AgentFactory = build_cli_application,
+    stdin: StdinLineReader | None = None,
+) -> int:
+    session = await open_cli_session(args, build_agent_fn=build_agent_fn, stdin=stdin)
+    session_id: str | None = getattr(args, "session_id", None)
+    renderer = session.renderer
+    exit_code = 0
+    try:
+        with interrupt_scope() as controller:
+            if command_mode == "resume":
+                if not session_id:
+                    raise CLIError("resume requires a session id")
+            if session_id:
+                await session.ensure_session_exists(session_id)
+                try:
+                    settled = await session.settle_session(session_id, controller.event)
+                except asyncio.CancelledError:
+                    if not controller.forced:
+                        raise
+                    return _force_quit(controller, renderer)
+                if settled is not None and settled.interrupted:
+                    controller.reset()
+            if not args.json:
+                renderer.notice(
+                    f"session_id: {session_id or '(new session on first message)'}\n"
+                    "type /help for built-in commands"
+                )
+            queued_prompts: list[str] = []
+            while True:
+                if queued_prompts:
+                    prompt = queued_prompts.pop(0)
+                    renderer.notice(f"(steer) sending as the next message: {prompt}")
+                else:
+                    prompt = await read_prompt(
+                        session.stdin,
+                        "" if args.json else CHAT_INPUT_PROMPT,
+                        controller.event,
+                    )
+                if prompt is None:
+                    # EOF，或提示符处的 Ctrl-C：离开会话。
+                    break
+                prompt = prompt.strip()
+                if not prompt:
+                    continue
+                if prompt in {"/exit", "/quit"}:
+                    break
+                if prompt == "/help":
+                    renderer.notice(CHAT_HELP)
+                    continue
+                if prompt == "/session":
+                    renderer.notice(session_id or "(no session yet)")
+                    continue
+                try:
+                    outcome = await session.run(
+                        prompt, session_id=session_id, interrupt=controller.event
+                    )
+                except asyncio.CancelledError:
+                    if not controller.forced:
+                        raise
+                    exit_code = _force_quit(controller, renderer)
+                    break
+                session_id = outcome.session_id
+                # 运行中输入若没赶上模型的下一步，就作为后续消息继续发，不能静默丢掉。
+                if not outcome.interrupted:
+                    queued_prompts.extend(outcome.unapplied_steers)
+                # 本轮的 Ctrl-C（如有）已处理完，下一次重新从"第一次"算起。
+                controller.reset()
+    finally:
+        await session.close()
+    if not args.json and session_id and exit_code == 0:
+        renderer.notice(f"resume later with: sage v2 resume {session_id}")
+    return exit_code
+
+
+async def v2_sessions_command(args: argparse.Namespace) -> int:
+    from app.cli.service import configure_cli_logging
+
+    configure_cli_logging(verbose=args.verbose)
+    session_root = resolve_session_root(getattr(args, "session_root", None))
+    if getattr(args, "sessions_command", None) == "inspect":
+        return await _inspect_session(args, session_root)
+    # 只读扫描，不取 SessionStore 的写锁：另一个 sage v2 进程在跑时也能列。
+    summaries, unreadable = await list_sessions(
+        session_root, limit=getattr(args, "limit", None)
+    )
+    if args.json:
+        print(sessions_json(session_root, summaries, unreadable))
+        return 0
+    print(format_sessions_table(summaries))
+    if unreadable:
+        sys.stderr.write(
+            f"skipped {len(unreadable)} unreadable session(s): {', '.join(unreadable)}\n"
+        )
+    return 0
+
+
+async def _inspect_session(args: argparse.Namespace, session_root: Path) -> int:
+    try:
+        transcript = await asyncio.to_thread(
+            inspect_session, session_root, args.session_id
+        )
+    except FileNotFoundError as exc:
+        raise CLIError(
+            str(exc),
+            next_steps=["List known sessions with: sage v2 sessions"],
+        ) from exc
+    if args.json:
+        print(json.dumps(transcript.to_json(), ensure_ascii=False))
+    else:
+        print(format_transcript(transcript))
+    return 0

--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -14,6 +14,11 @@ from app.cli.commands.management import (
     skills_command as _skills_command,
 )
 from app.cli.commands.tui import tui_command as _tui_command
+from app.cli.commands.v2 import (
+    v2_chat_command as _v2_chat_command,
+    v2_run_command as _v2_run_command,
+    v2_sessions_command as _v2_sessions_command,
+)
 from app.cli.commands.session import (
     build_request as _build_request_impl,
     chat_command as _chat_command_impl,
@@ -149,6 +154,12 @@ async def _main_async(args: argparse.Namespace) -> int:
             return 0
         if args.command == "tui":
             return _tui_command(args)
+        if args.command == "v2" and args.v2_command == "run":
+            return await _v2_run_command(args)
+        if args.command == "v2" and args.v2_command in {"chat", "resume"}:
+            return await _v2_chat_command(args, command_mode=args.v2_command)
+        if args.command == "v2" and args.v2_command == "sessions":
+            return await _v2_sessions_command(args)
         raise ValueError(f"Unsupported command: {args.command}")
     except Exception as exc:
         return _emit_cli_error(

--- a/app/cli/parser.py
+++ b/app/cli/parser.py
@@ -460,4 +460,128 @@ def build_argument_parser() -> argparse.ArgumentParser:
     provider_delete_parser.add_argument(
         "--verbose", action="store_true", help="Show runtime logs"
     )
+
+    _add_v2_parser(v2_subparsers, default_user_id=default_user_id)
     return parser
+
+
+def _add_v2_common_args(parser: argparse.ArgumentParser, *, default_user_id: str) -> None:
+    from app.cli.v2.package import DEFAULT_PRESET, available_presets
+
+    parser.add_argument(
+        "--preset",
+        dest="preset",
+        choices=list(available_presets()),
+        default=DEFAULT_PRESET,
+        help=f"Built-in agent preset used when no --package is given (default: {DEFAULT_PRESET})",
+    )
+    parser.add_argument(
+        "--package",
+        dest="package",
+        help="Path to a sage.yaml agent package (overrides --preset and model env config)",
+    )
+    parser.add_argument(
+        "--workspace",
+        dest="workspace",
+        help="Workspace directory exposed to the sandbox (default: current directory)",
+    )
+    parser.add_argument(
+        "--session-root",
+        dest="session_root",
+        help="Directory for the v2 session store (default: ~/.sage/v2/runtime)",
+    )
+    parser.add_argument("--user-id", dest="user_id", default=default_user_id)
+    parser.add_argument(
+        "--approval-mode",
+        dest="approval_mode",
+        choices=["ask", "approve-all", "deny-all"],
+        default=None,
+        help="How tool approvals are answered (default: ask on a TTY, deny-all otherwise)",
+    )
+    parser.add_argument(
+        "--read-only",
+        dest="read_only",
+        action="store_true",
+        help="Restrict the sandbox to read/list operations and read-only shell commands",
+    )
+    parser.add_argument(
+        "--mode",
+        dest="mode",
+        choices=["normal", "plan", "goal"],
+        default="normal",
+        help=(
+            "v2 invocation mode: plan = inspect only (read-only sandbox) and submit a "
+            "plan for approval; goal = must explicitly report completion"
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print native v2 events as NDJSON and read approval decisions from stdin",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Show runtime logs")
+
+
+def _add_v2_parser(v2_subparsers, *, default_user_id: str) -> None:
+    """在已有的 ``sage v2`` 子命令组上挂载进程内运行相关的子命令。"""
+
+    run_parser = v2_subparsers.add_parser(
+        "run", help="Run a single task in-process on the v2 runtime"
+    )
+    run_parser.add_argument("task", help="Task prompt to execute")
+    run_parser.add_argument(
+        "--session-id",
+        dest="session_id",
+        help="Continue an existing v2 session instead of creating a new one",
+    )
+    _add_v2_common_args(run_parser, default_user_id=default_user_id)
+
+    chat_parser = v2_subparsers.add_parser(
+        "chat", help="Start an interactive multi-turn session on the v2 runtime"
+    )
+    chat_parser.add_argument(
+        "--session-id",
+        dest="session_id",
+        help="Continue an existing v2 session instead of creating a new one",
+    )
+    _add_v2_common_args(chat_parser, default_user_id=default_user_id)
+
+    resume_parser = v2_subparsers.add_parser(
+        "resume", help="Resume an existing v2 session interactively"
+    )
+    resume_parser.add_argument("session_id", help="v2 session id to resume")
+    _add_v2_common_args(resume_parser, default_user_id=default_user_id)
+
+    sessions_parser = v2_subparsers.add_parser(
+        "sessions", help="List v2 sessions under a session root"
+    )
+    sessions_parser.add_argument(
+        "--limit", type=int, default=20, help="Maximum number of sessions to show"
+    )
+    sessions_parser.add_argument(
+        "--session-root",
+        dest="session_root",
+        help="Directory of the v2 session store (default: ~/.sage/v2/runtime)",
+    )
+    sessions_parser.add_argument(
+        "--json", action="store_true", help="Print sessions as JSON"
+    )
+    sessions_parser.add_argument(
+        "--verbose", action="store_true", help="Show runtime logs"
+    )
+    sessions_subparsers = sessions_parser.add_subparsers(dest="sessions_command")
+    inspect_parser = sessions_subparsers.add_parser(
+        "inspect", help="Replay the user/assistant transcript of one v2 session"
+    )
+    inspect_parser.add_argument("session_id", help="v2 session id to inspect")
+    inspect_parser.add_argument(
+        "--session-root",
+        dest="session_root",
+        help="Directory of the v2 session store (default: ~/.sage/v2/runtime)",
+    )
+    inspect_parser.add_argument(
+        "--json", action="store_true", help="Print the transcript as JSON"
+    )
+    inspect_parser.add_argument(
+        "--verbose", action="store_true", help="Show runtime logs"
+    )

--- a/app/cli/v2/__init__.py
+++ b/app/cli/v2/__init__.py
@@ -1,0 +1,5 @@
+"""Sage CLI 对 SAgents v2 运行时的进程内接入层。
+
+本包只依赖 ``sagents.v2`` 的公开组合根（``SAgentBuilder``）与契约，不触碰 v1 运行时，
+也不引入 HTTP：CLI 直接在进程内起 Run、消费 native 事件流、处理审批交互。
+"""

--- a/app/cli/v2/host.py
+++ b/app/cli/v2/host.py
@@ -1,0 +1,188 @@
+"""CLI 宿主端口：为每个真实 Run 绑定本地 workspace 沙箱，并组装 ``SAgent``。
+
+沙箱策略在这里以数据形式给出（策略即数据），``sagents.v2`` 只负责执行和校验；
+agent 自身无法选择或降低沙箱类型。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from sagents.v2 import SAgentApplication, SAgentBuilder
+from sagents.v2.model import ModelProvider
+from sagents.v2.package.manifest.root import SageManifest
+from sagents.v2.runtime.execution import (
+    ExecutionBindingRequest,
+    RunExecutionBinding,
+)
+from sagents.v2.runtime.execution.sandbox import (
+    FileOperation,
+    FileSystemPolicy,
+    NetworkPolicy,
+    ProcessPolicy,
+    ResolvedSandboxSpec,
+    SandboxGrantIssuer,
+)
+from sagents.v2.runtime.execution.sandbox import LocalWorkspaceSandboxProvider
+
+from app.cli.v2.jobs import cli_job_runtime_registration
+
+# 与 desktop_v2 的本地 workspace 沙箱保持同一档默认值，行为可对照。
+DEFAULT_ALLOWED_EXECUTABLES: tuple[str, ...] = (
+    "bash",
+    "sh",
+    "git",
+    "rg",
+    "python",
+    "python3",
+    "pytest",
+    "npm",
+    "node",
+)
+DEFAULT_ALLOWED_ENV_NAMES: tuple[str, ...] = ("PATH", "PYTHONPATH")
+
+
+@dataclass(frozen=True)
+class WorkspaceSandboxSettings:
+    """CLI 本地 workspace 沙箱的策略参数。"""
+
+    process_enabled: bool = True
+    read_only: bool = False
+    allowed_executables: tuple[str, ...] = DEFAULT_ALLOWED_EXECUTABLES
+    allowed_env_names: tuple[str, ...] = DEFAULT_ALLOWED_ENV_NAMES
+    max_wall_time_seconds: float = 300
+    max_output_bytes: int = 4 * 1024 * 1024
+    max_file_bytes: int = 64 * 1024 * 1024
+    max_total_bytes: int = 4 * 1024 * 1024 * 1024
+
+
+class LocalWorkspaceBindingProvider:
+    """``ExecutionBindingProvider`` 实现：每个 Run 一个绑定到宿主目录的本地沙箱。
+
+    workspace 以宿主真实路径暴露给模型（对齐 Codex 的 in-process 体验），
+    allowed_roots 同样限定为该路径。
+    """
+
+    def __init__(
+        self,
+        workspace: str | Path,
+        *,
+        settings: WorkspaceSandboxSettings | None = None,
+        issuer: SandboxGrantIssuer | None = None,
+        sandbox_provider: LocalWorkspaceSandboxProvider | None = None,
+    ) -> None:
+        self.workspace = Path(workspace).expanduser().resolve(strict=True)
+        if not self.workspace.is_dir():
+            raise ValueError(f"workspace must be a directory: {self.workspace}")
+        self.workspace_root = self.workspace.as_posix()
+        self.settings = settings or WorkspaceSandboxSettings()
+        self.issuer = issuer or SandboxGrantIssuer()
+        self.sandbox_provider = sandbox_provider or LocalWorkspaceSandboxProvider(
+            self.issuer.verification_key
+        )
+        self.bindings: list[RunExecutionBinding] = []
+
+    def sandbox_spec(self) -> ResolvedSandboxSpec:
+        settings = self.settings
+        filesystem = FileSystemPolicy(
+            allowed_operations=(
+                frozenset({FileOperation.READ, FileOperation.LIST})
+                if settings.read_only
+                else frozenset(FileOperation)
+            ),
+            allowed_roots=(self.workspace_root,),
+            max_file_bytes=settings.max_file_bytes,
+            max_total_bytes=settings.max_total_bytes,
+        )
+        process = ProcessPolicy(
+            enabled=settings.process_enabled,
+            read_only=settings.read_only,
+            allowed_executables=settings.allowed_executables,
+            allowed_env_names=settings.allowed_env_names,
+            max_wall_time_seconds=settings.max_wall_time_seconds,
+            max_output_bytes=settings.max_output_bytes,
+        )
+        network = NetworkPolicy()
+        policy_source = json.dumps(
+            {
+                "filesystem": filesystem.model_dump(mode="json"),
+                "process": process.model_dump(mode="json"),
+                "network": network.model_dump(mode="json"),
+            },
+            sort_keys=True,
+        )
+        policy_hash = f"sha256:{hashlib.sha256(policy_source.encode()).hexdigest()}"
+        spec_source = json.dumps(
+            {"policy_hash": policy_hash, "workspace_root": self.workspace_root},
+            sort_keys=True,
+        )
+        spec_hash = f"sha256:{hashlib.sha256(spec_source.encode()).hexdigest()}"
+        return ResolvedSandboxSpec(
+            spec_hash=spec_hash,
+            workspace_root=self.workspace_root,
+            architecture="native",
+            filesystem=filesystem,
+            process=process,
+            network=network,
+            policy_hash=policy_hash,
+            metadata={"host_workspace": str(self.workspace)},
+        )
+
+    async def acquire(self, request: ExecutionBindingRequest) -> RunExecutionBinding:
+        handle = await self.sandbox_provider.provision(
+            self.sandbox_spec(), request.context, run_id=request.run_id
+        )
+        binding = RunExecutionBinding(
+            run_id=request.run_id,
+            parent_run_id=request.parent_run_id,
+            agent_id=request.agent_id,
+            workspace_root=self.workspace_root,
+            workspace_policy=request.workspace_policy,
+            sandbox=handle,
+            grant_issuer=self.issuer,
+        )
+        # upstream a4bb126f：RunExecutionBinding.on_suspended 读取 self.lifecycle，但该字段只在
+        # ExecutionBindingRequest 上声明；这里显式带过去（builder 目前传 None），避免每次挂起
+        # 都记一条 AttributeError 日志。
+        binding.lifecycle = getattr(request, "lifecycle", None)
+        self.bindings.append(binding)
+        return binding
+
+    def binding_for_run(self, run_id: str) -> RunExecutionBinding | None:
+        """CLI job runtime 用它把 shell 作业送回所属 Run 的沙箱。"""
+
+        for binding in reversed(self.bindings):
+            if binding.run_id == run_id:
+                return binding
+        return None
+
+    async def close(self) -> None:
+        # 沙箱句柄由各 Run 的 binding 自己关闭；provider 本身无进程级资源。
+        return None
+
+
+async def build_cli_application(
+    *,
+    package: SageManifest,
+    session_root: str | Path,
+    bindings: LocalWorkspaceBindingProvider,
+    model_provider: ModelProvider | None = None,
+) -> SAgentApplication:
+    """用唯一组合根 ``SAgentBuilder`` 构建 CLI 使用的 ``SAgentApplication``。
+
+    ``model_provider`` 仅供测试/脚本化场景注入；生产路径由 manifest 的模型路由决定。
+    调用方通过 ``application.entrypoint()`` 取 ``SAgent``，用 ``application.close()`` 释放全部资源。
+    """
+
+    builder = (
+        SAgentBuilder()
+        .with_defaults(session_root=Path(session_root).expanduser())
+        .with_execution_binding_provider(bindings)
+        .register(cli_job_runtime_registration(bindings))
+    )
+    if model_provider is not None:
+        builder = builder.with_model_provider(model_provider)
+    return await builder.build(package)

--- a/app/cli/v2/interaction.py
+++ b/app/cli/v2/interaction.py
@@ -1,0 +1,266 @@
+"""交互决策器：把 v2 的 ``InteractionRequest``（审批 / 用户输入）交给用户或既定策略作答。"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any, Protocol, TextIO
+
+from sagents.v2.contracts.interactions import InteractionRequest, InteractionType
+
+from app.cli.v2.render import JsonRenderer
+
+# 读一行用户输入（去掉换行）；EOF 返回 None。由 ``StdinLineReader`` 提供，测试可注入。
+LineReader = Callable[[], Awaitable[str | None]]
+
+# 无法作答时的退化顺序：只会收紧（拒绝/停止），绝不放宽。
+DECISION_FALLBACK_ORDER = ("deny", "cancel")
+# ``--json`` 模式下，驱动方（如 Rust TUI）通过 stdin 回写的决策行类型。
+JSON_DECISION_TYPE = "v2_interaction_decision"
+_APPROVAL_KEYS = {
+    "a": "approve_once",
+    "approve": "approve_once",
+    "y": "approve_once",
+    "r": "approve_and_remember",
+    "remember": "approve_and_remember",
+    "d": "deny",
+    "deny": "deny",
+    "n": "deny",
+    "c": "cancel",
+    "cancel": "cancel",
+}
+_RECOVERY_KEYS = {
+    "r": "retry",
+    "retry": "retry",
+    "c": "change_direction",
+    "change": "change_direction",
+    "s": "cancel",
+    "stop": "cancel",
+    "cancel": "cancel",
+}
+
+
+@dataclass(frozen=True)
+class InteractionAnswer:
+    decision: str
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+class InteractionDecider(Protocol):
+    async def decide(self, interaction: InteractionRequest) -> InteractionAnswer: ...
+
+
+def fallback_decision(interaction: InteractionRequest) -> str:
+    for candidate in DECISION_FALLBACK_ORDER:
+        if candidate in interaction.allowed_decisions:
+            return candidate
+    return interaction.allowed_decisions[0]
+
+
+def coerce_answer(
+    interaction: InteractionRequest,
+    decision: str | None,
+    payload: dict[str, Any] | None = None,
+) -> InteractionAnswer:
+    """不在 ``allowed_decisions`` 内的答案一律退化为拒绝/停止。"""
+
+    if decision is not None and decision in interaction.allowed_decisions:
+        return InteractionAnswer(decision, dict(payload or {}))
+    return InteractionAnswer(fallback_decision(interaction))
+
+
+def summarize_interaction(interaction: InteractionRequest) -> str:
+    payload = interaction.payload
+    if interaction.interaction_type == InteractionType.APPROVAL:
+        lines = [
+            f"approval required: {payload.get('tool_name')}",
+            f"  arguments: {json.dumps(payload.get('arguments'), ensure_ascii=False)}",
+        ]
+        if payload.get("side_effect_level"):
+            lines.append(f"  risk: {payload.get('side_effect_level')}")
+        if payload.get("risk_reason"):
+            lines.append(f"  reason: {payload.get('risk_reason')}")
+        return "\n".join(lines)
+    title = payload.get("title") or f"{interaction.interaction_type.value} required"
+    lines = [str(title)]
+    if payload.get("prompt"):
+        lines.append(f"  {payload['prompt']}")
+    error = payload.get("error")
+    if isinstance(error, dict):
+        detail = error.get("message") or ""
+        diagnostic = (error.get("metadata") or {}).get("diagnostic_message")
+        if diagnostic and diagnostic not in detail:
+            detail = f"{detail} ({diagnostic})" if detail else str(diagnostic)
+        lines.append(f"  error: {error.get('code')}: {detail}")
+    for question in payload.get("questions") or ():
+        if not isinstance(question, dict):
+            continue
+        lines.append(f"  - {question.get('title') or question.get('id')}")
+        for option in question.get("options") or ():
+            if isinstance(option, dict):
+                lines.append(f"      [{option.get('value')}] {option.get('label')}")
+    lines.append(f"  allowed decisions: {', '.join(interaction.allowed_decisions)}")
+    return "\n".join(lines)
+
+
+class StaticInteractionDecider:
+    """固定答案（``--approval-mode approve-all|deny-all`` 或非交互 stdin）。
+
+    审批以外的交互（需要用户输入）无法用固定答案回答，只能停止本次 Run；
+    停止前把原因完整打出来，用户才能知道发生了什么。
+    """
+
+    def __init__(
+        self,
+        decision: str,
+        *,
+        notice: Callable[[str], None] | None = None,
+    ) -> None:
+        self.decision = decision
+        self.notice = notice
+
+    async def decide(self, interaction: InteractionRequest) -> InteractionAnswer:
+        answer = coerce_answer(interaction, self.decision)
+        if self.notice is not None:
+            self.notice(
+                summarize_interaction(interaction)
+                + f"\n  -> non-interactive decision: {answer.decision}"
+            )
+        return answer
+
+
+class PromptInteractionDecider:
+    """TTY 交互式提问；输入来自进程唯一的 stdin 读取者，等待可被中断。"""
+
+    def __init__(
+        self,
+        read_line: LineReader,
+        *,
+        err: TextIO | None = None,
+    ) -> None:
+        self.read_line = read_line
+        self.err = err or sys.stderr
+
+    async def decide(self, interaction: InteractionRequest) -> InteractionAnswer:
+        self._write("\n" + summarize_interaction(interaction) + "\n")
+        if interaction.interaction_type == InteractionType.APPROVAL:
+            return await self._decide_approval(interaction)
+        if "submit" in interaction.allowed_decisions:
+            return await self._decide_free_text(interaction)
+        if "retry" in interaction.allowed_decisions:
+            return await self._decide_recovery(interaction)
+        return await self._decide_by_name(interaction)
+
+    async def _decide_approval(self, interaction: InteractionRequest) -> InteractionAnswer:
+        options = "[a]pprove once / [d]eny / [c]ancel"
+        if "approve_and_remember" in interaction.allowed_decisions:
+            options = "[a]pprove once / [r]emember / [d]eny / [c]ancel"
+        while True:
+            raw = await self._ask(f"{options}: ")
+            if raw is None:
+                return InteractionAnswer(fallback_decision(interaction))
+            decision = _APPROVAL_KEYS.get(raw.strip().lower())
+            if decision is not None and decision in interaction.allowed_decisions:
+                return InteractionAnswer(decision)
+            self._write(f"please answer one of: {options}\n")
+
+    async def _decide_free_text(self, interaction: InteractionRequest) -> InteractionAnswer:
+        raw = await self._ask("your answer (empty line cancels): ")
+        text = (raw or "").strip()
+        if not text:
+            return InteractionAnswer(fallback_decision(interaction))
+        return InteractionAnswer("submit", {"text": text})
+
+    async def _decide_recovery(self, interaction: InteractionRequest) -> InteractionAnswer:
+        options = "[r]etry / [c]hange direction / [s]top"
+        while True:
+            raw = await self._ask(f"{options}: ")
+            if raw is None:
+                return InteractionAnswer(fallback_decision(interaction))
+            decision = _RECOVERY_KEYS.get(raw.strip().lower())
+            if decision is None or decision not in interaction.allowed_decisions:
+                self._write(f"please answer one of: {options}\n")
+                continue
+            if decision == "change_direction":
+                guidance = await self._ask("new direction (empty line cancels): ")
+                text = (guidance or "").strip()
+                if not text:
+                    return InteractionAnswer(fallback_decision(interaction))
+                return InteractionAnswer(decision, {"text": text})
+            return InteractionAnswer(decision)
+
+    async def _decide_by_name(self, interaction: InteractionRequest) -> InteractionAnswer:
+        options = " / ".join(interaction.allowed_decisions)
+        while True:
+            raw = await self._ask(f"decision ({options}): ")
+            if raw is None:
+                return InteractionAnswer(fallback_decision(interaction))
+            decision = raw.strip()
+            if decision in interaction.allowed_decisions:
+                return InteractionAnswer(decision)
+            self._write(f"please answer one of: {options}\n")
+
+    async def _ask(self, prompt: str) -> str | None:
+        self._write(prompt)
+        line = await self.read_line()
+        if line is None:
+            self._write("\n")
+        return line
+
+    def _write(self, text: str) -> None:
+        self.err.write(text)
+        self.err.flush()
+
+
+class JsonLineInteractionDecider:
+    """``--json`` 模式：向 stdout 发 ``cli_v2_interaction`` 帧，从 stdin 读决策行。"""
+
+    def __init__(self, renderer: JsonRenderer, read_line: LineReader) -> None:
+        self.renderer = renderer
+        self.read_line = read_line
+
+    async def decide(self, interaction: InteractionRequest) -> InteractionAnswer:
+        self.renderer.frame(interaction_frame(interaction))
+        while True:
+            line = await self.read_line()
+            if line is None:
+                return InteractionAnswer(fallback_decision(interaction))
+            payload = _parse_line(line)
+            if payload is None or payload.get("type") != JSON_DECISION_TYPE:
+                continue
+            target = payload.get("interaction_id")
+            if target and target != interaction.interaction_id:
+                continue
+            reply_payload = payload.get("payload")
+            return coerce_answer(
+                interaction,
+                payload.get("decision"),
+                reply_payload if isinstance(reply_payload, dict) else None,
+            )
+
+
+def interaction_frame(interaction: InteractionRequest) -> dict[str, Any]:
+    return {
+        "type": "cli_v2_interaction",
+        "run_id": interaction.run_id,
+        "interaction_id": interaction.interaction_id,
+        "interaction_type": interaction.interaction_type.value,
+        "allowed_decisions": list(interaction.allowed_decisions),
+        "payload": interaction.payload,
+        "expires_at": (
+            interaction.expires_at.isoformat() if interaction.expires_at else None
+        ),
+    }
+
+
+def _parse_line(line: str) -> dict[str, Any] | None:
+    text = line.strip()
+    if not text:
+        return None
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None

--- a/app/cli/v2/jobs.py
+++ b/app/cli/v2/jobs.py
@@ -1,0 +1,130 @@
+"""CLI 自带的 ``execution.job-runtime``：让官方 shell 工具在通用 builder 路径下可用。
+
+背景（upstream 回归，`cc54b858`）：`SAgentBuilder` 会把 application 级的 JobRuntime 注入每个
+Run 的 ``OfficialToolRuntime``，覆盖掉它自带的 ``official.shell`` runner；而 manifest 里配出来的
+``sage.job.ephemeral`` 是 ``runners: {}``，于是 ``execute_shell_command`` 一律失败
+``job.kind_unsupported``。shell runner 需要"本 Run 的 sandbox + grant issuer"，全局 runtime
+天然不知道——这里用 CLI 的 binding provider 按 ``owner_run_id`` 反查来补上。
+
+upstream 修复后（builder 不再覆盖，或共享 runtime 支持按 Run 分派）本模块可整体删除。
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from sagents.v2.contracts.errors import ErrorCategory, RuntimeErrorInfo, SageV2Error
+from sagents.v2.contracts.jobs import JobCompletion, JobSpec
+from sagents.v2.runtime.execution import RunExecutionBinding
+from sagents.v2.runtime.execution.jobs import InMemoryJobRuntime
+from sagents.v2.runtime.execution.sandbox import OperationIntent, ProcessRequest
+from sagents.v2.runtime.extensions import (
+    CapabilityOffer,
+    ExtensionDescriptor,
+    ExtensionRegistration,
+    ExtensionScope,
+)
+
+CLI_JOB_RUNTIME_PLUGIN = "sage.cli.job-runtime"
+JOB_RUNTIME_CAPABILITY = "execution.job-runtime"
+SHELL_JOB_KIND = "official.shell"
+
+
+class RunBindingResolver(Protocol):
+    def binding_for_run(self, run_id: str) -> RunExecutionBinding | None: ...
+
+
+class CliShellJobRuntime(InMemoryJobRuntime):
+    """进程内 JobRuntime，``official.shell`` 作业在所属 Run 的沙箱里执行。"""
+
+    def __init__(
+        self,
+        bindings: RunBindingResolver,
+        *,
+        max_concurrent_jobs: int = 32,
+    ) -> None:
+        super().__init__(
+            {SHELL_JOB_KIND: self._run_shell}, max_concurrent_jobs=max_concurrent_jobs
+        )
+        self.bindings = bindings
+
+    async def _run_shell(self, spec: JobSpec, emit, cancel_event) -> JobCompletion:
+        del cancel_event
+        binding = self.bindings.binding_for_run(spec.owner_run_id)
+        if binding is None or binding.closed:
+            raise SageV2Error(
+                RuntimeErrorInfo(
+                    code="job.sandbox_unavailable",
+                    category=ErrorCategory.VALIDATION,
+                    message=(
+                        f"no live sandbox binding for run {spec.owner_run_id!r}; "
+                        "shell jobs must run inside their own Run"
+                    ),
+                    safe_to_resume=True,
+                )
+            )
+        # 与 OfficialToolRuntime._run_shell_job 同构：非登录 shell、每次操作签发一次性 grant。
+        command = str(spec.payload["command"])
+        cwd = str(spec.payload["cwd"])
+        env = dict(spec.payload.get("env") or {})
+        argv = ("bash", "-c", command)
+        request = ProcessRequest(argv=argv, cwd=cwd, env=env)
+        intent = OperationIntent(
+            operation="process.run",
+            run_id=spec.owner_run_id,
+            tool_call_id=str(spec.payload["tool_call_id"]),
+            sandbox_id=binding.sandbox.ref.sandbox_id,
+            path=cwd,
+            executable="bash",
+            argv=argv,
+        )
+        grant = binding.grant_issuer.issue(
+            ref=binding.sandbox.ref,
+            intent=intent,
+            allowed_operations=frozenset({intent.operation}),
+        )
+        result = await binding.sandbox.process.run(request, intent=intent, grant=grant)
+        if result.stdout:
+            await emit("stdout", result.stdout)
+        if result.stderr:
+            await emit("stderr", result.stderr)
+        return JobCompletion(exit_code=result.exit_code)
+
+
+def cli_job_runtime_registration(bindings: RunBindingResolver) -> ExtensionRegistration:
+    """把 ``CliShellJobRuntime`` 注册为可被 manifest 选择的 ``execution.job-runtime`` 插件。"""
+
+    return ExtensionRegistration(
+        descriptor=ExtensionDescriptor(
+            plugin_id=CLI_JOB_RUNTIME_PLUGIN,
+            version="0.1.0",
+            name="Sage CLI job runtime",
+            description=(
+                "In-memory job runtime whose official.shell runner executes inside the "
+                "owning Run's local workspace sandbox."
+            ),
+            provides=(
+                CapabilityOffer(capability=JOB_RUNTIME_CAPABILITY, api_version="2"),
+            ),
+            supported_scopes=frozenset({ExtensionScope.PROCESS}),
+            config_schema={
+                "type": "object",
+                "properties": {
+                    "max_concurrent_jobs": {"type": "integer", "minimum": 1},
+                    # builder 对该 capability 的默认配置带 runners: {}；JSON 里放不了 Python
+                    # 可调用对象，这里接受但忽略它。
+                    "runners": {"type": "object"},
+                },
+                "additionalProperties": False,
+            },
+            capabilities={
+                "durable_across_process_restart": False,
+                "supports_reconnect": False,
+                "supports_suspend": False,
+            },
+        ),
+        factory=lambda context, dependencies: CliShellJobRuntime(
+            bindings,
+            max_concurrent_jobs=int(context.config.get("max_concurrent_jobs", 32)),
+        ),
+    )

--- a/app/cli/v2/package.py
+++ b/app/cli/v2/package.py
@@ -1,0 +1,152 @@
+"""为 CLI 组装 SAgents v2 的 Agent package（``sage.yaml`` 的进程内等价物）。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from sagents.v2.agent.presets.catalog import BUILTIN_AGENT_PRESETS
+from sagents.v2.package.manifest.loader import SageManifestLoader
+from sagents.v2.package.manifest.root import SageManifest
+from sagents.v2.package.manifest.runtime import CapabilitySelection
+from sagents.v2.package.presets.factory import BuiltinPackageFactory
+
+DEFAULT_PRESET = "coder"
+# 与 v1 CLI 共用同一个 API key 环境变量，避免用户维护两套配置。
+DEFAULT_CREDENTIAL_ENV = "SAGE_DEFAULT_LLM_API_KEY"
+OFFICIAL_TOOL_PLUGIN = "sage.tool.official"
+# CLI 默认让模型看到 preset 的全部工具：确定性、无额外模型调用。
+DIRECT_TOOL_SELECTION_PLUGIN = "sage.tool-selection.direct"
+# 单机重启恢复：进程崩溃后残留的孤儿 Run 在下次启动时被标为 execution.worker_restarted，
+# 否则 SERIAL 会话会被那个非终态 Run 永久占住、无法 resume。
+FILESYSTEM_SCHEDULER_PLUGIN = "sage.scheduler.filesystem"
+SCHEDULER_CAPABILITY = "execution.scheduler"
+# 孤儿 Run 的恢复靠 worker 租约过期后重新入队；CLI 是单机交互工具，租约短一点让
+# 崩溃后的 resume 只需等几秒（dispatcher 每 lease/3 续一次租）。
+CLI_SCHEDULER_LEASE_SECONDS = 5.0
+# 见 app/cli/v2/jobs.py：通用 builder 路径下官方 shell 工具需要一个知道每 Run 沙箱的 job runtime。
+JOB_RUNTIME_CAPABILITY = "execution.job-runtime"
+CLI_JOB_RUNTIME_PLUGIN = "sage.cli.job-runtime"
+
+
+@dataclass(frozen=True)
+class CliModelSettings:
+    """从 CLI 配置解析出的模型路由参数（不含密钥本身）。"""
+
+    model: str
+    base_url: str | None = None
+    credential_env: str = DEFAULT_CREDENTIAL_ENV
+    context_window: int | None = None
+    max_output_tokens: int | None = None
+
+
+def available_presets() -> tuple[str, ...]:
+    """CLI 可直接运行的内置 preset（仅 loop 型入口，flow 型另行接入）。"""
+
+    return tuple(
+        sorted(
+            preset_id
+            for preset_id, preset in BUILTIN_AGENT_PRESETS.items()
+            if preset.entrypoint.type == "loop"
+        )
+    )
+
+
+def build_preset_package(
+    preset: str,
+    model: CliModelSettings,
+    *,
+    package_id: str | None = None,
+    scheduler_root: str | Path | None = None,
+) -> SageManifest:
+    """基于内置 preset 生成一个可直接 build 的 package。
+
+    ``scheduler_root`` 给出时选用 filesystem scheduler（单写者、崩溃可恢复）；
+    为 None 则用运行时默认的 ephemeral scheduler。
+    """
+
+    if preset not in available_presets():
+        raise ValueError(
+            f"unknown v2 preset {preset!r}; available: {', '.join(available_presets())}"
+        )
+    manifest = BuiltinPackageFactory.create(
+        preset,
+        package_id=package_id or f"sage.cli.{preset}",
+        model=model.model,
+        base_url=model.base_url,
+        credential_env=model.credential_env,
+        context_window=model.context_window,
+        max_output_tokens=model.max_output_tokens,
+    )
+    capabilities = {
+        **manifest.runtime.capabilities,
+        "tool.catalog": CapabilitySelection(
+            plugin=OFFICIAL_TOOL_PLUGIN, name="official"
+        ),
+        "tool.selection-policy": CapabilitySelection(
+            plugin=DIRECT_TOOL_SELECTION_PLUGIN
+        ),
+        JOB_RUNTIME_CAPABILITY: CapabilitySelection(plugin=CLI_JOB_RUNTIME_PLUGIN),
+    }
+    if scheduler_root is not None:
+        capabilities[SCHEDULER_CAPABILITY] = CapabilitySelection(
+            plugin=FILESYSTEM_SCHEDULER_PLUGIN,
+            config={
+                "root": str(Path(scheduler_root).expanduser()),
+                "lease_seconds": CLI_SCHEDULER_LEASE_SECONDS,
+            },
+        )
+    return manifest.model_copy(
+        update={
+            "runtime": manifest.runtime.model_copy(
+                update={"capabilities": capabilities}
+            )
+        }
+    )
+
+
+def with_cli_job_runtime(manifest: SageManifest) -> SageManifest:
+    """用户自带的 package 若没选 job runtime，补上 CLI 的，否则 shell 工具不可用。"""
+
+    if JOB_RUNTIME_CAPABILITY in manifest.runtime.capabilities:
+        return manifest
+    capabilities = {
+        **manifest.runtime.capabilities,
+        JOB_RUNTIME_CAPABILITY: CapabilitySelection(plugin=CLI_JOB_RUNTIME_PLUGIN),
+    }
+    return manifest.model_copy(
+        update={
+            "runtime": manifest.runtime.model_copy(
+                update={"capabilities": capabilities}
+            )
+        }
+    )
+
+
+def without_filesystem_scheduler(manifest: SageManifest) -> SageManifest:
+    """退回 ephemeral scheduler（另一个进程正占着 filesystem scheduler 的写锁时）。"""
+
+    capabilities = dict(manifest.runtime.capabilities)
+    selection = capabilities.get(SCHEDULER_CAPABILITY)
+    plugins = (
+        {s.plugin for s in selection}
+        if isinstance(selection, tuple)
+        else {selection.plugin} if selection is not None else set()
+    )
+    if FILESYSTEM_SCHEDULER_PLUGIN not in plugins:
+        return manifest
+    capabilities.pop(SCHEDULER_CAPABILITY)
+    return manifest.model_copy(
+        update={
+            "runtime": manifest.runtime.model_copy(
+                update={"capabilities": capabilities}
+            )
+        }
+    )
+
+
+def load_package(path: str | Path) -> SageManifest:
+    """加载用户自带的 ``sage.yaml``；其 runtime 配置原样尊重。"""
+
+    return SageManifestLoader().load(Path(path).expanduser())
+

--- a/app/cli/v2/render.py
+++ b/app/cli/v2/render.py
@@ -1,0 +1,153 @@
+"""把 v2 native 事件渲染成终端输出：纯文本模式或 NDJSON（``--json``）模式。"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, Protocol, TextIO
+
+from sagents.v2.contracts.events import RuntimeEvent
+from sagents.v2.contracts.items import MessageItemData, TextBlock
+from sagents.v2.contracts.run_state import RunResult
+
+
+class EventRenderer(Protocol):
+    last_sequence: int
+
+    def handle(self, event: RuntimeEvent) -> None: ...
+
+    def frame(self, payload: dict[str, Any]) -> None:
+        """CLI 自身的框架信息（会话开始/审批请求/最终结果）。"""
+        ...
+
+    def notice(self, text: str) -> None: ...
+
+
+class PlainRenderer:
+    """人类可读渲染：assistant 文本流式到 stdout，其余状态行走 stderr。"""
+
+    def __init__(
+        self,
+        out: TextIO | None = None,
+        err: TextIO | None = None,
+        *,
+        verbose: bool = False,
+    ) -> None:
+        self.out = out or sys.stdout
+        self.err = err or sys.stderr
+        self.verbose = verbose
+        self.last_sequence = 0
+        self._assistant_items: set[str] = set()
+        self._streamed_chars: dict[str, int] = {}
+        self._announced_session: str | None = None
+
+    def handle(self, event: RuntimeEvent) -> None:
+        self.last_sequence = max(self.last_sequence, event.run_sequence)
+        data = event.data
+        if event.type == "message.started":
+            item = data.item
+            if isinstance(getattr(item, "data", None), MessageItemData):
+                if item.data.role == "assistant":
+                    self._assistant_items.add(item.item_id)
+            return
+        if event.type == "message.delta":
+            item_id = event.item_id or ""
+            if item_id not in self._assistant_items:
+                return
+            text = data.delta if isinstance(data.delta, str) else ""
+            if text:
+                self._streamed_chars[item_id] = (
+                    self._streamed_chars.get(item_id, 0) + len(text)
+                )
+                self.out.write(text)
+                self.out.flush()
+            return
+        if event.type == "message.completed":
+            item = data.item
+            if not isinstance(getattr(item, "data", None), MessageItemData):
+                return
+            if item.data.role != "assistant":
+                return
+            if self._streamed_chars.get(item.item_id, 0) == 0:
+                # provider 没有流式增量时，用完成态的完整文本兜底。
+                self.out.write(_message_text(item.data))
+            self.out.write("\n")
+            self.out.flush()
+            return
+        if data.kind == "tool":
+            line = f"[tool] {data.tool_name} {data.state}"
+            if data.error is not None:
+                line += f" ({data.error.code}: {data.error.message})"
+            self.notice(line)
+            return
+        if event.type == "run.failed" and data.error is not None:
+            self.notice(f"[run failed] {data.error.code}: {data.error.message}")
+            return
+        if event.type == "run.cancelled":
+            reason = f" reason={data.reason}" if data.reason else ""
+            self.notice(f"[run cancelled]{reason}")
+
+    def frame(self, payload: dict[str, Any]) -> None:
+        kind = payload.get("type")
+        if kind == "cli_v2_session":
+            session_id = str(payload.get("session_id"))
+            if session_id != self._announced_session:
+                self._announced_session = session_id
+                self.notice(f"session_id: {session_id}")
+            if self.verbose:
+                self.notice(f"run_id: {payload.get('run_id')}")
+        elif kind == "cli_v2_steer":
+            if payload.get("status") == "accepted":
+                self.notice(f"(steer) queued for the next model step: {payload.get('text')}")
+            elif payload.get("status") == "unapplied":
+                self.notice(
+                    f"(steer) the run ended before it could be applied: {payload.get('text')}"
+                )
+            else:
+                self.notice(
+                    f"(steer) not applied: {payload.get('detail') or 'rejected'}"
+                    + (f" — {payload.get('text')}" if payload.get("text") else "")
+                )
+        elif kind == "cli_v2_result" and payload.get("state") != "completed":
+            suffix = " (interrupted)" if payload.get("interrupted") else ""
+            self.notice(f"[result] state={payload.get('state')}{suffix}")
+
+    def notice(self, text: str) -> None:
+        self.err.write(text + "\n")
+        self.err.flush()
+
+
+class JsonRenderer:
+    """机器可读渲染：每行一个 JSON；native 事件原样透传，CLI 框架帧以 ``cli_v2_`` 前缀区分。"""
+
+    def __init__(self, out: TextIO | None = None) -> None:
+        self.out = out or sys.stdout
+        self.last_sequence = 0
+
+    def handle(self, event: RuntimeEvent) -> None:
+        self.last_sequence = max(self.last_sequence, event.run_sequence)
+        self._write(event.model_dump(mode="json"))
+
+    def frame(self, payload: dict[str, Any]) -> None:
+        self._write(payload)
+
+    def notice(self, text: str) -> None:
+        self._write({"type": "cli_v2_notice", "content": text})
+
+    def _write(self, payload: dict[str, Any]) -> None:
+        self.out.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        self.out.flush()
+
+
+def _message_text(data: MessageItemData) -> str:
+    return "".join(block.text for block in data.content if isinstance(block, TextBlock))
+
+
+def final_assistant_text(result: RunResult) -> str:
+    """从终态结果中拼出 assistant 的最终文本（多条消息以换行连接）。"""
+
+    return "\n".join(
+        _message_text(item.data)
+        for item in result.final_items
+        if isinstance(item.data, MessageItemData) and item.data.role == "assistant"
+    )

--- a/app/cli/v2/runner.py
+++ b/app/cli/v2/runner.py
@@ -1,0 +1,660 @@
+"""headless 纵切：StartRun → 消费事件流 → 审批 → 续跑 → 终态结果（支持用户中断与跨进程接管）。"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+from sagents.v2 import SAgent
+from sagents.v2.contracts.commands import (
+    CancelRun,
+    InputItem,
+    ReplyInteraction,
+    ResumeRun,
+    RunConfig,
+    StartRun,
+    SteerRun,
+)
+from sagents.v2.contracts.common import new_id
+from sagents.v2.contracts.errors import ErrorCategory, RuntimeErrorInfo
+from sagents.v2.contracts.items import TextBlock
+from sagents.v2.contracts.principals import RequestContext
+from sagents.v2.contracts.run_state import (
+    TERMINAL_RUN_STATES,
+    EventCursor,
+    RunSnapshot,
+    RunState,
+)
+
+from app.cli.services.base import CLIError
+from app.cli.v2.interaction import JSON_DECISION_TYPE, InteractionDecider
+from app.cli.v2.render import EventRenderer, final_assistant_text
+from app.cli.v2.signals import EXIT_INTERRUPTED
+
+# 用户中断后，等待 driver 在安全点退出的时间；超时不阻塞进程退出（durable 状态已是 CANCELLED）。
+INTERRUPT_GRACE_SECONDS = 5.0
+INTERRUPT_REASON = "user_interrupt"
+# CancelRun 是乐观 CAS；driver 每提交一次事件 revision 就会前进，撞车后重读重试的上限。
+CANCEL_CAS_ATTEMPTS = 8
+# SteerRun 同样是 CAS；运行中 revision 变得更快。
+STEER_CAS_ATTEMPTS = 6
+# ``--json`` 模式下，驱动方在 Run 进行中追加输入的帧类型。
+JSON_STEER_TYPE = "v2_steer"
+LineReader = Callable[[], Awaitable[str | None]]
+# 上一个进程崩溃后遗留的非终态 run：其 worker 租约（CLI 配 5s）过期后才会被重新入队并
+# 结算为 execution.worker_restarted，这里等待的上限要明显大于租约。
+PENDING_RUN_SETTLE_SECONDS = 12.0
+_PENDING_STATES = frozenset(
+    {RunState.QUEUED, RunState.RUNNING, RunState.RESUMING, RunState.SUSPEND_REQUESTED}
+)
+
+
+@dataclass
+class RunOutcome:
+    run_id: str
+    session_id: str
+    state: RunState
+    final_text: str = ""
+    error: RuntimeErrorInfo | None = None
+    event_types: list[str] = field(default_factory=list)
+    interrupted: bool = False
+    # 被接受但 Run 结束前没有机会应用的 steer 文本（模型没有再走下一步）。
+    unapplied_steers: tuple[str, ...] = ()
+
+    @property
+    def exit_code(self) -> int:
+        if self.interrupted:
+            return EXIT_INTERRUPTED
+        if self.state == RunState.COMPLETED:
+            return 0
+        if self.state == RunState.SUSPENDED:
+            return 2
+        return 1
+
+
+def build_start_run(
+    *,
+    agent_id: str,
+    task: str,
+    resolved_spec_hash: str,
+    session_id: str | None = None,
+    config: RunConfig | None = None,
+    metadata: dict | None = None,
+    invocation_mode: str | None = None,
+    idempotency_key: str | None = None,
+) -> StartRun:
+    if config is None:
+        config = RunConfig(metadata=dict(metadata or {}))
+    elif metadata:
+        config = config.model_copy(update={"metadata": {**config.metadata, **metadata}})
+    return StartRun(
+        session_id=session_id,
+        agent_id=agent_id,
+        input=(InputItem(role="user", content=(TextBlock(text=task),)),),
+        config=config,
+        resolved_spec_hash=resolved_spec_hash,
+        idempotency_key=idempotency_key or new_id("cli_request"),
+        invocation_mode=invocation_mode,
+    )
+
+
+class _EventTracker:
+    """记录本 Run 已看到的事件类型与续订阅 cursor（renderer 可能跨多个 Run 复用）。"""
+
+    def __init__(self, renderer: EventRenderer, *, start_sequence: int = 0) -> None:
+        self.renderer = renderer
+        self.seen: list[str] = []
+        self.run_sequence = start_sequence
+
+    def render(self, event) -> None:
+        self.seen.append(event.type)
+        self.run_sequence = max(self.run_sequence, event.run_sequence)
+        self.renderer.handle(event)
+
+    def cursor(self, run_id: str) -> EventCursor:
+        return EventCursor(run_id=run_id, run_sequence=self.run_sequence)
+
+
+async def run_task(
+    agent: SAgent,
+    command: StartRun,
+    context: RequestContext,
+    *,
+    renderer: EventRenderer,
+    decider: InteractionDecider,
+    session_frame: dict | None = None,
+    interrupt: asyncio.Event | None = None,
+    interrupt_grace_seconds: float = INTERRUPT_GRACE_SECONDS,
+    steer_source: LineReader | None = None,
+    steer_json: bool = False,
+) -> RunOutcome:
+    """驱动一次新 Run 直到终态；期间的每次挂起都交给 ``decider`` 作答。
+
+    ``interrupt`` 被置位（如用户按 Ctrl-C）时立即发 ``CancelRun``：durable 状态先变为
+    CANCELLED，driver 在下一个安全点看到终态自行退出。``steer_source`` 给出时，Run 进行中
+    读到的输入以 ``SteerRun`` 排入下一个安全模型边界。
+    """
+
+    stream = await agent.run_stream(command, context)
+    run_id = stream.handle.run_id
+    renderer.frame(
+        {
+            "type": "cli_v2_session",
+            "session_id": stream.handle.session_id,
+            "run_id": run_id,
+            "agent_id": command.agent_id,
+            **(session_frame or {}),
+        }
+    )
+    tracker = _EventTracker(renderer)
+    canceller = _InterruptCanceller(agent, run_id, context, renderer, interrupt)
+    steerer = _Steerer(agent, run_id, context, renderer, steer_source, json_frames=steer_json)
+    canceller.start()
+    try:
+        await _consume_events(stream.events, tracker, steerer)
+        snapshot = await canceller.wait_driver(stream.wait(), interrupt_grace_seconds)
+        snapshot = await _drive_suspensions(
+            agent,
+            snapshot,
+            context,
+            renderer=renderer,
+            decider=decider,
+            tracker=tracker,
+            canceller=canceller,
+            steerer=steerer,
+            interrupt=interrupt,
+            grace_seconds=interrupt_grace_seconds,
+        )
+    finally:
+        await canceller.stop()
+    return await _finish(agent, snapshot, renderer, tracker, canceller, steerer)
+
+
+async def resume_run(
+    agent: SAgent,
+    run_id: str,
+    context: RequestContext,
+    *,
+    renderer: EventRenderer,
+    decider: InteractionDecider,
+    session_frame: dict | None = None,
+    interrupt: asyncio.Event | None = None,
+    interrupt_grace_seconds: float = INTERRUPT_GRACE_SECONDS,
+    steer_source: LineReader | None = None,
+    steer_json: bool = False,
+) -> RunOutcome:
+    """接管一个已挂起的 Run（通常来自上一个进程）：作答/恢复后续跑到终态。"""
+
+    snapshot = await agent.runtime.get_run(run_id)
+    renderer.frame(
+        {
+            "type": "cli_v2_session",
+            "session_id": snapshot.session_id,
+            "run_id": run_id,
+            "resumed": True,
+            **(session_frame or {}),
+        }
+    )
+    tracker = _EventTracker(renderer, start_sequence=snapshot.last_run_sequence)
+    canceller = _InterruptCanceller(agent, run_id, context, renderer, interrupt)
+    steerer = _Steerer(agent, run_id, context, renderer, steer_source, json_frames=steer_json)
+    canceller.start()
+    try:
+        snapshot = await _drive_suspensions(
+            agent,
+            snapshot,
+            context,
+            renderer=renderer,
+            decider=decider,
+            tracker=tracker,
+            canceller=canceller,
+            steerer=steerer,
+            interrupt=interrupt,
+            grace_seconds=interrupt_grace_seconds,
+        )
+    finally:
+        await canceller.stop()
+    return await _finish(agent, snapshot, renderer, tracker, canceller, steerer)
+
+
+async def wait_for_pending_run_settlement(
+    agent: SAgent,
+    snapshot: RunSnapshot,
+    context: RequestContext,
+    *,
+    timeout: float = PENDING_RUN_SETTLE_SECONDS,
+) -> RunSnapshot:
+    """等一个非终态、非挂起的遗留 Run 被本进程的 dispatcher 恢复结算（或超时原样返回）。
+
+    filesystem scheduler 会在启动时把没有安全检查点的孤儿 Run 标为
+    ``execution.worker_restarted``；这里只是事件驱动地等那个结果，不重放任何副作用。
+    """
+
+    if snapshot.state not in _PENDING_STATES:
+        return snapshot
+
+    async def observe() -> None:
+        async for _ in agent.subscribe_events(
+            EventCursor(run_id=snapshot.run_id, run_sequence=snapshot.last_run_sequence),
+            context,
+        ):
+            current = await agent.runtime.get_run(snapshot.run_id)
+            if current.state not in _PENDING_STATES:
+                return
+
+    try:
+        await asyncio.wait_for(observe(), timeout=timeout)
+    except asyncio.TimeoutError:
+        pass
+    return await agent.runtime.get_run(snapshot.run_id)
+
+
+async def _drive_suspensions(
+    agent: SAgent,
+    snapshot: RunSnapshot,
+    context: RequestContext,
+    *,
+    renderer: EventRenderer,
+    decider: InteractionDecider,
+    tracker: _EventTracker,
+    canceller: "_InterruptCanceller",
+    steerer: "_Steerer",
+    interrupt: asyncio.Event | None,
+    grace_seconds: float,
+) -> RunSnapshot:
+    run_id = snapshot.run_id
+    while snapshot.state == RunState.SUSPENDED and not canceller.triggered:
+        replied = await _answer_suspension(
+            agent,
+            snapshot,
+            context,
+            decider=decider,
+            renderer=renderer,
+            abort=interrupt,
+        )
+        if not replied or canceller.triggered:
+            # 中断可能发生在等待用户作答期间：此时 Run 已被取消，不能再续跑。
+            if canceller.triggered:
+                snapshot = await agent.runtime.get_run(run_id)
+            break
+        execution = await agent.continue_run(run_id, context)
+        await _consume_events(
+            agent.subscribe_events(tracker.cursor(run_id), context), tracker, steerer
+        )
+        snapshot = await canceller.wait_driver(asyncio.shield(execution), grace_seconds)
+    return snapshot
+
+
+async def _consume_events(events, tracker: _EventTracker, steerer: "_Steerer") -> None:
+    """渲染事件流直到它在传输边界关闭；同时把运行中读到的输入交给 steerer。"""
+
+    if not steerer.enabled:
+        async for event in events:
+            tracker.render(event)
+            steerer.observe(event)
+        return
+    iterator = events.__aiter__()
+    next_event = asyncio.ensure_future(iterator.__anext__())
+    next_line: asyncio.Future | None = asyncio.ensure_future(steerer.read_line())
+    try:
+        while True:
+            waiting = {next_event} | ({next_line} if next_line is not None else set())
+            done, _ = await asyncio.wait(waiting, return_when=asyncio.FIRST_COMPLETED)
+            if next_line is not None and next_line in done:
+                line = next_line.result()
+                if line is None:
+                    next_line = None  # stdin EOF：不再读，只继续消费事件
+                else:
+                    await steerer.submit_line(line)
+                    next_line = asyncio.ensure_future(steerer.read_line())
+            if next_event in done:
+                try:
+                    event = next_event.result()
+                except StopAsyncIteration:
+                    return
+                tracker.render(event)
+                steerer.observe(event)
+                next_event = asyncio.ensure_future(iterator.__anext__())
+    finally:
+        # 取消挂着的 stdin 读取是安全的：单一读取者的队列不会因此丢行。
+        for task in (next_event, next_line):
+            if task is not None and not task.done():
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+
+
+class _Steerer:
+    """把 Run 进行中读到的输入变成 ``SteerRun``，在下一个安全模型边界生效。"""
+
+    def __init__(
+        self,
+        agent,
+        run_id: str,
+        context,
+        renderer: EventRenderer,
+        read_line: LineReader | None,
+        *,
+        json_frames: bool,
+    ) -> None:
+        self.agent = agent
+        self.run_id = run_id
+        self.context = context
+        self.renderer = renderer
+        self._read_line = read_line
+        self.json_frames = json_frames
+        self.turn_id: str | None = None
+        self.pending: list[str] = []
+        # 已提交待 steer.accepted 事件确认的文本（FIFO，与 inbox 顺序一致）
+        self._awaiting_ack: list[str] = []
+        self._accepted: dict[str, str] = {}  # steer_id -> text
+        self._settled: set[str] = set()  # applied / rejected
+
+    @property
+    def enabled(self) -> bool:
+        return self._read_line is not None
+
+    def unapplied(self) -> tuple[str, ...]:
+        return tuple(
+            text for steer_id, text in self._accepted.items() if steer_id not in self._settled
+        ) + tuple(self._awaiting_ack) + tuple(self.pending)
+
+    async def read_line(self) -> str | None:
+        assert self._read_line is not None
+        return await self._read_line()
+
+    def observe(self, event) -> None:
+        if event.type == "turn.started" and event.turn_id:
+            self.turn_id = event.turn_id
+            pending, self.pending = self.pending, []
+            for text in pending:
+                asyncio.ensure_future(self.submit(text))
+        elif event.type == "steer.accepted":
+            text = self._awaiting_ack.pop(0) if self._awaiting_ack else ""
+            self._accepted[event.data.steer_id] = text
+        elif event.type in {"steer.applied", "steer.rejected"}:
+            self._settled.add(event.data.steer_id)
+
+    def parse(self, line: str) -> str | None:
+        """把一行 stdin 解释成 steer 文本；不是 steer 的输入给出提示并丢弃。"""
+
+        if self.json_frames:
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                return None
+            if not isinstance(payload, dict):
+                return None
+            if payload.get("type") == JSON_STEER_TYPE:
+                text = str(payload.get("text") or "").strip()
+                return text or None
+            if payload.get("type") == JSON_DECISION_TYPE:
+                self._report("rejected", "", "no interaction is pending")
+            return None
+        text = line.strip()
+        if not text:
+            return None
+        if text.startswith("/"):
+            self.renderer.notice(
+                f"commands are not available while a run is active: {text}"
+            )
+            return None
+        return text
+
+    async def submit_line(self, line: str) -> None:
+        text = self.parse(line)
+        if text is not None:
+            await self.submit(text)
+
+    async def submit(self, text: str, *, attempts: int = STEER_CAS_ATTEMPTS) -> bool:
+        if self.turn_id is None:
+            # Turn 还没开始（run.accepted/queued 阶段）：等 turn.started 再发。
+            self.pending.append(text)
+            return False
+        runtime = self.agent.runtime
+        receipt = None
+        for _ in range(attempts):
+            current = await runtime.get_run(self.run_id)
+            if current.state in TERMINAL_RUN_STATES:
+                self._report("rejected", text, f"run is already {current.state.value}")
+                return False
+            receipt = await runtime.steer_run(
+                SteerRun(
+                    run_id=self.run_id,
+                    expected_revision=current.revision,
+                    expected_turn_id=self.turn_id,
+                    input=(InputItem(role="user", content=(TextBlock(text=text),)),),
+                    idempotency_key=new_id("cli_steer"),
+                ),
+                self.context,
+            )
+            if receipt.error is None:
+                self._awaiting_ack.append(text)
+                self._report("accepted", text, None)
+                return True
+            if receipt.error.category != ErrorCategory.CONFLICT:
+                break
+        code = receipt.error.code if receipt is not None and receipt.error else "?"
+        self._report("rejected", text, code)
+        return False
+
+    def _report(self, status: str, text: str, detail: str | None) -> None:
+        self.renderer.frame(
+            {
+                "type": "cli_v2_steer",
+                "run_id": self.run_id,
+                "status": status,
+                "text": text,
+                "detail": detail,
+            }
+        )
+
+
+async def _finish(
+    agent: SAgent,
+    snapshot: RunSnapshot,
+    renderer: EventRenderer,
+    tracker: _EventTracker,
+    canceller: "_InterruptCanceller",
+    steerer: "_Steerer",
+) -> RunOutcome:
+    outcome = RunOutcome(
+        run_id=snapshot.run_id,
+        session_id=snapshot.session_id,
+        state=snapshot.state,
+        event_types=tracker.seen,
+        interrupted=canceller.triggered,
+        unapplied_steers=steerer.unapplied(),
+    )
+    for text in outcome.unapplied_steers:
+        steerer._report("unapplied", text, "the run ended before its next model step")
+    if snapshot.state in TERMINAL_RUN_STATES and not canceller.driver_pending:
+        result = await agent.runtime.get_run_result(snapshot.run_id)
+        outcome.final_text = final_assistant_text(result)
+        outcome.error = result.error
+    renderer.frame(
+        {
+            "type": "cli_v2_result",
+            "run_id": outcome.run_id,
+            "session_id": outcome.session_id,
+            "state": outcome.state.value,
+            "interrupted": outcome.interrupted,
+            "final_text": outcome.final_text,
+            "error": outcome.error.model_dump(mode="json") if outcome.error else None,
+        }
+    )
+    return outcome
+
+
+class _InterruptCanceller:
+    """把用户中断翻译成一次幂等的 ``CancelRun``，并有限等待 driver 退出。"""
+
+    def __init__(self, agent, run_id, context, renderer, interrupt) -> None:
+        self.agent = agent
+        self.run_id = run_id
+        self.context = context
+        self.renderer = renderer
+        self.interrupt = interrupt
+        self.triggered = False
+        self.driver_pending = False
+        self._task: asyncio.Task | None = None
+
+    def start(self) -> None:
+        if self.interrupt is not None:
+            self._task = asyncio.create_task(self._watch())
+
+    async def stop(self) -> None:
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+    async def _watch(self) -> None:
+        assert self.interrupt is not None
+        await self.interrupt.wait()
+        self.triggered = True
+        self.renderer.notice("cancelling run (press Ctrl-C again to force quit)")
+        await self.cancel_run()
+
+    async def cancel_run(self, *, attempts: int = CANCEL_CAS_ATTEMPTS) -> bool:
+        """发 ``CancelRun``；revision 与 driver 的提交撞车时重读重试，直到终态或用尽次数。"""
+
+        runtime = self.agent.runtime
+        receipt = None
+        for _ in range(attempts):
+            current = await runtime.get_run(self.run_id)
+            if current.state in TERMINAL_RUN_STATES:
+                return True
+            receipt = await runtime.cancel_run(
+                CancelRun(
+                    run_id=self.run_id,
+                    expected_revision=current.revision,
+                    idempotency_key=(
+                        f"cli-interrupt:{self.run_id}:{current.revision}"
+                    ),
+                    reason=INTERRUPT_REASON,
+                ),
+                self.context,
+            )
+            if receipt.error is None:
+                return True
+        latest = await runtime.get_run(self.run_id)
+        if latest.state in TERMINAL_RUN_STATES:
+            return True
+        code = receipt.error.code if receipt is not None and receipt.error else "?"
+        self.renderer.notice(
+            f"cancel was rejected after {attempts} attempts ({code}); "
+            f"run is still {latest.state.value}"
+        )
+        return False
+
+    async def wait_driver(self, waiter, grace_seconds: float) -> RunSnapshot:
+        if not self.triggered:
+            return await waiter
+        try:
+            return await asyncio.wait_for(waiter, timeout=grace_seconds)
+        except asyncio.TimeoutError:
+            self.driver_pending = True
+            self.renderer.notice(
+                "run is cancelled; the local driver is still finishing its current "
+                "operation and will be abandoned on exit"
+            )
+            return await self.agent.runtime.get_run(self.run_id)
+
+
+async def _answer_suspension(
+    agent: SAgent,
+    snapshot: RunSnapshot,
+    context: RequestContext,
+    *,
+    decider: InteractionDecider,
+    renderer: EventRenderer,
+    abort: asyncio.Event | None = None,
+) -> bool:
+    """回答当前挂起的交互（或恢复一次手动暂停）；被中断时返回 False 交给上层。"""
+
+    store = agent.runtime.session_store
+    if snapshot.suspension_id is None:
+        return False
+    suspension = await store.get_suspension(snapshot.suspension_id)
+    if suspension.interaction_id is None:
+        return await _resume_manual_pause(agent, snapshot, suspension, context, renderer)
+    interaction = await store.get_interaction(suspension.interaction_id)
+    answer = await _decide_or_abort(decider, interaction, abort)
+    if answer is None:
+        return False
+    receipt = await agent.runtime.reply_interaction(
+        ReplyInteraction(
+            run_id=snapshot.run_id,
+            suspension_id=suspension.suspension_id,
+            interaction_id=interaction.interaction_id,
+            expected_revision=snapshot.revision,
+            expected_suspension_revision=suspension.expected_revision,
+            expected_interaction_revision=interaction.expected_revision,
+            decision=answer.decision,
+            payload=answer.payload,
+            idempotency_key=new_id("cli_reply"),
+        ),
+        context,
+    )
+    if receipt.error is not None:
+        latest = await agent.runtime.get_run(snapshot.run_id)
+        if latest.state in TERMINAL_RUN_STATES:
+            # 作答期间 Run 已到终态（典型：用户 Ctrl-C 取消），答案作废即可。
+            return False
+        raise CLIError(
+            f"interaction reply was rejected: {receipt.error.code}",
+            debug_detail=receipt.error.message,
+        )
+    return True
+
+
+async def _resume_manual_pause(agent, snapshot, suspension, context, renderer) -> bool:
+    """没有待答交互的挂起（手动暂停/上个进程留下的安全点）：显式 ResumeRun 后续跑。"""
+
+    renderer.notice(f"resuming paused run {snapshot.run_id}")
+    receipt = await agent.runtime.resume_run(
+        ResumeRun(
+            run_id=snapshot.run_id,
+            suspension_id=suspension.suspension_id,
+            expected_revision=snapshot.revision,
+            expected_suspension_revision=suspension.expected_revision,
+            idempotency_key=new_id("cli_resume"),
+        ),
+        context,
+    )
+    if receipt.error is not None:
+        latest = await agent.runtime.get_run(snapshot.run_id)
+        if latest.state in TERMINAL_RUN_STATES:
+            return False
+        raise CLIError(
+            f"resume was rejected: {receipt.error.code}",
+            debug_detail=receipt.error.message,
+        )
+    return True
+
+
+async def _decide_or_abort(decider, interaction, abort: asyncio.Event | None):
+    """等用户作答，但用户中断（Ctrl-C）时立刻放弃，不再等阻塞中的输入。"""
+
+    if abort is None:
+        return await decider.decide(interaction)
+    if abort.is_set():
+        return None
+    answer_task = asyncio.ensure_future(decider.decide(interaction))
+    abort_task = asyncio.ensure_future(abort.wait())
+    try:
+        done, _ = await asyncio.wait(
+            {answer_task, abort_task}, return_when=asyncio.FIRST_COMPLETED
+        )
+        if answer_task in done:
+            return answer_task.result()
+        return None
+    finally:
+        for task in (answer_task, abort_task):
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(answer_task, abort_task, return_exceptions=True)

--- a/app/cli/v2/sessions.py
+++ b/app/cli/v2/sessions.py
@@ -1,0 +1,361 @@
+"""列出某个 session root 下的 v2 会话（只读，不取 SessionStore 的写锁）。
+
+v2 明确不提供全局会话索引（README："Listing … belongs to the embedding application"），
+而 v4 的 `FilesystemSessionStore` 是单写者：另一个 `sage v2` 进程在跑时不能再打开它。
+因此列表直接读每个会话目录的权威数据：`state.json` 压缩基线 + `journal.jsonl` 增量，
+用运行时公开的 `SessionAggregate.apply` 叠加——`run.json`/`session.json` 只是可能滞后的投影。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from sagents.v2.contracts.commands import StartRun
+from sagents.v2.contracts.events import RuntimeEvent
+from sagents.v2.contracts.items import MessageItemData, TextBlock
+from sagents.v2.runtime.extensions import ExtensionScope, ExtensionScopeContext
+from sagents.v2.runtime.extensions.official import builtin_extension_registry
+from sagents.v2.runtime.session import SessionStore
+from sagents.v2.runtime.session.aggregate import SessionAggregate
+from sagents.v2.runtime.session.journal import (
+    RunRowSnapshot,
+    SessionAggregateSnapshotV2,
+    SessionMutationEnvelope,
+    SessionSnapshotEnvelope,
+)
+
+SESSION_STORE_PLUGIN = "sage.session.filesystem"
+SESSION_DIR_PREFIX = "session_"
+
+
+@dataclass(frozen=True)
+class SessionSummary:
+    session_id: str
+    created_at: datetime
+    updated_at: datetime
+    run_count: int
+    last_run_id: str | None
+    last_state: str | None
+    agent_id: str | None
+    task: str
+    workspace: str | None
+    package_id: str | None
+
+    def to_json(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["created_at"] = self.created_at.isoformat()
+        value["updated_at"] = self.updated_at.isoformat()
+        return value
+
+
+def open_session_store(session_root: str | Path) -> SessionStore:
+    """用与 ``SAgentBuilder`` 相同的插件打开文件系统 SessionStore（会取写锁）。"""
+
+    registration = builtin_extension_registry().get(SESSION_STORE_PLUGIN)
+    return registration.factory(
+        ExtensionScopeContext(
+            scope=ExtensionScope.PROCESS,
+            scope_id="sage-cli-v2-sessions",
+            config={"root": str(Path(session_root).expanduser())},
+        ),
+        {},
+    )
+
+
+def discover_session_dirs(session_root: str | Path) -> list[Path]:
+    sessions_dir = Path(session_root).expanduser() / "sessions"
+    if not sessions_dir.is_dir():
+        return []
+    return sorted(
+        entry
+        for entry in sessions_dir.iterdir()
+        if entry.is_dir() and entry.name.startswith(SESSION_DIR_PREFIX)
+    )
+
+
+def discover_session_ids(session_root: str | Path) -> list[str]:
+    return [entry.name for entry in discover_session_dirs(session_root)]
+
+
+def read_session_aggregate(session_dir: Path) -> SessionAggregateSnapshotV2:
+    """只读地重建一个会话的权威聚合：v4 基线 + 尚未压缩进基线的 journal 增量。
+
+    与 store 的 ``_read_session_aggregate`` 同一套规则：忽略不完整的 journal 尾行，
+    跳过基线已包含的旧修订，要求修订连续。不校验 checksum（列表是只读的尽力读取）。
+    """
+
+    envelope = SessionSnapshotEnvelope.model_validate_json(
+        (session_dir / "state.json").read_bytes()
+    )
+    aggregate = SessionAggregate(envelope.state)
+    revision = envelope.current_session_revision
+    journal = session_dir / "journal.jsonl"
+    if not journal.exists():
+        return aggregate.snapshot
+    lines = journal.read_bytes().splitlines(keepends=True)
+    for index, line in enumerate(lines):
+        if not line.endswith(b"\n"):
+            if index != len(lines) - 1:
+                raise ValueError("journal contains an incomplete middle record")
+            break
+        mutation = SessionMutationEnvelope.model_validate_json(line)
+        if mutation.current_session_revision <= revision:
+            continue
+        if mutation.previous_session_revision != revision:
+            raise ValueError("journal is not revision-contiguous")
+        aggregate = aggregate.apply(mutation.mutation)
+        revision = mutation.current_session_revision
+    return aggregate.snapshot
+
+
+def start_command_task(command: StartRun) -> str:
+    for item in command.input:
+        if item.role != "user":
+            continue
+        text = " ".join(
+            block.text for block in item.content if isinstance(block, TextBlock)
+        ).strip()
+        if text:
+            return text
+    return ""
+
+
+def summarize_aggregate(snapshot: SessionAggregateSnapshotV2) -> SessionSummary:
+    if len(snapshot.sessions) != 1:
+        raise ValueError("session aggregate must contain exactly one Session")
+    session = snapshot.sessions[0]
+    runs: list[RunRowSnapshot] = sorted(
+        snapshot.runs, key=lambda run: (run.created_at, run.run_id)
+    )
+    task = ""
+    agent_id = None
+    workspace = None
+    package_id = None
+    first_command = next((run.start_command for run in runs if run.start_command), None)
+    if first_command is not None:
+        task = start_command_task(first_command)
+        agent_id = first_command.agent_id
+        metadata = first_command.config.metadata
+        workspace = metadata.get("workspace") or None
+        package_id = metadata.get("package_id") or None
+    last = runs[-1] if runs else None
+    return SessionSummary(
+        session_id=session.session_id,
+        created_at=session.created_at,
+        updated_at=max((run.updated_at for run in runs), default=session.updated_at),
+        run_count=len(runs),
+        last_run_id=last.run_id if last else None,
+        last_state=last.state.value if last else None,
+        agent_id=agent_id,
+        task=task,
+        workspace=workspace,
+        package_id=package_id,
+    )
+
+
+async def list_sessions(
+    session_root: str | Path,
+    *,
+    limit: int | None = None,
+) -> tuple[list[SessionSummary], list[str]]:
+    """返回按最近活动倒序的会话摘要，以及无法读取的 session id。"""
+
+    summaries: list[SessionSummary] = []
+    unreadable: list[str] = []
+    for session_dir in discover_session_dirs(session_root):
+        try:
+            snapshot = await asyncio.to_thread(read_session_aggregate, session_dir)
+            summaries.append(summarize_aggregate(snapshot))
+        except Exception:  # noqa: BLE001 - 单个损坏会话不该让整个列表失败
+            unreadable.append(session_dir.name)
+    summaries.sort(key=lambda value: value.updated_at, reverse=True)
+    if limit is not None:
+        summaries = summaries[:limit]
+    return summaries, unreadable
+
+
+def format_sessions_table(summaries: list[SessionSummary], *, task_width: int = 60) -> str:
+    if not summaries:
+        return "no v2 sessions found"
+    lines = []
+    for value in summaries:
+        task = value.task.replace("\n", " ")
+        if len(task) > task_width:
+            task = task[: task_width - 1] + "…"
+        lines.append(
+            f"{value.session_id}  {value.updated_at.strftime('%Y-%m-%d %H:%M')}  "
+            f"runs={value.run_count}  last={value.last_state or '-'}  "
+            f"agent={value.agent_id or '-'}  {task}"
+        )
+    return "\n".join(lines)
+
+
+def sessions_json(
+    session_root: str | Path,
+    summaries: list[SessionSummary],
+    unreadable: list[str],
+) -> str:
+    return json.dumps(
+        {
+            "session_root": str(session_root),
+            "total": len(summaries),
+            "unreadable": unreadable,
+            "list": [value.to_json() for value in summaries],
+        },
+        ensure_ascii=False,
+    )
+
+
+@dataclass(frozen=True)
+class TranscriptEntry:
+    kind: str  # "user" | "assistant" | "tool" | "interaction"
+    text: str
+    detail: str | None = None
+
+    def to_json(self) -> dict[str, Any]:
+        value = {"kind": self.kind, "text": self.text}
+        if self.detail is not None:
+            value["detail"] = self.detail
+        return value
+
+
+@dataclass(frozen=True)
+class RunTranscript:
+    run_id: str
+    state: str
+    invocation_mode: str | None
+    created_at: datetime
+    updated_at: datetime
+    entries: tuple[TranscriptEntry, ...]
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "state": self.state,
+            "invocation_mode": self.invocation_mode,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "entries": [entry.to_json() for entry in self.entries],
+        }
+
+
+@dataclass(frozen=True)
+class SessionTranscript:
+    summary: SessionSummary
+    runs: tuple[RunTranscript, ...]
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "session": self.summary.to_json(),
+            "runs": [run.to_json() for run in self.runs],
+        }
+
+
+def _message_text(data: MessageItemData) -> str:
+    return "".join(block.text for block in data.content if isinstance(block, TextBlock))
+
+
+def transcript_entries(
+    command: StartRun | None, events: tuple[RuntimeEvent, ...]
+) -> tuple[TranscriptEntry, ...]:
+    """从一个 Run 的 durable 事件重建对话：用户输入、assistant 消息、工具终态、交互。"""
+
+    entries: list[TranscriptEntry] = []
+    if command is not None:
+        task = start_command_task(command)
+        if task:
+            entries.append(TranscriptEntry("user", task))
+    for event in events:
+        data = event.data
+        if event.type == "message.completed":
+            item = getattr(data, "item", None)
+            payload = getattr(item, "data", None)
+            if isinstance(payload, MessageItemData) and payload.role == "assistant":
+                text = _message_text(payload)
+                if text:
+                    entries.append(TranscriptEntry("assistant", text))
+        elif event.type == "item.completed":
+            item = getattr(data, "item", None)
+            payload = getattr(item, "data", None)
+            # 用户输入以 user 消息项落账；StartRun 之外的用户输入（如 steer）也在这里。
+            if isinstance(payload, MessageItemData) and payload.role == "user":
+                text = _message_text(payload)
+                if text and (command is None or text != start_command_task(command)):
+                    entries.append(TranscriptEntry("user", text))
+        elif data.kind == "tool" and event.type in {
+            "tool.call.succeeded",
+            "tool.call.failed",
+            "tool.call.cancelled",
+        }:
+            detail = None
+            if data.error is not None:
+                detail = f"{data.error.code}: {data.error.message}"
+            outcome = event.type.rsplit(".", 1)[-1]  # succeeded / failed / cancelled
+            entries.append(TranscriptEntry("tool", f"{data.tool_name} {outcome}", detail))
+        elif event.type == "interaction.resolved":
+            entries.append(
+                TranscriptEntry(
+                    "interaction",
+                    f"{data.interaction_type} -> {data.decision}",
+                    str(data.payload.get("tool_name") or data.payload.get("prompt") or "")
+                    or None,
+                )
+            )
+    return tuple(entries)
+
+
+def inspect_session(session_root: str | Path, session_id: str) -> SessionTranscript:
+    """只读地重建一个会话的完整转录（与 ``list_sessions`` 同一份权威聚合）。"""
+
+    session_dir = Path(session_root).expanduser() / "sessions" / session_id
+    if not (session_dir / "state.json").is_file():
+        raise FileNotFoundError(f"v2 session {session_id!r} was not found under {session_root}")
+    snapshot = read_session_aggregate(session_dir)
+    summary = summarize_aggregate(snapshot)
+    runs = sorted(snapshot.runs, key=lambda run: (run.created_at, run.run_id))
+    transcripts = tuple(
+        RunTranscript(
+            run_id=run.run_id,
+            state=run.state.value,
+            invocation_mode=(
+                run.start_command.invocation_mode if run.start_command else None
+            ),
+            created_at=run.created_at,
+            updated_at=run.updated_at,
+            entries=transcript_entries(
+                run.start_command, snapshot.run_events.get(run.run_id, ())
+            ),
+        )
+        for run in runs
+    )
+    return SessionTranscript(summary=summary, runs=transcripts)
+
+
+def format_transcript(transcript: SessionTranscript) -> str:
+    summary = transcript.summary
+    lines = [
+        f"session {summary.session_id}  created {summary.created_at:%Y-%m-%d %H:%M}  "
+        f"updated {summary.updated_at:%Y-%m-%d %H:%M}  runs={summary.run_count}"
+    ]
+    if summary.workspace:
+        lines.append(f"workspace: {summary.workspace}")
+    for index, run in enumerate(transcript.runs, start=1):
+        mode = f" mode={run.invocation_mode}" if run.invocation_mode else ""
+        lines.append(f"--- run {index} {run.run_id}  state={run.state}{mode}")
+        for entry in run.entries:
+            if entry.kind == "user":
+                lines.append(f"> {entry.text}")
+            elif entry.kind == "assistant":
+                lines.append(entry.text)
+            elif entry.kind == "tool":
+                suffix = f" ({entry.detail})" if entry.detail else ""
+                lines.append(f"[tool] {entry.text}{suffix}")
+            else:
+                suffix = f" ({entry.detail})" if entry.detail else ""
+                lines.append(f"[interaction] {entry.text}{suffix}")
+    return "\n".join(lines)

--- a/app/cli/v2/signals.py
+++ b/app/cli/v2/signals.py
@@ -1,0 +1,192 @@
+"""用户输入与中断：单一 stdin 读取者 + 覆盖整个命令生命周期的 SIGINT 控制器。"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import io
+import os
+import signal
+import sys
+import threading
+from collections.abc import Iterator
+from typing import TextIO
+
+EXIT_INTERRUPTED = 130
+
+
+class InterruptController:
+    """把 SIGINT 变成可等待的事件。
+
+    第一次按下：置位 ``event``（Run 中 → 取消 Run；提示符处 → 退出）。
+    第二次按下（事件尚未被 ``reset``）：取消当前任务，强制退出。
+    """
+
+    def __init__(self, task: asyncio.Task | None) -> None:
+        self.event = asyncio.Event()
+        self.forced = False
+        self._task = task
+
+    def on_sigint(self) -> None:
+        if not self.event.is_set():
+            self.event.set()
+            return
+        self.forced = True
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+
+    def reset(self) -> None:
+        """一段工作结束后清除中断标记，下一次 Ctrl-C 重新从"第一次"算起。"""
+
+        self.event.clear()
+
+    @property
+    def triggered(self) -> bool:
+        return self.event.is_set()
+
+
+@contextlib.contextmanager
+def interrupt_scope() -> Iterator[InterruptController]:
+    """在作用域内接管 SIGINT；离开作用域恢复默认行为。"""
+
+    loop = asyncio.get_running_loop()
+    controller = InterruptController(asyncio.current_task())
+    installed = False
+    try:
+        loop.add_signal_handler(signal.SIGINT, controller.on_sigint)
+        installed = True
+    except (NotImplementedError, RuntimeError, ValueError):
+        # Windows / 非主线程：退回 KeyboardInterrupt 语义。
+        installed = False
+    try:
+        yield controller
+    finally:
+        if installed:
+            loop.remove_signal_handler(signal.SIGINT)
+
+
+class StdinLineReader:
+    """整个进程唯一的 stdin 行读取者。
+
+    提示符输入、``--json`` 模式的决策行都从这里取，避免多个线程/协程争抢同一个 fd：
+    被 Ctrl-C 打断的读取不会留下孤儿线程去"偷"用户的下一行。优先用
+    ``loop.add_reader``（非阻塞、可取消），不支持时退回单个常驻 daemon 线程。
+    """
+
+    def __init__(self, stream: TextIO | None = None) -> None:
+        self.stream = stream if stream is not None else sys.stdin
+        self._queue: asyncio.Queue[str | None] | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._fd: int | None = None
+        self._buffer = bytearray()
+        self._eof = False
+
+    def isatty(self) -> bool:
+        try:
+            return self.stream.isatty()
+        except (AttributeError, ValueError, OSError):
+            return False
+
+    async def read_line(self) -> str | None:
+        """返回去掉行尾换行的一行；EOF 返回 None。"""
+
+        queue = self._ensure_started()
+        if self._eof and queue.empty():
+            return None
+        line = await queue.get()
+        if line is None:
+            self._eof = True
+        return line
+
+    def close(self) -> None:
+        if self._fd is not None and self._loop is not None:
+            with contextlib.suppress(Exception):
+                self._loop.remove_reader(self._fd)
+            self._fd = None
+
+    def _ensure_started(self) -> asyncio.Queue[str | None]:
+        if self._queue is not None:
+            return self._queue
+        self._loop = asyncio.get_running_loop()
+        self._queue = asyncio.Queue()
+        try:
+            fd = self.stream.fileno()
+            self._loop.add_reader(fd, self._on_readable)
+            self._fd = fd
+        except (
+            AttributeError,
+            NotImplementedError,
+            OSError,
+            RuntimeError,
+            ValueError,
+            io.UnsupportedOperation,
+        ):
+            self._start_thread()
+        return self._queue
+
+    def _on_readable(self) -> None:
+        assert self._fd is not None
+        try:
+            chunk = os.read(self._fd, 4096)
+        except BlockingIOError:
+            return
+        except OSError:
+            chunk = b""
+        if not chunk:
+            self.close()
+            if self._buffer:
+                self._push(self._buffer.decode("utf-8", errors="replace").rstrip("\r"))
+                self._buffer.clear()
+            self._push(None)
+            return
+        self._buffer.extend(chunk)
+        while b"\n" in self._buffer:
+            line, _, rest = self._buffer.partition(b"\n")
+            self._buffer[:] = rest
+            self._push(line.decode("utf-8", errors="replace").rstrip("\r"))
+
+    def _start_thread(self) -> None:
+        loop = self._loop
+        assert loop is not None
+
+        def worker() -> None:
+            while True:
+                try:
+                    line = self.stream.readline()
+                except Exception:  # noqa: BLE001 - 读失败视同 EOF
+                    line = ""
+                if line == "":
+                    loop.call_soon_threadsafe(self._push, None)
+                    return
+                loop.call_soon_threadsafe(self._push, line.rstrip("\r\n"))
+
+        threading.Thread(target=worker, name="sage-cli-v2-stdin", daemon=True).start()
+
+    def _push(self, line: str | None) -> None:
+        assert self._queue is not None
+        self._queue.put_nowait(line)
+
+
+async def read_line_or_interrupt(
+    reader: StdinLineReader, interrupt: asyncio.Event | None
+) -> str | None:
+    """等一行输入；用户中断时立即返回 None，不再等待 stdin。"""
+
+    if interrupt is None:
+        return await reader.read_line()
+    if interrupt.is_set():
+        return None
+    read_task = asyncio.ensure_future(reader.read_line())
+    wait_task = asyncio.ensure_future(interrupt.wait())
+    try:
+        done, _ = await asyncio.wait(
+            {read_task, wait_task}, return_when=asyncio.FIRST_COMPLETED
+        )
+        if read_task in done:
+            return read_task.result()
+        return None
+    finally:
+        for task in (read_task, wait_task):
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(read_task, wait_task, return_exceptions=True)

--- a/app/terminal/CLI_CONTRACT.md
+++ b/app/terminal/CLI_CONTRACT.md
@@ -63,3 +63,56 @@ If one of these contracts must change:
 3. update Rust-side tests
 4. update Python-side JSON contract tests
 5. update this document if the surface area changed
+
+## Experimental: `sage v2 {run,chat,resume,sessions} --json` (SAgents v2 runtime)
+
+`sage v2 run <task> --json` streams the v2 runtime's native `RuntimeEvent`s as NDJSON
+(one JSON object per line, `protocol_version: "sage.runtime/v2"`). CLI framing lines are
+interleaved and distinguished by a `cli_v2_` prefix on `type`:
+
+- `cli_v2_session` — first line of a run: `session_id`, `run_id`, `agent_id`, `workspace`, `session_root`, `package_id`;
+  `resumed: true` when the CLI is taking over a run left suspended by a previous process
+- `cli_v2_interaction` — the run is suspended waiting for an answer: `interaction_id`,
+  `interaction_type` (`approval` | `user_input` | ...), `allowed_decisions`, `payload`
+- `cli_v2_notice` — human-readable notice
+- `cli_v2_result` — last line of a run: `state` (`completed` | `failed` | `cancelled` | `suspended`),
+  `interrupted` (true when the user cancelled it with Ctrl-C; process exit code 130), `final_text`, `error`
+
+The driver answers a `cli_v2_interaction` by writing one JSON line to the CLI's stdin:
+
+```json
+{"type": "v2_interaction_decision", "interaction_id": "...", "decision": "approve_once", "payload": {}}
+```
+
+`decision` must be one of `allowed_decisions`; anything else is coerced to `deny`/`cancel`.
+`payload` carries `{"text": "..."}` for `submit` / `change_direction` answers.
+
+While a run is active (no interaction pending) the driver may append input for the next model step:
+
+```json
+{"type": "v2_steer", "text": "also update the tests"}
+```
+
+The CLI answers with `cli_v2_steer` (`status`: `accepted` | `rejected` | `unapplied`, `text`, `detail`).
+`unapplied` is emitted at the end of a run for input that was accepted but never reached a next model
+step; `sage v2 chat` then sends that text as the next message automatically. A decision
+frame sent while no interaction is pending is reported as a rejected steer with
+`detail: "no interaction is pending"`. In plain (non-JSON) mode steering is enabled only when stdin is
+a terminal; lines piped into `sage v2 chat` are always treated as the next prompts.
+
+`sage v2 sessions --json` is a one-shot command like `sage sessions --json`: it prints one JSON
+object with `session_root`, `total`, `unreadable` (session ids whose state could not be read) and
+`list` (newest first; each entry has `session_id`, `created_at`, `updated_at`, `run_count`,
+`last_run_id`, `last_state`, `agent_id`, `task`, `workspace`, `package_id`).
+
+`sage v2 sessions inspect <session_id> --json` prints one JSON object: `session` (the same entry
+shape as the listing) and `runs` (in order; each with `run_id`, `state`, `invocation_mode`,
+`created_at`, `updated_at` and `entries` — `{kind: user|assistant|tool|interaction, text, detail?}`
+rebuilt from the session's durable events).
+
+`sage v2 chat --json` and `sage v2 resume <session_id> --json` repeat the run framing per turn:
+between turns the CLI reads one plain-text prompt line from stdin (`/exit` ends the session);
+while a run is active, stdin lines are interpreted only as decision lines. Every turn after the
+first reuses the `session_id` announced by the first `cli_v2_session` frame.
+
+This surface is not yet consumed by `sage-terminal` and may change until the TUI integration lands.

--- a/sagents/utils/sandbox/providers/local/local.py
+++ b/sagents/utils/sandbox/providers/local/local.py
@@ -339,6 +339,15 @@ class LocalSandboxProvider(ISandboxHandle):
         # workspace-local installation for Desktop and CLI compatibility.
         if is_server_process():
             return
+        # 预装 uv 只是便利，不是沙箱正确性的一部分：CI / 离线环境可显式跳过，
+        # 避免在访问不到镜像源的机器上把 venv 准备拖到分钟级。
+        if os.environ.get("SAGE_SANDBOX_SKIP_UV_INSTALL", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+        }:
+            logger.info("[LocalSandboxProvider] SAGE_SANDBOX_SKIP_UV_INSTALL 已设置，跳过 uv 预装")
+            return
 
         venv_python = self._get_venv_python()
         if not venv_python:

--- a/tests/app/cli/test_v2_run.py
+++ b/tests/app/cli/test_v2_run.py
@@ -1,0 +1,1878 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import io
+import json
+import sys
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import app.cli.commands.v2 as v2_command
+from app.cli.parser import build_argument_parser
+from app.cli.services.base import CLIError
+from app.cli.v2.interaction import (
+    JSON_DECISION_TYPE,
+    InteractionAnswer,
+    JsonLineInteractionDecider,
+    PromptInteractionDecider,
+    StaticInteractionDecider,
+)
+from app.cli.v2.host import (
+    LocalWorkspaceBindingProvider,
+    WorkspaceSandboxSettings,
+    build_cli_application,
+)
+from app.cli.v2.package import (
+    CliModelSettings,
+    available_presets,
+    build_preset_package,
+)
+from app.cli.v2.render import JsonRenderer, PlainRenderer
+from app.cli.v2.runner import build_start_run, run_task
+from app.cli.v2.signals import (
+    StdinLineReader,
+    interrupt_scope,
+    read_line_or_interrupt,
+)
+from sagents.v2.contracts.common import new_id
+from sagents.v2.contracts.errors import ErrorCategory, RuntimeErrorInfo
+from sagents.v2.contracts.interactions import InteractionRequest, InteractionType
+from sagents.v2.contracts.principals import ActorRef, PrincipalType, RequestContext
+from sagents.v2.contracts.run_state import RunState
+from sagents.v2.model.contracts import (
+    ModelEventKind,
+    ModelResponse,
+    ModelStreamEvent,
+    ModelToolCall,
+)
+from sagents.v2.runtime.execution.sandbox import FileOperation
+from sagents.v2.testing.plugins.scripted_model import (
+    ScriptedModelProvider,
+    ScriptedModelStep,
+)
+
+CONTEXT = RequestContext(
+    actor=ActorRef(principal_id="cli-user", principal_type=PrincipalType.USER)
+)
+MODEL = CliModelSettings(model="scripted", base_url="https://model.invalid/v1")
+
+
+def _completed(text, calls=()):
+    return ModelStreamEvent(
+        kind=ModelEventKind.COMPLETED,
+        response=ModelResponse(
+            response_id=new_id("resp"),
+            text=text,
+            tool_calls=calls,
+            finish_reason="tool_calls" if calls else "stop",
+        ),
+    )
+
+
+def _delta(text):
+    return ModelStreamEvent(kind=ModelEventKind.TEXT_DELTA, delta=text)
+
+
+def write_hello_model():
+    """第 1 步调用 file_write（需要审批），第 2 步收尾。"""
+
+    return ScriptedModelProvider(
+        (
+            ScriptedModelStep(
+                events=(
+                    _delta("Writing hello.txt"),
+                    _completed(
+                        "Writing hello.txt",
+                        calls=(
+                            ModelToolCall(
+                                tool_call_id="call_1",
+                                name="file_write",
+                                arguments={
+                                    "file_path": "hello.txt",
+                                    "content": "hello\n",
+                                },
+                            ),
+                        ),
+                    ),
+                )
+            ),
+            ScriptedModelStep(events=(_delta("Done."), _completed("Done."))),
+        )
+    )
+
+
+class ClosableAgent:
+    """测试便利：像旧的 ``SAgent`` 一样 ``await agent.close()``，实际关闭整个 application。"""
+
+    def __init__(self, application):
+        self.application = application
+        self.agent = application.entrypoint()
+
+    def __getattr__(self, name):
+        return getattr(self.agent, name)
+
+    async def close(self):
+        await self.application.close()
+
+
+async def make_agent(tmp_path, model):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    package = build_preset_package("coder", MODEL)
+    bindings = LocalWorkspaceBindingProvider(
+        workspace, settings=WorkspaceSandboxSettings(process_enabled=False)
+    )
+    application = await build_cli_application(
+        package=package,
+        session_root=tmp_path / "runtime",
+        bindings=bindings,
+        model_provider=model,
+    )
+    command = build_start_run(
+        agent_id=package.entrypoint.agent,
+        task="create hello.txt",
+        resolved_spec_hash=application.composition_hash,
+    )
+    return workspace, bindings, ClosableAgent(application), command
+
+
+def line_source(*values):
+    """测试用的异步行来源：值用完即 EOF（None）。"""
+
+    remaining = list(values)
+
+    async def read_line():
+        return remaining.pop(0) if remaining else None
+
+    return read_line
+
+
+def approval_interaction(allowed=("approve_once", "deny", "cancel")):
+    return InteractionRequest(
+        interaction_id="interaction_1",
+        run_id="run_1",
+        interaction_type=InteractionType.APPROVAL,
+        allowed_decisions=tuple(allowed),
+        payload={
+            "tool_name": "file_write",
+            "arguments": {"file_path": "hello.txt"},
+            "side_effect_level": "write",
+        },
+        requested_at=datetime.now(timezone.utc),
+    )
+
+
+async def test_approve_once_writes_file_and_persists_session(tmp_path):
+    workspace, bindings, agent, command = await make_agent(tmp_path, write_hello_model())
+    out, err = io.StringIO(), io.StringIO()
+
+    outcome = await run_task(
+        agent,
+        command,
+        CONTEXT,
+        renderer=PlainRenderer(out, err),
+        decider=StaticInteractionDecider("approve_once"),
+    )
+    await agent.close()
+
+    assert outcome.state == RunState.COMPLETED
+    assert outcome.exit_code == 0
+    assert outcome.final_text == "Writing hello.txt\nDone."
+    assert (workspace / "hello.txt").read_text() == "hello\n"
+    assert "interaction.requested" in outcome.event_types
+    assert "tool.call.succeeded" in outcome.event_types
+    assert out.getvalue() == "Writing hello.txt\nDone.\n"
+    assert "[tool] file_write" in err.getvalue()
+    assert bindings.bindings[0].closed is True
+    state_file = tmp_path / "runtime" / "sessions" / outcome.session_id / "state.json"
+    assert state_file.exists()
+
+
+async def test_deny_leaves_workspace_untouched(tmp_path):
+    workspace, _, agent, command = await make_agent(tmp_path, write_hello_model())
+
+    outcome = await run_task(
+        agent,
+        command,
+        CONTEXT,
+        renderer=PlainRenderer(io.StringIO(), io.StringIO()),
+        decider=StaticInteractionDecider("deny"),
+    )
+    await agent.close()
+
+    assert outcome.state == RunState.COMPLETED
+    assert not (workspace / "hello.txt").exists()
+    assert "tool.call.cancelled" in outcome.event_types
+    assert "tool.call.dispatching" not in outcome.event_types
+
+
+async def test_json_mode_streams_native_events_and_reads_decision_line(tmp_path):
+    workspace, _, agent, command = await make_agent(tmp_path, write_hello_model())
+    out = io.StringIO()
+    renderer = JsonRenderer(out)
+    stdin_lines = line_source(
+        "not json",
+        json.dumps({"type": "something_else"}),
+        json.dumps(
+            {
+                "type": JSON_DECISION_TYPE,
+                "interaction_id": "wrong-id",
+                "decision": "approve_once",
+            }
+        ),
+        json.dumps({"type": JSON_DECISION_TYPE, "decision": "approve_once"}),
+    )
+
+    outcome = await run_task(
+        agent,
+        command,
+        CONTEXT,
+        renderer=renderer,
+        decider=JsonLineInteractionDecider(renderer, stdin_lines),
+    )
+    await agent.close()
+
+    lines = [json.loads(line) for line in out.getvalue().splitlines()]
+    types = [line["type"] for line in lines]
+    assert outcome.state == RunState.COMPLETED
+    assert (workspace / "hello.txt").exists()
+    assert types[0] == "cli_v2_session"
+    assert types[-1] == "cli_v2_result"
+    assert "cli_v2_interaction" in types
+    assert "run.completed" in types
+    interaction = next(line for line in lines if line["type"] == "cli_v2_interaction")
+    assert interaction["allowed_decisions"] == ["approve_once", "deny", "cancel"]
+    assert interaction["payload"]["tool_name"] == "file_write"
+    native = next(line for line in lines if line["type"] == "run.accepted")
+    assert native["protocol_version"] == "sage.runtime/v2"
+    assert lines[-1]["state"] == "completed"
+    assert lines[-1]["final_text"] == "Writing hello.txt\nDone."
+
+
+async def test_static_decider_never_widens_to_a_disallowed_decision():
+    decider = StaticInteractionDecider("approve_and_remember")
+    assert await decider.decide(approval_interaction()) == InteractionAnswer("deny")
+    assert await StaticInteractionDecider("cancel").decide(
+        approval_interaction(("approve_once", "cancel"))
+    ) == InteractionAnswer("cancel")
+
+
+def recovery_interaction():
+    return InteractionRequest(
+        interaction_id="interaction_2",
+        run_id="run_1",
+        interaction_type=InteractionType.USER_INPUT,
+        allowed_decisions=("retry", "change_direction", "cancel"),
+        payload={
+            "title": "The agent needs your guidance",
+            "prompt": "The model provider is temporarily unavailable.",
+            "error": {
+                "code": "model.provider_transient",
+                "message": "The model provider is temporarily unavailable.",
+                "metadata": {"diagnostic_message": "Error code: 502"},
+            },
+            "questions": [
+                {
+                    "id": "recovery_action",
+                    "type": "single",
+                    "title": "What should happen next?",
+                    "options": [
+                        {"label": "Try again", "value": "retry"},
+                        {"label": "Stop this run", "value": "cancel"},
+                    ],
+                }
+            ],
+        },
+        requested_at=datetime.now(timezone.utc),
+    )
+
+
+def user_input_interaction():
+    return InteractionRequest(
+        interaction_id="interaction_3",
+        run_id="run_1",
+        interaction_type=InteractionType.USER_INPUT,
+        allowed_decisions=("submit", "cancel"),
+        payload={"prompt": "Which target?", "questions": [{"id": "q", "type": "text"}]},
+        requested_at=datetime.now(timezone.utc),
+    )
+
+
+async def test_static_decider_cancels_user_input_and_explains_why():
+    notices: list[str] = []
+    decider = StaticInteractionDecider("approve_once", notice=notices.append)
+
+    answer = await decider.decide(recovery_interaction())
+
+    assert answer == InteractionAnswer("cancel")
+    text = notices[0]
+    assert "The model provider is temporarily unavailable." in text
+    assert "Error code: 502" in text
+    assert "[retry] Try again" in text
+    assert "non-interactive decision: cancel" in text
+
+
+async def test_prompt_decider_handles_recovery_and_free_text_questions():
+    decider = PromptInteractionDecider(line_source("?", "c", "use staging"), err=io.StringIO())
+    assert await decider.decide(recovery_interaction()) == InteractionAnswer(
+        "change_direction", {"text": "use staging"}
+    )
+
+    retry = PromptInteractionDecider(line_source("r"), err=io.StringIO())
+    assert await retry.decide(recovery_interaction()) == InteractionAnswer("retry")
+
+    submit = PromptInteractionDecider(line_source("Use staging."), err=io.StringIO())
+    assert await submit.decide(user_input_interaction()) == InteractionAnswer(
+        "submit", {"text": "Use staging."}
+    )
+
+    empty = PromptInteractionDecider(line_source("   "), err=io.StringIO())
+    assert await empty.decide(user_input_interaction()) == InteractionAnswer("cancel")
+
+
+async def test_prompt_decider_maps_keys_and_falls_back_on_eof():
+    err = io.StringIO()
+    decider = PromptInteractionDecider(line_source("?", "r", "a"), err=err)
+    assert await decider.decide(approval_interaction()) == InteractionAnswer(
+        "approve_once"
+    )
+    assert err.getvalue().count("please answer one of") == 2
+
+    decider = PromptInteractionDecider(line_source(), err=io.StringIO())
+    assert await decider.decide(approval_interaction()) == InteractionAnswer("deny")
+
+    remember = PromptInteractionDecider(line_source("r"), err=io.StringIO())
+    assert await remember.decide(
+        approval_interaction(("approve_once", "approve_and_remember", "deny"))
+    ) == InteractionAnswer("approve_and_remember")
+
+
+async def test_provider_failure_becomes_recovery_question_then_cancels_headless(
+    tmp_path,
+):
+    failing_model = ScriptedModelProvider(
+        (
+            ScriptedModelStep(
+                events=(),
+                error=RuntimeErrorInfo(
+                    code="model.provider_transient",
+                    category=ErrorCategory.PROVIDER_TRANSIENT,
+                    message="provider unreachable",
+                    retryable=True,
+                    safe_to_resume=True,
+                ),
+            ),
+        )
+    )
+    _, _, agent, command = await make_agent(tmp_path, failing_model)
+    out, err = io.StringIO(), io.StringIO()
+    renderer = PlainRenderer(out, err)
+
+    outcome = await run_task(
+        agent,
+        command,
+        CONTEXT,
+        renderer=renderer,
+        decider=StaticInteractionDecider("deny", notice=renderer.notice),
+    )
+    await agent.close()
+
+    assert outcome.state == RunState.CANCELLED
+    assert outcome.exit_code == 1
+    assert "interaction.requested" in outcome.event_types
+    assert "non-interactive decision: cancel" in err.getvalue()
+    assert "[run cancelled] reason=interaction_cancelled" in err.getvalue()
+    assert out.getvalue() == ""
+
+
+def test_binding_provider_exposes_host_workspace_paths(tmp_path):
+    provider = LocalWorkspaceBindingProvider(tmp_path)
+    spec = provider.sandbox_spec()
+
+    assert spec.workspace_root == tmp_path.resolve().as_posix()
+    assert spec.filesystem.allowed_roots == (spec.workspace_root,)
+    assert spec.metadata["host_workspace"] == str(tmp_path.resolve())
+    assert spec.process.enabled is True
+    assert spec.filesystem.allowed_operations == frozenset(FileOperation)
+
+    read_only = LocalWorkspaceBindingProvider(
+        tmp_path, settings=WorkspaceSandboxSettings(read_only=True)
+    ).sandbox_spec()
+    assert read_only.filesystem.allowed_operations == frozenset(
+        {FileOperation.READ, FileOperation.LIST}
+    )
+    assert read_only.process.read_only is True
+    assert read_only.policy_hash != spec.policy_hash
+
+
+def test_parser_v2_run_defaults():
+    args = build_argument_parser().parse_args(["v2", "run", "hello"])
+    assert args.command == "v2"
+    assert args.v2_command == "run"
+    assert args.task == "hello"
+    assert args.preset == "coder"
+    assert args.package is None
+    assert args.approval_mode is None
+    assert args.json is False
+
+
+def test_available_presets_only_include_loop_entrypoints():
+    presets = available_presets()
+    assert "coder" in presets
+    assert "assistant" in presets
+    assert "flow_orchestrator" not in presets
+
+
+def _command_args(tmp_path, **overrides):
+    values = {
+        "task": "create hello.txt",
+        "preset": "coder",
+        "package": None,
+        "workspace": str(tmp_path / "workspace"),
+        "session_id": None,
+        "session_root": str(tmp_path / "runtime"),
+        "user_id": "cli-user",
+        "approval_mode": "approve-all",
+        "read_only": False,
+        "mode": "normal",
+        "json": False,
+        "verbose": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+async def test_v2_run_command_requires_model_configuration(tmp_path, monkeypatch):
+    (tmp_path / "workspace").mkdir()
+    monkeypatch.delenv("SAGE_DEFAULT_LLM_API_KEY", raising=False)
+    cfg = SimpleNamespace(default_llm_model_name="", default_llm_api_base_url="")
+
+    with patch("app.cli.service.configure_cli_logging", return_value=cfg):
+        with pytest.raises(CLIError) as raised:
+            await v2_command.v2_run_command(_command_args(tmp_path))
+
+    steps = " ".join(raised.value.next_steps)
+    assert "SAGE_DEFAULT_LLM_MODEL_NAME" in steps
+    assert "SAGE_DEFAULT_LLM_API_KEY" in steps
+    assert "--package" in steps
+
+
+async def test_v2_run_command_end_to_end_with_injected_model(
+    tmp_path, monkeypatch, capsys
+):
+    (tmp_path / "workspace").mkdir()
+    monkeypatch.setenv("SAGE_DEFAULT_LLM_API_KEY", "test-key")
+    cfg = SimpleNamespace(
+        default_llm_model_name="scripted",
+        default_llm_api_base_url="https://model.invalid/v1",
+    )
+
+    async def build_agent(**kwargs):
+        return await build_cli_application(**kwargs, model_provider=write_hello_model())
+
+    with patch("app.cli.service.configure_cli_logging", return_value=cfg):
+        exit_code = await v2_command.v2_run_command(
+            _command_args(tmp_path), build_agent_fn=build_agent
+        )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert (tmp_path / "workspace" / "hello.txt").read_text() == "hello\n"
+    assert captured.out == "Writing hello.txt\nDone.\n"
+    assert "session_id:" in captured.err
+    assert (tmp_path / "runtime" / "sessions").is_dir()
+
+
+# ---------- C1-b：中断、续聊、多轮 chat ----------
+
+
+def talk_model(*answers):
+    return ScriptedModelProvider(
+        tuple(ScriptedModelStep(events=(_completed(text),)) for text in answers)
+    )
+
+
+def _request_texts(request):
+    return [
+        block.text
+        for message in request.messages
+        for block in message.content
+        if hasattr(block, "text")
+    ]
+
+
+class InterruptOnFirstDelta(PlainRenderer):
+    def __init__(self, interrupt: asyncio.Event, out, err):
+        super().__init__(out, err)
+        self.interrupt = interrupt
+
+    def handle(self, event):
+        super().handle(event)
+        if event.type == "message.delta" and not self.interrupt.is_set():
+            self.interrupt.set()
+
+
+async def test_interrupt_cancels_run_durably_and_exits_130(tmp_path):
+    slow_model = ScriptedModelProvider(
+        (
+            ScriptedModelStep(
+                events=(*(_delta("x") for _ in range(40)), _completed("x" * 40))
+            ),
+        )
+    )
+    _, _, agent, command = await make_agent(tmp_path, slow_model)
+    interrupt = asyncio.Event()
+    out, err = io.StringIO(), io.StringIO()
+
+    outcome = await run_task(
+        agent,
+        command,
+        CONTEXT,
+        renderer=InterruptOnFirstDelta(interrupt, out, err),
+        decider=StaticInteractionDecider("deny"),
+        interrupt=interrupt,
+    )
+    stored = await agent.runtime.get_run(outcome.run_id)
+    await agent.close()
+
+    assert outcome.interrupted is True
+    assert outcome.state == RunState.CANCELLED
+    assert outcome.exit_code == 130
+    assert stored.state == RunState.CANCELLED
+    assert "run.cancelled" in outcome.event_types
+    assert "run.completed" not in outcome.event_types
+    assert "cancelling run" in err.getvalue()
+    assert "[run cancelled] reason=user_interrupt" in err.getvalue()
+
+
+async def test_second_run_in_same_session_sees_previous_history(tmp_path):
+    model = talk_model("first answer", "second answer")
+    _, _, agent, _ = await make_agent(tmp_path, model)
+    spec_hash = agent.application.composition_hash
+    renderer = PlainRenderer(io.StringIO(), io.StringIO())
+    decider = StaticInteractionDecider("deny")
+
+    first = await run_task(
+        agent,
+        build_start_run(agent_id="coder", task="first task", resolved_spec_hash=spec_hash),
+        CONTEXT,
+        renderer=renderer,
+        decider=decider,
+    )
+    second = await run_task(
+        agent,
+        build_start_run(
+            agent_id="coder",
+            task="second task",
+            resolved_spec_hash=spec_hash,
+            session_id=first.session_id,
+        ),
+        CONTEXT,
+        renderer=renderer,
+        decider=decider,
+    )
+    await agent.close()
+
+    assert second.session_id == first.session_id
+    assert second.run_id != first.run_id
+    assert second.final_text == "second answer"
+    texts = _request_texts(model.requests[1])
+    assert "first task" in texts
+    assert "first answer" in texts
+    assert texts[-1] == "second task"
+
+
+def model_session_id(text: str) -> str:
+    return next(
+        part
+        for part in text.split()
+        if part.startswith("session_") and not part.startswith("session_id")
+    )
+
+
+def _patched_cfg():
+    return patch(
+        "app.cli.service.configure_cli_logging",
+        return_value=SimpleNamespace(
+            default_llm_model_name="scripted",
+            default_llm_api_base_url="https://model.invalid/v1",
+        ),
+    )
+
+
+async def test_chat_loop_runs_turns_in_one_session_until_exit(
+    tmp_path, monkeypatch, capsys
+):
+    (tmp_path / "workspace").mkdir()
+    monkeypatch.setenv("SAGE_DEFAULT_LLM_API_KEY", "test-key")
+    model = talk_model("hi there", "hi again")
+    stdin = StdinLineReader(
+        io.StringIO("/help\n/session\nhello\n/session\n  \nagain\n/exit\nnever\n")
+    )
+
+    async def build_agent(**kwargs):
+        return await build_cli_application(**kwargs, model_provider=model)
+
+    with _patched_cfg():
+        exit_code = await v2_command.v2_chat_command(
+            _command_args(tmp_path, task=None),
+            build_agent_fn=build_agent,
+            stdin=stdin,
+        )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out == "hi there\nhi again\n"
+    assert "built-in commands" in captured.err
+    assert "(no session yet)" in captured.err
+    assert captured.err.count("session_id: session_") == 1
+    assert captured.err.count(model_session_id(captured.err)) >= 3
+    assert "resume later with: sage v2 resume session_" in captured.err
+    assert len(model.requests) == 2
+    assert "hello" in _request_texts(model.requests[1])
+    assert "hi there" in _request_texts(model.requests[1])
+
+
+async def test_resume_unknown_session_fails_before_prompting(tmp_path, monkeypatch):
+    (tmp_path / "workspace").mkdir()
+    monkeypatch.setenv("SAGE_DEFAULT_LLM_API_KEY", "test-key")
+
+    async def build_agent(**kwargs):
+        return await build_cli_application(**kwargs, model_provider=talk_model("unused"))
+
+    with _patched_cfg():
+        with pytest.raises(CLIError) as raised:
+            await v2_command.v2_chat_command(
+                _command_args(tmp_path, task=None, session_id="session_missing"),
+                command_mode="resume",
+                build_agent_fn=build_agent,
+                stdin=StdinLineReader(io.StringIO("never\n")),
+            )
+    assert "session_missing" in str(raised.value)
+
+
+def test_parser_v2_chat_and_resume():
+    parser = build_argument_parser()
+    chat = parser.parse_args(["v2", "chat", "--approval-mode", "deny-all"])
+    assert (chat.v2_command, chat.session_id, chat.approval_mode) == (
+        "chat",
+        None,
+        "deny-all",
+    )
+    resume = parser.parse_args(["v2", "resume", "session_abc", "--read-only"])
+    assert (resume.v2_command, resume.session_id, resume.read_only) == (
+        "resume",
+        "session_abc",
+        True,
+    )
+
+
+# ---------- C1-d：会话列表 ----------
+
+
+async def test_sessions_listing_reads_authoritative_state(tmp_path):
+    from app.cli.v2.sessions import (
+        discover_session_ids,
+        format_sessions_table,
+        list_sessions,
+    )
+
+    session_root = tmp_path / "runtime"
+    assert discover_session_ids(session_root) == []
+    assert format_sessions_table([]) == "no v2 sessions found"
+
+    model = talk_model("one", "two")
+    _, _, agent, _ = await make_agent(tmp_path, model)
+    spec_hash = agent.application.composition_hash
+    renderer = PlainRenderer(io.StringIO(), io.StringIO())
+    decider = StaticInteractionDecider("deny")
+    first = await run_task(
+        agent,
+        build_start_run(
+            agent_id="coder",
+            task="first task",
+            resolved_spec_hash=spec_hash,
+            metadata={"workspace": "/w", "package_id": "sage.cli.coder"},
+        ),
+        CONTEXT,
+        renderer=renderer,
+        decider=decider,
+    )
+    second = await run_task(
+        agent,
+        build_start_run(
+            agent_id="coder",
+            task="second task\nwith detail",
+            resolved_spec_hash=spec_hash,
+            metadata={"workspace": "/w", "package_id": "sage.cli.coder"},
+        ),
+        CONTEXT,
+        renderer=renderer,
+        decider=decider,
+    )
+    await agent.close()
+
+    summaries, unreadable = await list_sessions(session_root)
+    limited, _ = await list_sessions(session_root, limit=1)
+
+    assert unreadable == []
+    assert [value.session_id for value in summaries] == [
+        second.session_id,
+        first.session_id,
+    ]
+    newest = summaries[0]
+    assert newest.task == "second task\nwith detail"
+    assert newest.run_count == 1
+    assert newest.last_run_id == second.run_id
+    assert newest.last_state == "completed"
+    assert newest.agent_id == "coder"
+    assert newest.workspace == "/w"
+    assert newest.package_id == "sage.cli.coder"
+    assert [value.session_id for value in limited] == [second.session_id]
+    table = format_sessions_table(summaries)
+    assert second.session_id in table
+    assert "last=completed" in table
+    assert "second task with detail" in table
+    assert newest.to_json()["updated_at"] == newest.updated_at.isoformat()
+
+
+async def test_v2_sessions_command_prints_json(tmp_path, monkeypatch, capsys):
+    (tmp_path / "workspace").mkdir()
+    monkeypatch.setenv("SAGE_DEFAULT_LLM_API_KEY", "test-key")
+
+    async def build_agent(**kwargs):
+        return await build_cli_application(**kwargs, model_provider=talk_model("hi"))
+
+    with _patched_cfg():
+        assert (
+            await v2_command.v2_run_command(
+                _command_args(tmp_path), build_agent_fn=build_agent
+            )
+            == 0
+        )
+        capsys.readouterr()
+        exit_code = await v2_command.v2_sessions_command(
+            argparse.Namespace(
+                limit=5,
+                session_root=str(tmp_path / "runtime"),
+                json=True,
+                verbose=False,
+            )
+        )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["total"] == 1
+    assert payload["unreadable"] == []
+    entry = payload["list"][0]
+    assert entry["task"] == "create hello.txt"
+    assert entry["last_state"] == "completed"
+    assert entry["workspace"] == str((tmp_path / "workspace").resolve())
+    assert entry["package_id"] == "sage.cli.coder"
+
+
+def test_parser_v2_sessions():
+    args = build_argument_parser().parse_args(["v2", "sessions", "--limit", "5"])
+    assert (args.v2_command, args.limit, args.json) == ("sessions", 5, False)
+
+
+
+# ---------- 取消安全：CAS 撞车、审批等待期间中断、关闭容忍 ----------
+
+
+async def test_cancel_retries_when_run_revision_races_with_driver():
+    from sagents.v2.contracts.commands import CommandDecision, CommandReceipt
+    from sagents.v2.contracts.run_state import RunSnapshot, SessionConcurrencyMode
+
+    from app.cli.v2.runner import _InterruptCanceller
+
+    now = datetime.now(timezone.utc)
+    state = {"revision": 3, "run_state": RunState.RUNNING, "cancel_calls": []}
+
+    def snapshot():
+        return RunSnapshot(
+            session_id="session_1",
+            run_id="run_1",
+            state=state["run_state"],
+            revision=state["revision"],
+            last_run_sequence=0,
+            concurrency_mode=SessionConcurrencyMode.SERIAL,
+            base_session_revision=0,
+            base_session_sequence=0,
+            accepted_session_revision=0,
+            resolved_spec_hash="sha256:x",
+            created_at=now,
+            updated_at=now,
+        )
+
+    class FakeRuntime:
+        async def get_run(self, run_id):
+            return snapshot()
+
+        async def cancel_run(self, command, context):
+            state["cancel_calls"].append(command.expected_revision)
+            if command.expected_revision != state["revision"]:
+                return CommandReceipt(
+                    command_id="cmd",
+                    decision=CommandDecision.REJECTED,
+                    error=RuntimeErrorInfo(
+                        code="run.revision_conflict",
+                        category=ErrorCategory.CONFLICT,
+                        message="stale",
+                    ),
+                )
+            state["run_state"] = RunState.CANCELLED
+            return CommandReceipt(command_id="cmd", decision=CommandDecision.ACCEPTED)
+
+    notices: list[str] = []
+    renderer = SimpleNamespace(notice=notices.append)
+    canceller = _InterruptCanceller(
+        SimpleNamespace(runtime=FakeRuntime()), "run_1", CONTEXT, renderer, None
+    )
+
+    # 第一次 get_run 之后 driver 又提交了一次（revision 前进），CancelRun 撞车。
+    original_get_run = FakeRuntime.get_run
+    calls = {"n": 0}
+
+    async def racing_get_run(self, run_id):
+        calls["n"] += 1
+        value = await original_get_run(self, run_id)
+        if calls["n"] == 1:
+            state["revision"] += 1
+        return value
+
+    FakeRuntime.get_run = racing_get_run
+    assert await canceller.cancel_run() is True
+    assert state["cancel_calls"] == [3, 4]
+    assert state["run_state"] == RunState.CANCELLED
+    assert notices == []
+
+
+async def test_interrupt_while_waiting_for_approval_exits_cleanly(tmp_path):
+    workspace, _, agent, command = await make_agent(tmp_path, write_hello_model())
+    interrupt = asyncio.Event()
+
+    class InterruptingDecider:
+        async def decide(self, interaction):
+            interrupt.set()
+            for _ in range(5):
+                await asyncio.sleep(0)
+            return InteractionAnswer("approve_once")
+
+    err = io.StringIO()
+    outcome = await run_task(
+        agent,
+        command,
+        CONTEXT,
+        renderer=PlainRenderer(io.StringIO(), err),
+        decider=InterruptingDecider(),
+        interrupt=interrupt,
+    )
+    await agent.close()
+
+    assert outcome.interrupted is True
+    assert outcome.state == RunState.CANCELLED
+    assert outcome.exit_code == 130
+    assert "tool.call.dispatching" not in outcome.event_types
+    assert not (workspace / "hello.txt").exists()
+    assert "cancelling run" in err.getvalue()
+
+
+async def test_close_tolerates_only_pending_driver_errors(tmp_path):
+    from sagents.v2.contracts.errors import SageV2Error
+
+    notices: list[str] = []
+
+    class FakeApplication:
+        def __init__(self, error):
+            self.error = error
+
+        async def close(self):
+            if self.error is not None:
+                raise self.error
+
+    class FakeBindings:
+        async def close(self):
+            return None
+
+    def session(error):
+        return v2_command.CliSession(
+            application=FakeApplication(error),
+            agent=None,
+            stdin=StdinLineReader(io.StringIO("")),
+            bindings=FakeBindings(),
+            package=None,
+            spec_hash="sha256:test",
+            agent_id="coder",
+            context=CONTEXT,
+            renderer=SimpleNamespace(notice=notices.append),
+            decider=None,
+            workspace=tmp_path,
+            session_root=tmp_path,
+        )
+
+    active = SageV2Error(
+        RuntimeErrorInfo(
+            code="agent.close_active_runs",
+            category=ErrorCategory.CONFLICT,
+            message="active",
+        )
+    )
+    wrapped = RuntimeError("1 application scope(s) failed to close")
+    wrapped.__cause__ = active
+    await session(wrapped).close()
+    assert notices and "still finishing" in notices[0]
+
+    with pytest.raises(RuntimeError, match="unrelated"):
+        await session(RuntimeError("unrelated")).close()
+
+
+async def test_interrupt_does_not_wait_for_a_blocked_prompt(tmp_path):
+    """用户 Ctrl-C 时哪怕审批提示还卡在 stdin 上，也要立刻取消并返回。"""
+
+    _, _, agent, command = await make_agent(tmp_path, write_hello_model())
+    interrupt = asyncio.Event()
+    never = asyncio.Event()
+
+    class BlockedDecider:
+        async def decide(self, interaction):
+            interrupt.set()
+            await never.wait()
+            raise AssertionError("must not be reached")
+
+    outcome = await asyncio.wait_for(
+        run_task(
+            agent,
+            command,
+            CONTEXT,
+            renderer=PlainRenderer(io.StringIO(), io.StringIO()),
+            decider=BlockedDecider(),
+            interrupt=interrupt,
+        ),
+        timeout=1.5,
+    )
+    await agent.close()
+
+    assert outcome.interrupted is True
+    assert outcome.state == RunState.CANCELLED
+    assert outcome.exit_code == 130
+
+
+
+# ---------- 单一 stdin 读取者 / SIGINT 控制器 / 跨 Run cursor ----------
+
+
+async def test_stdin_reader_uses_the_event_loop_for_real_descriptors():
+    import os
+
+    read_fd, write_fd = os.pipe()
+    stream = os.fdopen(read_fd, "r")
+    reader = StdinLineReader(stream)
+    os.write(write_fd, b"first\r\nsec")
+    assert await reader.read_line() == "first"
+    os.write(write_fd, b"ond\ntail-without-newline")
+    assert await reader.read_line() == "second"
+    os.close(write_fd)
+    assert await reader.read_line() == "tail-without-newline"
+    assert await reader.read_line() is None
+    assert await reader.read_line() is None
+    reader.close()
+    stream.close()
+
+
+async def test_stdin_reader_falls_back_to_a_thread_for_non_descriptor_streams():
+    reader = StdinLineReader(io.StringIO("one\ntwo\n"))
+    assert reader.isatty() is False
+    assert await reader.read_line() == "one"
+    assert await reader.read_line() == "two"
+    assert await reader.read_line() is None
+
+
+async def test_read_line_or_interrupt_returns_none_without_waiting_for_stdin():
+    import os
+
+    read_fd, write_fd = os.pipe()
+    stream = os.fdopen(read_fd, "r")
+    reader = StdinLineReader(stream)
+    interrupt = asyncio.Event()
+
+    async def press_ctrl_c():
+        await asyncio.sleep(0.05)
+        interrupt.set()
+
+    asyncio.get_running_loop().create_task(press_ctrl_c())
+    assert await asyncio.wait_for(read_line_or_interrupt(reader, interrupt), 1.0) is None
+    # 之后到达的输入仍由同一个读取者交付，不会被"孤儿"读取者吞掉。
+    os.write(write_fd, b"later\n")
+    assert await asyncio.wait_for(reader.read_line(), 1.0) == "later"
+    os.close(write_fd)
+    reader.close()
+    stream.close()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signals only")
+async def test_interrupt_scope_first_sigint_signals_second_force_cancels():
+    import os
+    import signal
+
+    with interrupt_scope() as controller:
+        os.kill(os.getpid(), signal.SIGINT)
+        for _ in range(20):
+            if controller.event.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert controller.event.is_set()
+        assert controller.forced is False
+
+        os.kill(os.getpid(), signal.SIGINT)
+        with pytest.raises(asyncio.CancelledError):
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+        assert controller.forced is True
+        asyncio.current_task().uncancel()
+
+        controller.reset()
+        assert controller.event.is_set() is False
+
+
+async def test_resume_cursor_is_per_run_when_one_renderer_spans_two_runs(tmp_path):
+    """第二轮也需要审批时，续订阅必须从本 Run 的序号开始，而不是上一轮的。"""
+
+    model = ScriptedModelProvider(
+        (
+            *write_hello_model()._steps,
+            *write_hello_model()._steps,
+        )
+    )
+    workspace, _, agent, _ = await make_agent(tmp_path, model)
+    spec_hash = agent.application.composition_hash
+    renderer = PlainRenderer(io.StringIO(), io.StringIO())
+    decider = StaticInteractionDecider("approve_once")
+
+    first = await run_task(
+        agent,
+        build_start_run(agent_id="coder", task="first", resolved_spec_hash=spec_hash),
+        CONTEXT,
+        renderer=renderer,
+        decider=decider,
+    )
+    second = await asyncio.wait_for(
+        run_task(
+            agent,
+            build_start_run(
+                agent_id="coder",
+                task="second",
+                resolved_spec_hash=spec_hash,
+                session_id=first.session_id,
+            ),
+            CONTEXT,
+            renderer=renderer,
+            decider=decider,
+        ),
+        timeout=1.5,
+    )
+    await agent.close()
+
+    assert first.state == RunState.COMPLETED
+    assert second.state == RunState.COMPLETED
+    assert second.event_types.count("tool.call.succeeded") == 1
+    assert second.event_types[-1] == "run.completed"
+
+
+# ---------- C1-e：崩溃恢复与跨进程接管挂起的 Run ----------
+
+
+def test_preset_package_selects_filesystem_scheduler_only_when_root_given(tmp_path):
+    from app.cli.v2.package import (
+        FILESYSTEM_SCHEDULER_PLUGIN,
+        SCHEDULER_CAPABILITY,
+        without_filesystem_scheduler,
+    )
+
+    plain = build_preset_package("coder", MODEL)
+    assert SCHEDULER_CAPABILITY not in plain.runtime.capabilities
+
+    durable = build_preset_package("coder", MODEL, scheduler_root=tmp_path / "sched")
+    selection = durable.runtime.capabilities[SCHEDULER_CAPABILITY]
+    assert selection.plugin == FILESYSTEM_SCHEDULER_PLUGIN
+    assert selection.config["root"] == str(tmp_path / "sched")
+
+    fallback = without_filesystem_scheduler(durable)
+    assert SCHEDULER_CAPABILITY not in fallback.runtime.capabilities
+    assert without_filesystem_scheduler(plain) is plain
+
+
+async def test_cli_session_uses_filesystem_scheduler_and_falls_back_when_owned(
+    tmp_path, monkeypatch, capsys
+):
+    from sagents.v2.runtime.execution.scheduler import (
+        FilesystemScheduler,
+        InMemoryScheduler,
+    )
+
+    (tmp_path / "workspace").mkdir()
+    monkeypatch.setenv("SAGE_DEFAULT_LLM_API_KEY", "test-key")
+
+    async def build_agent(**kwargs):
+        return await build_cli_application(**kwargs, model_provider=talk_model("x"))
+
+    with _patched_cfg():
+        session = await v2_command.open_cli_session(
+            _command_args(tmp_path), build_agent_fn=build_agent
+        )
+        try:
+            scheduler = session.application.services["execution.scheduler"]
+            assert isinstance(scheduler, FilesystemScheduler)
+            assert (tmp_path / "runtime" / "scheduler" / ".writer.lock").exists()
+        finally:
+            await session.close()
+
+        owner = FilesystemScheduler(tmp_path / "runtime" / "scheduler")
+        try:
+            degraded = await v2_command.open_cli_session(
+                _command_args(tmp_path), build_agent_fn=build_agent
+            )
+            try:
+                assert isinstance(
+                    degraded.application.services["execution.scheduler"],
+                    InMemoryScheduler,
+                )
+            finally:
+                await degraded.close()
+        finally:
+            await owner.close()
+
+    assert "running without restart recovery" in capsys.readouterr().err
+
+
+async def test_run_orphaned_by_a_crash_is_settled_then_the_session_resumes(
+    tmp_path, monkeypatch, capsys
+):
+    """模拟上一个进程在执行中被 kill：session 里留下 RUNNING 的 run + scheduler 里的 WorkItem。"""
+
+    from sagents.v2.contracts.common import utc_now
+    from sagents.v2.runtime import HarnessRuntime
+    from sagents.v2.runtime.execution.scheduler import FilesystemScheduler, WorkItem
+
+    from app.cli.v2.sessions import list_sessions, open_session_store
+
+    (tmp_path / "workspace").mkdir()
+    monkeypatch.setenv("SAGE_DEFAULT_LLM_API_KEY", "test-key")
+    session_root = tmp_path / "runtime"
+
+    store = open_session_store(session_root)
+    runtime = HarnessRuntime(store)
+    handle = await runtime.start_run(
+        build_start_run(agent_id="coder", task="orphan", resolved_spec_hash="sha256:x"),
+        CONTEXT,
+    )
+    running = await runtime.start_execution(
+        run_id=handle.run_id,
+        expected_revision=handle.run_revision,
+        context=CONTEXT,
+        idempotency_key="crash:start",
+    )
+    assert running.state == RunState.RUNNING
+    await store.close()
+    scheduler = FilesystemScheduler(session_root / "scheduler")
+    await scheduler.submit(
+        WorkItem(
+            work_id=f"work-{handle.run_id}",
+            run_id=handle.run_id,
+            available_at=utc_now(),
+            idempotency_key=f"dispatch:{handle.run_id}",
+            payload={
+                "resume": False,
+                "request_context": CONTEXT.model_dump(mode="json"),
+            },
+        )
+    )
+    await scheduler.close()
+
+    async def build_agent(**kwargs):
+        return await build_cli_application(**kwargs, model_provider=talk_model("hi there"))
+
+    with _patched_cfg():
+        exit_code = await v2_command.v2_chat_command(
+            _command_args(tmp_path, task=None, session_id=handle.session_id),
+            command_mode="resume",
+            build_agent_fn=build_agent,
+            stdin=StdinLineReader(io.StringIO("hello\n/exit\n")),
+        )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    # 孤儿 run 通常在 build() 内的 dispatcher.start() 就被结算；若恢复稍慢，
+    # settle_session 会等它。两条路径都必须以"新 run 正常完成"收尾。
+    assert captured.out == "hi there\n"
+
+    summaries, _ = await list_sessions(session_root)
+    store = open_session_store(session_root)
+    try:
+        runs = await store.list_session_runs(handle.session_id)
+        orphan_result = await store.get_run_result(handle.run_id)
+    finally:
+        await store.close()
+    assert summaries[0].run_count == 2
+    assert [run.state for run in runs] == [RunState.FAILED, RunState.COMPLETED]
+    assert orphan_result.error is not None
+    # 上游把无检查点孤儿 run 的结算码从 worker_restarted 演进为 barrier_recovery_failed；
+    # 对 CLI 重要的是：它被结算为终态 FAILED，会话可以继续。
+    assert orphan_result.error.code in {
+        "execution.worker_restarted",
+        "execution.barrier_recovery_failed",
+    }
+
+
+async def test_suspended_run_from_a_previous_process_is_resumed_first(
+    tmp_path, monkeypatch, capsys
+):
+    """模拟上一个进程在等审批时退出：run 停在 SUSPENDED，新进程 resume 应先接管它。"""
+
+    (tmp_path / "workspace").mkdir()
+    monkeypatch.setenv("SAGE_DEFAULT_LLM_API_KEY", "test-key")
+    workspace = tmp_path / "workspace"
+    session_root = tmp_path / "runtime"
+    package = build_preset_package("coder", MODEL, scheduler_root=session_root / "scheduler")
+
+    first_bindings = LocalWorkspaceBindingProvider(
+        workspace, settings=WorkspaceSandboxSettings(process_enabled=False)
+    )
+    first = await build_cli_application(
+        package=package,
+        session_root=session_root,
+        bindings=first_bindings,
+        model_provider=write_hello_model(),
+    )
+    agent = first.entrypoint()
+    stream = await agent.run_stream(
+        build_start_run(
+            agent_id="coder",
+            task="create hello.txt",
+            resolved_spec_hash=first.composition_hash,
+        ),
+        CONTEXT,
+    )
+    async for _ in stream.events:
+        pass
+    suspended = await stream.wait()
+    assert suspended.state == RunState.SUSPENDED
+    await first.close()
+    assert not (workspace / "hello.txt").exists()
+
+    async def build_agent(**kwargs):
+        return await build_cli_application(**kwargs, model_provider=talk_model("Done."))
+
+    with _patched_cfg():
+        exit_code = await v2_command.v2_chat_command(
+            _command_args(tmp_path, task=None, session_id=suspended.session_id),
+            command_mode="resume",
+            build_agent_fn=build_agent,
+            stdin=StdinLineReader(io.StringIO("/exit\n")),
+        )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert f"resuming suspended run {suspended.run_id}" in captured.err
+    assert (workspace / "hello.txt").read_text() == "hello\n"
+    assert captured.out.endswith("Done.\n")
+
+
+
+async def test_sessions_listing_is_read_only_and_sees_journal_deltas(tmp_path):
+    """另一个进程正占着 store 写锁时也能列会话，且读到 journal 里最新的 run 状态。"""
+
+    from app.cli.v2.sessions import list_sessions, open_session_store
+
+    session_root = tmp_path / "runtime"
+    _, _, agent, command = await make_agent(tmp_path, write_hello_model())
+    outcome = await run_task(
+        agent,
+        command,
+        CONTEXT,
+        renderer=PlainRenderer(io.StringIO(), io.StringIO()),
+        decider=StaticInteractionDecider("approve_once"),
+    )
+    await agent.close()
+
+    owner = open_session_store(session_root)
+    try:
+        summaries, unreadable = await list_sessions(session_root)
+    finally:
+        await owner.close()
+
+    assert unreadable == []
+    assert [value.session_id for value in summaries] == [outcome.session_id]
+    assert summaries[0].last_state == "completed"
+    assert summaries[0].task == "create hello.txt"
+
+
+async def test_cli_session_reports_when_the_session_root_is_owned(
+    tmp_path, monkeypatch
+):
+    from app.cli.v2.sessions import open_session_store
+
+    (tmp_path / "workspace").mkdir()
+    monkeypatch.setenv("SAGE_DEFAULT_LLM_API_KEY", "test-key")
+    owner = open_session_store(tmp_path / "runtime")
+    try:
+        with _patched_cfg():
+            with pytest.raises(CLIError) as raised:
+                await v2_command.open_cli_session(_command_args(tmp_path))
+    finally:
+        await owner.close()
+    assert "another sage v2 process is using the session root" in str(raised.value)
+    assert any("--session-root" in step for step in raised.value.next_steps)
+
+
+# ---------- --mode plan|goal 与 sessions inspect ----------
+
+
+def plan_model():
+    """plan 模式：先提交计划（需审批），再给出解释文本完成。"""
+
+    return ScriptedModelProvider(
+        (
+            ScriptedModelStep(
+                events=(
+                    _completed(
+                        "",
+                        calls=(
+                            ModelToolCall(
+                                tool_call_id="call_plan",
+                                name="goal_submit",
+                                arguments={"content": "1. read files\n2. propose patch"},
+                            ),
+                        ),
+                    ),
+                )
+            ),
+            ScriptedModelStep(events=(_completed("Here is the plan."),)),
+        )
+    )
+
+
+async def test_plan_mode_submits_a_plan_for_approval_on_a_read_only_sandbox(
+    tmp_path, monkeypatch, capsys
+):
+    (tmp_path / "workspace").mkdir()
+    monkeypatch.setenv("SAGE_DEFAULT_LLM_API_KEY", "test-key")
+    model = plan_model()
+
+    async def build_agent(**kwargs):
+        return await build_cli_application(**kwargs, model_provider=model)
+
+    with _patched_cfg():
+        session = await v2_command.open_cli_session(
+            _command_args(tmp_path, mode="plan"), build_agent_fn=build_agent
+        )
+        try:
+            assert session.bindings.settings.read_only is True
+            assert session.invocation_mode == "plan"
+            outcome = await session.run("plan the change", session_id=None, interrupt=None)
+            command = await session.agent.runtime.session_store.get_start_command(
+                outcome.run_id
+            )
+        finally:
+            await session.close()
+
+    assert outcome.state == RunState.COMPLETED
+    assert command.invocation_mode == "plan"
+    assert "tool.call.awaiting_approval" in outcome.event_types
+    assert "tool.call.succeeded" in outcome.event_types
+    assert outcome.final_text.endswith("Here is the plan.")
+    assert "goal_submit" in capsys.readouterr().err
+
+
+async def test_sessions_inspect_replays_the_transcript_read_only(tmp_path):
+    from app.cli.v2.sessions import format_transcript, inspect_session
+
+    session_root = tmp_path / "runtime"
+    model = ScriptedModelProvider((*write_hello_model()._steps, *talk_model("bye")._steps))
+    _, _, agent, command = await make_agent(tmp_path, model)
+    renderer = PlainRenderer(io.StringIO(), io.StringIO())
+    first = await run_task(
+        agent, command, CONTEXT, renderer=renderer, decider=StaticInteractionDecider("approve_once")
+    )
+    spec_hash = agent.application.composition_hash
+    second = await run_task(
+        agent,
+        build_start_run(
+            agent_id="coder",
+            task="say bye",
+            resolved_spec_hash=spec_hash,
+            session_id=first.session_id,
+        ),
+        CONTEXT,
+        renderer=renderer,
+        decider=StaticInteractionDecider("deny"),
+    )
+    await agent.close()
+
+    transcript = inspect_session(session_root, first.session_id)
+    assert transcript.summary.run_count == 2
+    assert [run.run_id for run in transcript.runs] == [first.run_id, second.run_id]
+    kinds = [(entry.kind, entry.text) for entry in transcript.runs[0].entries]
+    assert kinds[0] == ("user", "create hello.txt")
+    assert ("assistant", "Writing hello.txt") in kinds
+    assert ("interaction", "approval -> approve_once") in kinds
+    assert ("tool", "file_write succeeded") in kinds
+    assert kinds[-1] == ("assistant", "Done.")
+    assert [(e.kind, e.text) for e in transcript.runs[1].entries] == [
+        ("user", "say bye"),
+        ("assistant", "bye"),
+    ]
+    text = format_transcript(transcript)
+    assert "> create hello.txt" in text
+    assert "[tool] file_write succeeded" in text
+    assert transcript.to_json()["runs"][1]["entries"][-1] == {"kind": "assistant", "text": "bye"}
+
+    with pytest.raises(FileNotFoundError):
+        inspect_session(session_root, "session_missing")
+
+
+async def test_v2_sessions_inspect_command_prints_json(tmp_path, monkeypatch, capsys):
+    (tmp_path / "workspace").mkdir()
+    monkeypatch.setenv("SAGE_DEFAULT_LLM_API_KEY", "test-key")
+
+    async def build_agent(**kwargs):
+        return await build_cli_application(**kwargs, model_provider=talk_model("hi"))
+
+    with _patched_cfg():
+        assert (
+            await v2_command.v2_run_command(_command_args(tmp_path), build_agent_fn=build_agent)
+            == 0
+        )
+        capsys.readouterr()
+        listing = await v2_command.v2_sessions_command(
+            argparse.Namespace(
+                limit=5, session_root=str(tmp_path / "runtime"), json=True, verbose=False
+            )
+        )
+        session_id = json.loads(capsys.readouterr().out)["list"][0]["session_id"]
+        exit_code = await v2_command.v2_sessions_command(
+            argparse.Namespace(
+                sessions_command="inspect",
+                session_id=session_id,
+                session_root=str(tmp_path / "runtime"),
+                json=True,
+                verbose=False,
+            )
+        )
+        payload = json.loads(capsys.readouterr().out)
+        with pytest.raises(CLIError):
+            await v2_command.v2_sessions_command(
+                argparse.Namespace(
+                    sessions_command="inspect",
+                    session_id="session_missing",
+                    session_root=str(tmp_path / "runtime"),
+                    json=False,
+                    verbose=False,
+                )
+            )
+
+    assert listing == 0 and exit_code == 0
+    assert payload["session"]["session_id"] == session_id
+    assert payload["runs"][0]["entries"] == [
+        {"kind": "user", "text": "create hello.txt"},
+        {"kind": "assistant", "text": "hi"},
+    ]
+
+
+def test_parser_v2_mode_and_sessions_inspect():
+    parser = build_argument_parser()
+    run = parser.parse_args(["v2", "run", "x", "--mode", "plan"])
+    assert run.mode == "plan"
+    assert parser.parse_args(["v2", "chat"]).mode == "normal"
+    inspect = parser.parse_args(["v2", "sessions", "inspect", "session_abc", "--json"])
+    assert (inspect.sessions_command, inspect.session_id, inspect.json) == (
+        "inspect",
+        "session_abc",
+        True,
+    )
+
+
+# ---------- shell 工具：CLI job runtime ----------
+
+
+def shell_model(command="printf hello-from-shell"):
+    return ScriptedModelProvider(
+        (
+            ScriptedModelStep(
+                events=(
+                    _completed(
+                        "",
+                        calls=(
+                            ModelToolCall(
+                                tool_call_id="call_sh",
+                                name="execute_shell_command",
+                                arguments={"command": command},
+                            ),
+                        ),
+                    ),
+                )
+            ),
+            ScriptedModelStep(events=(_completed("shell done"),)),
+        )
+    )
+
+
+def shell_tool_result(request):
+    """execute_shell_command 的结果是 JsonBlock：从第二次模型请求的 tool 消息里取出来。"""
+
+    for message in request.messages:
+        if message.role != "tool":
+            continue
+        for block in message.content:
+            if getattr(block, "kind", None) == "json":
+                return block.value
+    raise AssertionError("no json tool result in request")
+
+
+async def make_shell_agent(tmp_path, model, *, read_only=False):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(exist_ok=True)
+    package = build_preset_package("coder", MODEL)
+    bindings = LocalWorkspaceBindingProvider(
+        workspace, settings=WorkspaceSandboxSettings(read_only=read_only)
+    )
+    application = await build_cli_application(
+        package=package,
+        session_root=tmp_path / "runtime",
+        bindings=bindings,
+        model_provider=model,
+    )
+    command = build_start_run(
+        agent_id="coder", task="run it", resolved_spec_hash=application.composition_hash
+    )
+    return workspace, bindings, ClosableAgent(application), command
+
+
+async def test_binding_carries_the_request_lifecycle_so_suspension_hooks_do_not_raise(tmp_path):
+    from sagents.v2.runtime.execution import ExecutionBindingRequest
+
+    provider = LocalWorkspaceBindingProvider(tmp_path)
+    binding = await provider.acquire(
+        ExecutionBindingRequest(run_id="run_1", agent_id="coder", context=CONTEXT)
+    )
+    try:
+        assert binding.lifecycle is None
+        await binding.on_suspended(CONTEXT)  # 不能因缺少属性而抛 AttributeError
+    finally:
+        await binding.close()
+
+
+async def test_shell_tool_runs_inside_the_run_sandbox_via_cli_job_runtime(tmp_path):
+    from app.cli.v2.jobs import CliShellJobRuntime
+
+    model = shell_model()
+    _, _, agent, command = await make_shell_agent(tmp_path, model)
+    assert isinstance(
+        agent.application.services["execution.job-runtime"], CliShellJobRuntime
+    )
+    outcome = await run_task(
+        agent,
+        command,
+        CONTEXT,
+        renderer=PlainRenderer(io.StringIO(), io.StringIO()),
+        decider=StaticInteractionDecider("approve_once"),
+    )
+    await agent.close()
+
+    assert outcome.state == RunState.COMPLETED
+    assert "tool.call.succeeded" in outcome.event_types
+    result = shell_tool_result(model.requests[1])
+    assert result["success"] is True
+    assert result["status"] == "completed"
+    assert result["exit_code"] == 0
+    assert result["stdout"] == "hello-from-shell"
+
+
+async def test_read_only_sandbox_rejects_mutating_shell_commands(tmp_path):
+    model = shell_model("rm -rf important")
+    _, _, agent, command = await make_shell_agent(tmp_path, model, read_only=True)
+    err = io.StringIO()
+    outcome = await run_task(
+        agent,
+        command,
+        CONTEXT,
+        renderer=PlainRenderer(io.StringIO(), err),
+        decider=StaticInteractionDecider("approve_once"),
+    )
+    await agent.close()
+
+    # 本地 workspace 沙箱在只读策略下拒绝任何进程执行；工具以结构化失败告知模型，文件未动。
+    assert outcome.state == RunState.COMPLETED
+    result = shell_tool_result(model.requests[1])
+    assert result["success"] is False
+    assert result["status"] == "failed"
+    assert result["error"]["code"] == "job.runner_failed"
+    assert "read-only" in result["error"]["message"]
+    assert "kind_unsupported" not in err.getvalue()
+
+
+async def test_cli_job_runtime_refuses_shell_jobs_without_a_live_binding():
+    from sagents.v2.contracts.errors import SageV2Error
+    from sagents.v2.contracts.jobs import JobSpec
+
+    from app.cli.v2.jobs import CliShellJobRuntime
+
+    class NoBindings:
+        def binding_for_run(self, run_id):
+            return None
+
+    runtime = CliShellJobRuntime(NoBindings())
+    handle = await runtime.submit(
+        JobSpec(
+            owner_run_id="run_x",
+            kind="official.shell",
+            payload={"command": "true", "cwd": "/tmp", "tool_call_id": "c"},
+            idempotency_key="k",
+        )
+    )
+    snapshot = await runtime.wait(handle.job_id)
+    assert snapshot.state.value == "failed"
+    await runtime.close()
+
+    async def emit(stream, data):
+        return None
+
+    with pytest.raises(SageV2Error) as raised:
+        await runtime._run_shell(
+            JobSpec(
+                owner_run_id="run_x",
+                kind="official.shell",
+                payload={"command": "true", "cwd": "/tmp", "tool_call_id": "c"},
+                idempotency_key="k2",
+            ),
+            emit,
+            None,
+        )
+    assert raised.value.info.code == "job.sandbox_unavailable"
+
+
+def test_packages_select_the_cli_job_runtime(tmp_path):
+    from app.cli.v2.package import (
+        CLI_JOB_RUNTIME_PLUGIN,
+        JOB_RUNTIME_CAPABILITY,
+        with_cli_job_runtime,
+    )
+
+    preset = build_preset_package("coder", MODEL)
+    assert preset.runtime.capabilities[JOB_RUNTIME_CAPABILITY].plugin == CLI_JOB_RUNTIME_PLUGIN
+    assert with_cli_job_runtime(preset) is preset
+    bare = preset.model_copy(
+        update={
+            "runtime": preset.runtime.model_copy(
+                update={
+                    "capabilities": {
+                        k: v
+                        for k, v in preset.runtime.capabilities.items()
+                        if k != JOB_RUNTIME_CAPABILITY
+                    }
+                }
+            )
+        }
+    )
+    assert JOB_RUNTIME_CAPABILITY not in bare.runtime.capabilities
+    assert (
+        with_cli_job_runtime(bare).runtime.capabilities[JOB_RUNTIME_CAPABILITY].plugin
+        == CLI_JOB_RUNTIME_PLUGIN
+    )
+
+
+# ---------- C1-g：运行中输入 → SteerRun ----------
+
+
+class GatedListDirModel:
+    """第 1 步等放行后调用 list_dir（无需审批），第 2 步收尾；用于在模型步骤之间注入 steer。"""
+
+    def __init__(self):
+        self.first_started = asyncio.Event()
+        self.release_first = asyncio.Event()
+        self.requests = []
+
+    async def capabilities(self, model_binding):
+        from sagents.v2.model.contracts import ModelCapabilities
+
+        return ModelCapabilities(
+            supports_streaming=True,
+            supports_tools=True,
+            supports_parallel_tool_calls=False,
+            supports_reasoning=False,
+            supports_multimodal_input=False,
+            supports_structured_output=False,
+        )
+
+    def stream(self, request):
+        return self._stream(request)
+
+    async def _stream(self, request):
+        self.requests.append(request)
+        if len(self.requests) == 1:
+            self.first_started.set()
+            await self.release_first.wait()
+            yield _completed(
+                "",
+                calls=(ModelToolCall(tool_call_id="c1", name="list_dir", arguments={}),),
+            )
+        else:
+            yield _completed("done")
+
+
+async def test_typing_during_a_run_steers_the_next_model_step(tmp_path):
+    model = GatedListDirModel()
+    _, _, agent, command = await make_agent(tmp_path, model)
+    accepted = asyncio.Event()
+    err = io.StringIO()
+
+    class Observer(PlainRenderer):
+        def handle(self, event):
+            super().handle(event)
+            if event.type == "steer.accepted":
+                accepted.set()
+
+    sent = {"count": 0}
+
+    async def steer_source():
+        if sent["count"] == 0:
+            sent["count"] += 1
+            await model.first_started.wait()
+            return "also check the tests"
+        await asyncio.Event().wait()  # 之后不再有输入；结束时会被取消
+
+    async def release_when_accepted():
+        await accepted.wait()
+        model.release_first.set()
+
+    releaser = asyncio.create_task(release_when_accepted())
+    outcome = await asyncio.wait_for(
+        run_task(
+            agent,
+            command,
+            CONTEXT,
+            renderer=Observer(io.StringIO(), err),
+            decider=StaticInteractionDecider("deny"),
+            steer_source=steer_source,
+        ),
+        timeout=1.8,
+    )
+    await releaser
+    await agent.close()
+
+    assert outcome.state == RunState.COMPLETED
+    assert "steer.accepted" in outcome.event_types
+    assert "steer.applied" in outcome.event_types
+    assert "also check the tests" in _request_texts(model.requests[1])
+    assert "(steer) queued for the next model step: also check the tests" in err.getvalue()
+
+
+async def test_steerer_parses_frames_and_defers_until_the_turn_starts():
+    from app.cli.v2.runner import JSON_STEER_TYPE, _Steerer
+
+    notices: list[str] = []
+    frames: list[dict] = []
+    renderer = SimpleNamespace(notice=notices.append, frame=frames.append)
+
+    json_steerer = _Steerer(None, "run_1", CONTEXT, renderer, None, json_frames=True)
+    assert json_steerer.parse(json.dumps({"type": JSON_STEER_TYPE, "text": " go "})) == "go"
+    assert json_steerer.parse("garbage") is None
+    assert json_steerer.parse(json.dumps({"type": JSON_DECISION_TYPE, "decision": "deny"})) is None
+    assert frames[-1]["status"] == "rejected"
+    assert frames[-1]["detail"] == "no interaction is pending"
+
+    plain = _Steerer(None, "run_1", CONTEXT, renderer, None, json_frames=False)
+    assert plain.parse("   ") is None
+    assert plain.parse("/help") is None
+    assert "not available while a run is active" in notices[-1]
+    assert plain.parse("more detail please") == "more detail please"
+    assert await plain.submit("early") is False
+    assert plain.pending == ["early"]
+
+
+async def test_steering_is_enabled_only_for_tty_or_json_stdin(tmp_path, monkeypatch, capsys):
+    (tmp_path / "workspace").mkdir()
+    monkeypatch.setenv("SAGE_DEFAULT_LLM_API_KEY", "test-key")
+
+    async def build_agent(**kwargs):
+        return await build_cli_application(**kwargs, model_provider=talk_model("x"))
+
+    with _patched_cfg():
+        piped = await v2_command.open_cli_session(
+            _command_args(tmp_path), build_agent_fn=build_agent, stdin=StdinLineReader(io.StringIO(""))
+        )
+        try:
+            assert piped.steer_enabled is False
+        finally:
+            await piped.close()
+        driven = await v2_command.open_cli_session(
+            _command_args(tmp_path, json=True),
+            build_agent_fn=build_agent,
+            stdin=StdinLineReader(io.StringIO("")),
+        )
+        try:
+            assert driven.steer_enabled is True
+            assert driven._steer_kwargs()["steer_json"] is True
+        finally:
+            await driven.close()
+    capsys.readouterr()
+
+
+async def test_steer_accepted_after_the_last_model_step_is_reported_as_unapplied(tmp_path):
+    """模型一步收尾时，已接受的 steer 没有下一步可应用：不能静默丢掉。"""
+
+    class GatedOneStepModel(GatedListDirModel):
+        async def _stream(self, request):
+            self.requests.append(request)
+            self.first_started.set()
+            await self.release_first.wait()
+            yield _completed("done in one step")
+
+    model = GatedOneStepModel()
+    _, _, agent, command = await make_agent(tmp_path, model)
+    accepted = asyncio.Event()
+    err = io.StringIO()
+
+    class Observer(PlainRenderer):
+        def handle(self, event):
+            super().handle(event)
+            if event.type == "steer.accepted":
+                accepted.set()
+
+    sent = {"count": 0}
+
+    async def steer_source():
+        if sent["count"] == 0:
+            sent["count"] += 1
+            await model.first_started.wait()
+            return "one more thing"
+        await asyncio.Event().wait()
+
+    async def release_when_accepted():
+        await accepted.wait()
+        model.release_first.set()
+
+    releaser = asyncio.create_task(release_when_accepted())
+    outcome = await asyncio.wait_for(
+        run_task(
+            agent,
+            command,
+            CONTEXT,
+            renderer=Observer(io.StringIO(), err),
+            decider=StaticInteractionDecider("deny"),
+            steer_source=steer_source,
+        ),
+        timeout=1.8,
+    )
+    await releaser
+    await agent.close()
+
+    assert outcome.state == RunState.COMPLETED
+    assert "steer.accepted" in outcome.event_types
+    assert "steer.applied" not in outcome.event_types
+    assert outcome.unapplied_steers == ("one more thing",)
+    assert "(steer) the run ended before it could be applied: one more thing" in err.getvalue()

--- a/tests/sagents/utils/sandbox/test_lifecycle_e2e.py
+++ b/tests/sagents/utils/sandbox/test_lifecycle_e2e.py
@@ -10,7 +10,9 @@ from sagents.utils.sandbox.interface import SandboxType
 
 @pytest.mark.parametrize("mode", [SandboxType.PASSTHROUGH, SandboxType.LOCAL])
 @pytest.mark.timeout(60)
-def test_sandbox_lifecycle_syncs_skill_and_executes_python(tmp_path, mode):
+def test_sandbox_lifecycle_syncs_skill_and_executes_python(tmp_path, mode, monkeypatch):
+    # 生命周期测试不需要 uv；预装 uv 要访问 PyPI 镜像，在海外 CI 上常常独自耗尽 60s 预算。
+    monkeypatch.setenv("SAGE_SANDBOX_SKIP_UV_INSTALL", "1")
     host_skills = tmp_path / "host-skills"
     skill_dir = host_skills / "e2e-skill"
     skill_dir.mkdir(parents=True)

--- a/tests/sagents/v2/test_source_boundary_matrix.py
+++ b/tests/sagents/v2/test_source_boundary_matrix.py
@@ -9,6 +9,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 
 REPOSITORY_ROOT = Path(__file__).parents[3]
 V2_ROOT = REPOSITORY_ROOT / "sagents" / "v2"
@@ -375,8 +377,13 @@ def test_v2_contains_no_symlink_to_repository_owned_code():
     assert offenders == []
 
 
+@pytest.mark.timeout(30)
 def test_v2_imports_when_it_is_the_only_sagents_implementation(tmp_path: Path):
-    """Physically isolate V2 so an accidental old-module import cannot succeed."""
+    """Physically isolate V2 so an accidental old-module import cannot succeed.
+
+    This copies the whole V2 tree and imports every module in a fresh interpreter;
+    that is well beyond the 2s default budget on CI runners, so it gets its own limit.
+    """
 
     package_root = tmp_path / "isolated"
     isolated_sagents = package_root / "sagents"


### PR DESCRIPTION
## Summary

This PR adds a headless CLI on the standalone SAgents v2 runtime. It is the second real consumer of v2 next to `app/desktop_v2`, and it uses **only the public composition root and facade** — `SAgentBuilder` → `SAgentApplication`, `run_stream` / `reply_interaction` / `continue_run` / `subscribe_events`, plus one `ExecutionBindingProvider` — so it doubles as an end-to-end exercise of the v2 host boundary from a non-GUI host.

It coexists with the v1 `sage run/chat/resume` commands and hangs off the existing `sage v2` group (next to `sage v2 migrate`). The CLI commit touches nothing under `sagents/`, `app/desktop*`, `app/server` or `app/chrome-extension`; the only files outside `app/cli/` are the new tests and a short experimental section in `app/terminal/CLI_CONTRACT.md`.

> **Note on the second commit.** `Pytest (sagents)` was already failing on `main` before this PR, for two machine-dependent timeouts unrelated to the CLI (#261). The second commit (`test: stop two sandbox/v2 tests from timing out on CI runners`, 3 files, +20/−2) fixes them so this PR's CI can be judged on its own. It is deliberately kept as a separate commit and can be split into its own PR if you prefer. Details in the **CI** section below.

```text
sage v2 run|chat|resume|sessions
        │  app/cli/commands/v2.py        argument handling, session lifetime, exit codes
        ▼
app/cli/v2/
  package.py      preset or sage.yaml → SageManifest (+ CLI capability selections)
  host.py         LocalWorkspaceBindingProvider (ExecutionBindingProvider) + build_cli_application()
  runner.py       run_task / resume_run: StartRun → events → interactions → continue → terminal result
  interaction.py  InteractionDecider: TTY prompt | fixed policy | JSON stdin frames
  render.py       PlainRenderer (streamed text) | JsonRenderer (NDJSON + cli_v2_* frames)
  signals.py      one StdinLineReader + InterruptController (Ctrl-C semantics)
  sessions.py     read-only listing / transcript from the store's authoritative aggregate
  jobs.py         CLI job runtime so official.shell works on the builder path (see "Upstream issues")
        │
        ▼
sagents.v2  (SAgentBuilder → SAgentApplication → SAgent; RuntimeEvent stream; SessionStore v4)
```

## Commands

| command | behaviour |
|---|---|
| `sage v2 run <task>` | One Run, in-process. Exit codes: `0` completed, `1` failed/cancelled, `2` suspended without a pending interaction, `130` interrupted by Ctrl-C. |
| `sage v2 chat` | Multi-turn REPL on one session; every turn is a new Run in the same `session_id`, so later turns see earlier history. Input typed while a Run is active steers it. |
| `sage v2 resume <session_id>` | Same REPL on an existing session. A Run left `SUSPENDED` by a previous process is taken over first; an orphaned `RUNNING` Run is settled before a new one starts. |
| `sage v2 sessions [--limit N] [--json]` | Newest-first listing of sessions under a session root. Read-only; works while another process holds the store. |
| `sage v2 sessions inspect <session_id> [--json]` | Transcript replay (user inputs, assistant messages, tool outcomes, resolved interactions) per Run. |

Common options: `--preset` (any built-in loop preset, default `coder`) or `--package path/to/sage.yaml`; `--workspace` (default: cwd); `--session-root` (default `~/.sage/v2/runtime`); `--mode normal|plan|goal`; `--approval-mode ask|approve-all|deny-all`; `--read-only`; `--json`; `--user-id`; `--verbose`.

Model configuration is reused from the v1 CLI (`SAGE_DEFAULT_LLM_MODEL_NAME`, `SAGE_DEFAULT_LLM_API_BASE_URL`, `SAGE_DEFAULT_LLM_API_KEY`, loaded from `~/.sage/.sage_env` like every other `sage` command), so a configured v1 user can run `sage v2 run "…"` with no extra setup. A user-supplied `sage.yaml` is respected as-is (its own runtime capabilities included); the CLI only adds its job-runtime selection when the package selects none.

## Design notes

**Sandbox policy is data supplied by the host.** `LocalWorkspaceBindingProvider` builds a `ResolvedSandboxSpec` per Run for `LocalWorkspaceSandboxProvider`: the workspace is exposed by its host path, `allowed_roots` is that path, the process allowlist mirrors desktop_v2, and `--read-only` (or plan mode) narrows the filesystem policy to read/list and sets `ProcessPolicy.read_only`. The agent has no way to select or lower any of it.

**Native events drive rendering.** Plain mode streams assistant text to stdout and keeps status lines on stderr (filtering by item role, so the user's own input echoed back as `message.completed` is not printed). `--json` mode prints every `RuntimeEvent` as one NDJSON line, interleaved with a few `cli_v2_*` framing lines (`cli_v2_session`, `cli_v2_interaction`, `cli_v2_steer`, `cli_v2_notice`, `cli_v2_result`). The framing is documented in `app/terminal/CLI_CONTRACT.md` and marked experimental; it is the surface the Rust TUI will consume next.

**Interactions.** `approval` and `user_input` requests (including the runtime's recovery questionnaire after a provider failure) go through one `InteractionDecider` protocol with three implementations: a TTY prompt, a fixed policy (`--approval-mode approve-all|deny-all`, also the default on a non-TTY stdin), and a JSON stdin decoder (`{"type":"v2_interaction_decision","interaction_id":…,"decision":…,"payload":…}`). Any answer outside `allowed_decisions` is coerced to `deny`/`cancel` — the CLI can only narrow, never widen. Headless runs print the full interaction (title, prompt, error, options) before cancelling, so an unreachable provider ends with an explanation rather than a silent cancel.

**Cancellation.** `CancelRun` is an optimistic CAS and the driver advances the Run revision on every committed event, so the interrupt path re-reads and retries (bounded). Once the Run is terminal, a late answer to an interaction is discarded instead of raised and the loop never tries to `continue_run` a cancelled Run. One `InterruptController` spans the whole command: the first Ctrl-C cancels the active Run (or leaves the chat prompt), the second force-quits with exit code 130 and no traceback.

**stdin.** All prompt, decision and steer reads go through one `StdinLineReader` (event-loop `add_reader` on real descriptors, a single daemon thread otherwise), and every wait is raced against the interrupt. An abandoned read therefore never leaves an orphan thread that could swallow the next line or block process exit. Piped input into a plain `sage v2 chat` is always treated as the next prompts, never as steering.

**Steering.** While a Run is active the CLI reads stdin next to the event stream and turns each line into a `SteerRun` for the next safe model boundary (TTY: any typed line; `--json`: `{"type":"v2_steer","text":…}` frames answered with `cli_v2_steer`). It learns the turn id from `turn.started`, retries the CAS on revision races and reports rejections instead of failing the Run. Because a steer is applied only at the *next* model step, input accepted after the model's final step would otherwise be lost; the CLI correlates `steer.accepted`/`steer.applied` per steer id, reports such input as `unapplied`, and `sage v2 chat` sends it as the next message.

**Crash recovery.** A SERIAL session is owned by its last Run until that Run is terminal, so a process killed mid-run used to leave the session permanently unusable (`session.serial_run_active`). Preset packages therefore select `sage.scheduler.filesystem` under the session root with a 5 s worker lease; on the next start the dispatcher settles the orphaned, uncheckpointed Run and `resume`/`--session-id` wait (bounded, event-driven) for that before starting a new Run. A Run left `SUSPENDED` because the process died while waiting for an approval is taken over first: its pending interaction is answered through the normal decider and the Run is continued to a terminal state; manual pauses are resumed with an explicit `ResumeRun`. If another live process already owns the scheduler root, the CLI falls back to the ephemeral scheduler with a notice.

**Session listing is read-only.** v2 deliberately leaves listing to the host, and the v4 `FilesystemSessionStore` is single-writer per root, so `sage v2 sessions` never opens the store. It discovers session directories and rebuilds each session's authoritative aggregate from the v4 base snapshot plus the revision-contiguous journal (`SessionAggregate.apply`), which also works while another `sage v2` process is running. `run`/`chat` explain `session_store.in_use` instead of failing with a raw error. CLI-started Runs record `workspace` and `package_id` in `RunConfig.metadata` so the listing can show where a session came from.

**Modes.** `--mode plan|goal` sets `StartRun.invocation_mode`; plan mode also forces the read-only sandbox. The runtime grants `goal_submit`/`goal_complete` per invocation and asks approval for the submitted plan. On the local workspace sandbox, the read-only policy refuses process execution entirely, so plan mode has no shell; write attempts return structured failures to the model.

## Upstream issues found while building this

Both were introduced by the recent v2 refactors and are invisible to desktop_v2, which constructs its tool runtime by hand. The CLI carries small, self-contained workarounds that can be deleted once the runtime is fixed; I can open separate issues/PRs with the repros.

1. **`execute_shell_command` fails with `job.kind_unsupported` on the builder path.** `SAgentBuilder.build()` → `configure_official_runtime()` assigns the application-level `execution.job-runtime` (the `sage.job.ephemeral` instance built from the manifest, `runners: {}`) to every Run's `OfficialToolRuntime.job_runtime`, replacing the runtime's built-in `InMemoryJobRuntime({"official.shell": self._run_shell_job})`. The shell runner needs the Run's own sandbox and grant issuer, which a process-wide runtime built from JSON cannot carry. Workaround: `app/cli/v2/jobs.py` registers `sage.cli.job-runtime`, an in-memory job runtime whose `official.shell` runner resolves the Run's sandbox binding by `owner_run_id` through the CLI's `ExecutionBindingProvider` and executes there with a freshly issued grant, mirroring `OfficialToolRuntime._run_shell_job`.
2. **`RunExecutionBinding.on_suspended` reads `self.lifecycle`, which is only declared on `ExecutionBindingRequest`.** Any binding built per the protocol raises `AttributeError` on every suspension (logged as "failed to close terminal Run driver"). Workaround: the CLI binding provider copies `request.lifecycle` onto the binding.

## Known limits / follow-ups (intentionally out of scope here)

- **Approval strategy is the builder default.** `SAgentBuilder` has no `with_tool_policy(...)` hook, so `--approval-mode` decides how the CLI *answers*, not whether the runtime *asks* (desktop_v2 passes its `DefaultToolPolicy` to `create_engine` by hand). Likewise the builder path does not consume `RunConfig.enabled_tools`, so plan mode cannot hide write tools from the model; the sandbox is the enforcement boundary. Both are small builder additions I am happy to propose separately.
- The `--json` framing is experimental until the Rust TUI consumes it.
- One `sage v2 run/chat` process per session root (the v4 store is single-writer); the CLI reports this clearly.
- No `SteerRun` for delegated child Runs, no session deletion/renaming — listing and inspection only.

## Testing

`tests/app/cli/test_v2_run.py` — 49 tests, all with the scripted model provider, no network, each under the repository's 2 s limit. They run the real local sandbox, the real filesystem session store and the real filesystem scheduler in temp directories and cover: approve/deny end to end (file written vs. untouched), JSON framing plus stdin decision and steer frames, decider coercion and the recovery questionnaire, history projection into later Runs of a session, the chat loop and its built-in commands, resume of an unknown session, durable cancellation and its revision races (including Ctrl-C while an approval prompt is open), per-Run cursor across turns, the single stdin reader (pipe and thread fallback) and SIGINT controller, simulated crashes (orphaned `RUNNING` Run + persisted work item; `SUSPENDED` hand-over between application instances), scheduler fallback when the root is owned, read-only listing/inspection while the store is owned, `session_store.in_use` reporting, plan mode, shell execution through the CLI job runtime, and the parser surface.

Full runs on this branch: `tests/app/cli` 169 passed, `tests/sagents/v2` 1659 passed / 17 skipped, `tests/app` 370 passed (excluding `tests/app/server/test_agui_v2_router.py`, which needs the optional `ag_ui` package), `ruff check app/cli` clean.

Manually verified against a real provider on the current `main`: run, chat, cross-process resume (a token from the previous process is recalled), shell via `execute_shell_command`, plan mode (plan submitted for approval, write attempt rejected by the read-only sandbox), Ctrl-C during streaming (exit 130, store shows `cancelled`), double Ctrl-C (force quit, no traceback), `kill -9` mid-run followed by `sage v2 resume` (orphan settled, session continues), `sage v2 sessions` while another run is active, an unreachable provider (recovery questionnaire → explained cancel, exit 1), JSON steer frames, and `sage v2 migrate --help` unchanged.

## CI

Fixes #261.

The first run of this PR failed only in `Pytest (sagents)`, on the same two tests that fail on the current `main` ([run for `a4bb126f`](https://github.com/ZHangZHengEric/Sage/actions/runs/33506079141)); neither is related to the CLI. The second commit fixes both, and with it the job went from 4–5 min red to [2m03s green](https://github.com/ZHangZHengEric/Sage/actions/runs/33530542525):

- `tests/sagents/utils/sandbox/test_lifecycle_e2e.py::…[SandboxType.LOCAL]` spends its whole 60 s budget in `LocalSandboxProvider._ensure_uv_in_venv()`, which pip-installs `uv` from `mirrors.aliyun.com` before falling back to PyPI; GitHub's hosted runners reach that mirror slowly enough that pip's retries alone exceed the limit. Pre-installing `uv` is a convenience rather than part of sandbox correctness, so the provider now honours `SAGE_SANDBOX_SKIP_UV_INSTALL` (same style as the existing `is_server_process()` skip) and the lifecycle test sets it. Production behaviour is unchanged unless the variable is set.
- `tests/sagents/v2/test_source_boundary_matrix.py::test_v2_imports_when_it_is_the_only_sagents_implementation` copies the whole V2 tree and imports every module in a fresh interpreter, which takes ≈1.2 s on a laptop and more than the 2 s global limit on a two-core runner. It gets its own 30 s budget.

## Files

- `app/cli/v2/{__init__,package,host,runner,interaction,render,signals,sessions,jobs}.py` — new
- `app/cli/commands/v2.py` — new
- `app/cli/parser.py`, `app/cli/main.py` — attach `run|chat|resume|sessions` to the existing `sage v2` group
- `app/terminal/CLI_CONTRACT.md` — experimental `--json` framing for the TUI
- `tests/app/cli/test_v2_run.py` — new
- `sagents/utils/sandbox/providers/local/local.py`, `tests/sagents/utils/sandbox/test_lifecycle_e2e.py`, `tests/sagents/v2/test_source_boundary_matrix.py` — CI timeout fixes (second commit)
