### PR TITLE
build: add redis and prometheus-client to requirements.txt so tests/app collects on CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ uvicorn[standard]>=0.38.0
 uvloop>=0.21.0; sys_platform != "win32"
 pydantic>=2.5.0
 jsonschema>=4.20.0
+redis>=5.0.0
 
 ##############################
 # 多模型协同（MCP + 工具）
@@ -100,3 +101,4 @@ Pillow
 opentelemetry-api>=1.20.0
 opentelemetry-sdk>=1.20.0
 opentelemetry-exporter-otlp>=1.20.0
+prometheus-client>=0.20.0


### PR DESCRIPTION
## Summary

Fixes #264.

`tests/app` has been red on `main` since server v2 landed: `tests/app/server_v2/conftest.py` imports `app.server_v2`, which imports `prometheus_client` and `redis` at module import time, but CI installs only `requirements.txt` and neither package is listed there (both are declared only as optional dependencies in `pyproject.toml`). Collection of the whole app suite is interrupted, so the app matrix cannot catch real regressions.

This adds the two lines to `requirements.txt`, using the same version pins as `pyproject.toml`:

```
redis>=5.0.0
prometheus-client>=0.20.0
```

No code changes.

## Verification

- Fresh virtualenv, `pip install -r requirements.txt` from this branch, `python -m pytest tests/app -q`: 460 passed (the suite is interrupted at collection without this change; 419 items collected before the `server_v2` error).
- With only `prometheus-client` added, collection succeeds but `test_health_auth.py::test_create_app_wires_required_clients` still fails on the missing `redis` module, which is why both lines are needed.
