### PR TITLE
fix(sagents): resumable ledger after manual reconciliation; sandbox denials as clean tool failures

### DIFF
--- a/sagents/v2/tool/official/runtime.py
+++ b/sagents/v2/tool/official/runtime.py
@@ -13,9 +13,11 @@ import asyncio
 import inspect
 import json
 import re
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Protocol
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterator, Protocol
 from urllib.parse import urlsplit
 
+from sagents.v2.contracts.errors import ErrorCategory, RuntimeErrorInfo, SageV2Error
 from sagents.v2.memory import MemoryService
 from sagents.v2.session_memory import SessionMemoryService
 from sagents.v2.agent.policy import ContinuationSignals, InteractionDraft
@@ -55,6 +57,79 @@ class ImageContextPublisher(Protocol):
 
 
 ToolCatalogResolver = Callable[[str], Awaitable[tuple[str, ...]] | tuple[str, ...]]
+
+# Sandbox error codes that a provider raises from its authorization gate,
+# before it touches the workspace. Each of them proves that the requested
+# operation was not applied, so the Tool executor can report a clean failure
+# instead of escalating to the unknown-side-effect reconciliation flow.
+SANDBOX_DENIAL_CODES = frozenset(
+    {
+        "sandbox.permission_denied",
+        "sandbox.protected_path",
+        "sandbox.grant_mismatch",
+        "sandbox.grant_invalid",
+        "sandbox.grant_expired",
+        "sandbox.grant_replayed",
+        "sandbox.policy_stale",
+        "sandbox.resource_exhausted",
+        "sandbox.unavailable",
+        "sandbox.lost",
+        "sandbox.ref_mismatch",
+    }
+)
+
+
+def sandbox_denial_as_not_applied(exc: BaseException) -> SageV2Error | None:
+    """Return the typed ``not_applied`` form of a sandbox denial, else ``None``.
+
+    Only failures that the sandbox contract guarantees happened before any
+    mutation are mapped. Anything else (an ``OSError`` from inside the write,
+    a lost response, an unknown code) keeps its identity so the executor still
+    treats a write-class failure as an unknown outcome.
+    """
+
+    if isinstance(exc, SageV2Error):
+        info = exc.info
+        if info.code not in SANDBOX_DENIAL_CODES:
+            return None
+        if info.metadata.get("side_effect_state") == "not_applied":
+            return None
+        return SageV2Error(
+            info.model_copy(
+                update={
+                    "safe_to_resume": True,
+                    "metadata": {**info.metadata, "side_effect_state": "not_applied"},
+                }
+            )
+        )
+    # Providers raise a bare ``PermissionError(message)`` for policy, path and
+    # grant violations, always before any I/O. A ``PermissionError`` raised by
+    # the operating system from inside an I/O call carries ``errno`` and is
+    # deliberately left alone.
+    if isinstance(exc, PermissionError) and exc.errno is None:
+        return SageV2Error(
+            RuntimeErrorInfo(
+                code="sandbox.permission_denied",
+                category=ErrorCategory.POLICY_DENIED,
+                message=str(exc) or "sandbox denied the operation",
+                safe_to_resume=True,
+                metadata={"side_effect_state": "not_applied"},
+            )
+        )
+    return None
+
+
+@contextmanager
+def sandbox_denials_not_applied() -> Iterator[None]:
+    """Re-raise sandbox denials as typed errors carrying ``not_applied``."""
+
+    try:
+        yield
+    except (SageV2Error, PermissionError) as exc:
+        typed = sandbox_denial_as_not_applied(exc)
+        if typed is None:
+            raise
+        raise typed from exc
 
 
 class OfficialToolRuntime:
@@ -103,7 +178,8 @@ class OfficialToolRuntime:
     def virtual_path(self, value: str | None) -> str:
         """Ask the active sandbox to resolve a canonical resource path."""
 
-        return self.sandbox.filesystem.normalize_path(value or ".")
+        with sandbox_denials_not_applied():
+            return self.sandbox.filesystem.normalize_path(value or ".")
 
     def _intent(
         self,
@@ -138,9 +214,10 @@ class OfficialToolRuntime:
     async def read_bytes(self, path: str, invocation: ToolInvocation) -> bytes:
         path = self.virtual_path(path)
         intent = self._intent(invocation, FileOperation.READ.value, path=path)
-        return await self.sandbox.filesystem.read_bytes(
-            path, intent=intent, grant=self._grant(intent)
-        )
+        with sandbox_denials_not_applied():
+            return await self.sandbox.filesystem.read_bytes(
+                path, intent=intent, grant=self._grant(intent)
+            )
 
     async def read_text(self, path: str, invocation: ToolInvocation) -> str:
         return (await self.read_bytes(path, invocation)).decode("utf-8")
@@ -149,9 +226,10 @@ class OfficialToolRuntime:
         path = self.virtual_path(path)
         intent = self._intent(invocation, FileOperation.READ.value, path=path)
         try:
-            await self.sandbox.filesystem.stat(
-                path, intent=intent, grant=self._grant(intent)
-            )
+            with sandbox_denials_not_applied():
+                await self.sandbox.filesystem.stat(
+                    path, intent=intent, grant=self._grant(intent)
+                )
         except FileNotFoundError:
             return False
         return True
@@ -159,9 +237,10 @@ class OfficialToolRuntime:
     async def stat(self, path: str, invocation: ToolInvocation):
         path = self.virtual_path(path)
         intent = self._intent(invocation, FileOperation.READ.value, path=path)
-        return await self.sandbox.filesystem.stat(
-            path, intent=intent, grant=self._grant(intent)
-        )
+        with sandbox_denials_not_applied():
+            return await self.sandbox.filesystem.stat(
+                path, intent=intent, grant=self._grant(intent)
+            )
 
     async def write_bytes(
         self,
@@ -178,13 +257,14 @@ class OfficialToolRuntime:
             else FileOperation.CREATE
         )
         intent = self._intent(invocation, operation.value, path=path)
-        stat = await self.sandbox.filesystem.write_bytes(
-            path,
-            content,
-            intent=intent,
-            grant=self._grant(intent),
-            overwrite=overwrite,
-        )
+        with sandbox_denials_not_applied():
+            stat = await self.sandbox.filesystem.write_bytes(
+                path,
+                content,
+                intent=intent,
+                grant=self._grant(intent),
+                overwrite=overwrite,
+            )
         return stat.path
 
     async def write_text(
@@ -203,16 +283,18 @@ class OfficialToolRuntime:
     async def delete_file(self, path: str, invocation: ToolInvocation) -> None:
         path = self.virtual_path(path)
         intent = self._intent(invocation, FileOperation.DELETE.value, path=path)
-        await self.sandbox.filesystem.delete(
-            path, intent=intent, grant=self._grant(intent)
-        )
+        with sandbox_denials_not_applied():
+            await self.sandbox.filesystem.delete(
+                path, intent=intent, grant=self._grant(intent)
+            )
 
     async def list_paths(self, path: str | None, invocation: ToolInvocation):
         path = self.virtual_path(path)
         intent = self._intent(invocation, FileOperation.LIST.value, path=path)
-        return await self.sandbox.filesystem.list_paths(
-            path, intent=intent, grant=self._grant(intent)
-        )
+        with sandbox_denials_not_applied():
+            return await self.sandbox.filesystem.list_paths(
+                path, intent=intent, grant=self._grant(intent)
+            )
 
     async def shell(
         self,

--- a/sagents/v2/使用手册.md
+++ b/sagents/v2/使用手册.md
@@ -224,6 +224,8 @@ Agent 的 `tools:` 是授权名单。常用官方工具：
 | 质量 | `read_lints` |
 | 交互 | `questionnaire_async` |
 
+沙箱拒绝（路径越界、受保护路径、策略 / 授权不通过、配额超限等）由 `OfficialToolRuntime` 统一映射成带 `side_effect_state: not_applied` 的 `sandbox.*` 错误：这些拒绝都发生在触碰工作区之前，所以写类工具走普通失败（`tool.call.failed`），不会触发"结果未知"的人工核对；真正进入写入之后的错误（如 `OSError`）仍按未知副作用处理。
+
 也可 `with_tool_provider(catalog, executor)` 完全自带目录，或选 `sage.tool.ephemeral` 用内存 catalog/executor（进程退出即丢；`tools` / `handlers` 由宿主注入）。
 
 `sage.tool.mcp` 的每个 server 可配置 `required`、`max_tools`、`max_pages`、`max_schema_bytes`、`max_result_bytes` 和 `timeout_seconds`。工具发现会读取所有分页，并拒绝重复游标或超出页数/工具数上限的目录；可选 server 发现失败时会隔离该 server。工具执行超时、取消或丢失响应仍按未知副作用处理，不能自动重放。

--- a/tests/app/cli/test_v2_run.py
+++ b/tests/app/cli/test_v2_run.py
@@ -224,6 +224,57 @@ async def test_deny_leaves_workspace_untouched(tmp_path):
     assert "tool.call.dispatching" not in outcome.event_types
 
 
+def write_outside_model():
+    """第 1 步把文件写到工作区之外（需要审批），第 2 步收尾。"""
+
+    return ScriptedModelProvider(
+        (
+            ScriptedModelStep(
+                events=(
+                    _completed(
+                        "",
+                        calls=(
+                            ModelToolCall(
+                                tool_call_id="call_out",
+                                name="file_write",
+                                arguments={
+                                    "file_path": "../outside.txt",
+                                    "content": "escaped\n",
+                                },
+                            ),
+                        ),
+                    ),
+                )
+            ),
+            ScriptedModelStep(events=(_completed("Done."),)),
+        )
+    )
+
+
+async def test_write_outside_the_workspace_fails_cleanly_without_reconciliation(tmp_path):
+    workspace, _, agent, command = await make_agent(tmp_path, write_outside_model())
+    err = io.StringIO()
+
+    outcome = await run_task(
+        agent,
+        command,
+        CONTEXT,
+        renderer=PlainRenderer(io.StringIO(), err),
+        decider=StaticInteractionDecider("approve_once"),
+    )
+    await agent.close()
+
+    # 沙箱在写入之前就拒绝了：这是普通失败（tool.call.failed），
+    # 不是"结果未知"的人工核对；唯一的交互是那次审批。
+    assert outcome.state == RunState.COMPLETED
+    assert "tool.call.failed" in outcome.event_types
+    assert "tool.call.unknown" not in outcome.event_types
+    assert outcome.event_types.count("interaction.requested") == 1
+    assert not (tmp_path / "outside.txt").exists()
+    assert not (workspace / "outside.txt").exists()
+    assert "[tool] file_write failed (sandbox.permission_denied:" in err.getvalue()
+
+
 async def test_json_mode_streams_native_events_and_reads_decision_line(tmp_path):
     workspace, _, agent, command = await make_agent(tmp_path, write_hello_model())
     out = io.StringIO()
@@ -273,6 +324,16 @@ async def test_static_decider_never_widens_to_a_disallowed_decision():
     assert await StaticInteractionDecider("cancel").decide(
         approval_interaction(("approve_once", "cancel"))
     ) == InteractionAnswer("cancel")
+
+
+async def test_static_decider_answers_a_reconciliation_prompt_with_cancel():
+    """人工核对交互（confirm_succeeded / mark_failed / cancel）没有 deny：
+    固定答案只收紧不放宽，approve-all 与 deny-all 都退化为 cancel。"""
+
+    interaction = approval_interaction(("confirm_succeeded", "mark_failed", "cancel"))
+    for fixed in ("approve_once", "deny"):
+        answer = await StaticInteractionDecider(fixed).decide(interaction)
+        assert answer == InteractionAnswer("cancel")
 
 
 def recovery_interaction():

--- a/tests/sagents/v2/test_agent_loop_matrix.py
+++ b/tests/sagents/v2/test_agent_loop_matrix.py
@@ -3249,3 +3249,190 @@ async def test_unavailable_tool_guidance_starts_new_model_decision():
         TextBlock(text="Skip that tool."),
     )
     assert executor.calls == []
+
+
+async def reply_pending_interaction(runtime, handle, snapshot, decision, key):
+    """回答当前挂起的交互，返回该交互以便断言其 allowed_decisions。"""
+
+    suspension = await runtime.session_store.get_suspension(snapshot.suspension_id)
+    interaction = await runtime.session_store.get_interaction(suspension.interaction_id)
+    await runtime.reply_interaction(
+        ReplyInteraction(
+            run_id=handle.run_id,
+            suspension_id=suspension.suspension_id,
+            interaction_id=interaction.interaction_id,
+            expected_revision=snapshot.revision,
+            expected_suspension_revision=suspension.expected_revision,
+            expected_interaction_revision=interaction.expected_revision,
+            decision=decision,
+            idempotency_key=key,
+        ),
+        CONTEXT,
+    )
+    return interaction
+
+
+def persisted_tool_result(events, tool_call_id):
+    """从 canonical Item 事件里取出某次工具调用落盘的结果 Item。"""
+
+    for event in events:
+        if event.type != "item.completed":
+            continue
+        item = event.data.item
+        if (
+            isinstance(item.data, ToolResultItemData)
+            and item.data.tool_call_id == tool_call_id
+        ):
+            return item
+    raise AssertionError(f"no persisted tool result for {tool_call_id}")
+
+
+def two_write_steps_model():
+    """两步都调用 write_value（各需一次审批），第三步收尾。"""
+
+    return ScriptedModelProvider(
+        (
+            ScriptedModelStep(events=(completed("", calls=(tool_call("write_value"),)),)),
+            ScriptedModelStep(
+                events=(
+                    completed(
+                        "",
+                        calls=(
+                            ModelToolCall(
+                                tool_call_id="call_2",
+                                name="write_value",
+                                arguments={"key": "b", "value": "2"},
+                            ),
+                        ),
+                    ),
+                )
+            ),
+            ScriptedModelStep(events=(completed("done"),)),
+        )
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decision", ["cancel", "mark_failed"])
+async def test_manual_reconciliation_failure_keeps_the_checkpoint_ledger_resumable(
+    decision,
+):
+    """人工核对以 cancel / mark_failed 结束后，下一次挂起再 resume 不能报 ledger 不一致。
+
+    写进 checkpoint 的 ledger 摘要按内存 messages 计算，resume 时按 canonical Item
+    事件重建；两者必须一致，所以内存里的工具结果消息必须来自真正落盘的 Item。
+    """
+
+    dispatches = []
+
+    async def first_call_outcome_unknown(call, context):
+        dispatches.append(call.tool_call_id)
+        if len(dispatches) == 1:
+            raise SageV2Error(
+                RuntimeErrorInfo(
+                    code="remote.rejected",
+                    category=ErrorCategory.PROVIDER_PERMANENT,
+                    message="remote rejected the write",
+                    safe_to_resume=True,
+                )
+            )
+        return await tool_handler(call, context)
+
+    model = two_write_steps_model()
+    runtime, handle, loop, _ = await setup_loop(
+        model,
+        handlers={"read_value": tool_handler, "write_value": first_call_outcome_unknown},
+    )
+
+    awaiting_first = await loop.execute(handle.run_id, CONTEXT)
+    await reply_pending_interaction(
+        runtime, handle, awaiting_first, "approve_once", "approve_1"
+    )
+    unknown = await loop.resume(handle.run_id, CONTEXT)
+    interaction = await reply_pending_interaction(
+        runtime, handle, unknown, decision, "resolve_1"
+    )
+    awaiting_second = await loop.resume(handle.run_id, CONTEXT)
+
+    assert unknown.state == RunState.SUSPENDED
+    assert interaction.allowed_decisions == ("confirm_succeeded", "mark_failed", "cancel")
+    assert awaiting_second.state == RunState.SUSPENDED
+
+    await reply_pending_interaction(
+        runtime, handle, awaiting_second, "approve_once", "approve_2"
+    )
+    result = await loop.resume(handle.run_id, CONTEXT)
+    events = await runtime.session_store.read_events(handle.run_id)
+    types = [event.type for event in events]
+    persisted = persisted_tool_result(events, "call_1")
+    tool_message = next(
+        message
+        for message in model.requests[1].messages
+        if message.role == "tool" and message.tool_call_id == "call_1"
+    )
+
+    assert result.state == RunState.COMPLETED
+    assert dispatches == ["call_1", "call_2"]
+    assert types.count("tool.call.unknown") == 1
+    assert ("tool.call.cancelled" if decision == "cancel" else "tool.call.reconciled") in types
+    assert persisted.status == (
+        ItemStatus.DECLINED if decision == "cancel" else ItemStatus.FAILED
+    )
+    assert persisted.data.error is not None
+    assert persisted.data.error.code == "tool.outcome_manually_failed"
+    assert tool_message.content == persisted.data.content
+    assert tool_message.metadata["manually_confirmed"] is True
+
+
+@pytest.mark.asyncio
+async def test_authoritative_tool_error_content_is_persisted_and_resumable():
+    """带 tool_result_received 的失败：模型看到的内容与落盘 Item 一致，之后仍可 resume。"""
+
+    class RejectedWriteExecutor:
+        async def execute(self, call, context):
+            del context
+            return ToolExecutionResult(
+                tool_call_id=call.tool_call_id,
+                operation_id=call.operation_id,
+                content=(TextBlock(text="remote rejected the write: quota exceeded"),),
+                error=RuntimeErrorInfo(
+                    code="remote.write_rejected",
+                    category=ErrorCategory.PROVIDER_PERMANENT,
+                    message="write rejected",
+                    safe_to_resume=True,
+                    metadata={"tool_result_received": True},
+                ),
+                metadata={"tool_result_received": True},
+            )
+
+    model = two_write_steps_model()
+    runtime, handle, loop, _ = await setup_loop(model, tools=(WRITE_TOOL,))
+    loop.tool_executor = RejectedWriteExecutor()
+
+    awaiting_first = await loop.execute(handle.run_id, CONTEXT)
+    await reply_pending_interaction(
+        runtime, handle, awaiting_first, "approve_once", "approve_1"
+    )
+    awaiting_second = await loop.resume(handle.run_id, CONTEXT)
+    assert awaiting_second.state == RunState.SUSPENDED
+    await reply_pending_interaction(
+        runtime, handle, awaiting_second, "approve_once", "approve_2"
+    )
+    result = await loop.resume(handle.run_id, CONTEXT)
+    events = await runtime.session_store.read_events(handle.run_id)
+    types = [event.type for event in events]
+    persisted = persisted_tool_result(events, "call_1")
+    tool_message = next(
+        message
+        for message in model.requests[1].messages
+        if message.role == "tool" and message.tool_call_id == "call_1"
+    )
+
+    assert result.state == RunState.COMPLETED
+    assert types.count("tool.call.failed") == 2
+    assert "tool.call.unknown" not in types
+    assert persisted.status == ItemStatus.FAILED
+    assert persisted.data.content[0].text == "remote rejected the write: quota exceeded"
+    assert persisted.data.error is not None
+    assert persisted.data.error.message_key == "error.provider_permanent"
+    assert tool_message.content == persisted.data.content

--- a/tests/sagents/v2/test_agent_loop_matrix.py
+++ b/tests/sagents/v2/test_agent_loop_matrix.py
@@ -3436,3 +3436,42 @@ async def test_authoritative_tool_error_content_is_persisted_and_resumable():
     assert persisted.data.error is not None
     assert persisted.data.error.message_key == "error.provider_permanent"
     assert tool_message.content == persisted.data.content
+
+
+@pytest.mark.asyncio
+async def test_write_failure_marked_not_applied_is_a_known_failure():
+    """写工具的错误若带 side_effect_state=not_applied，就是普通失败，不进人工核对。"""
+
+    async def denied_before_write(call, context):
+        del call, context
+        raise SageV2Error(
+            RuntimeErrorInfo(
+                code="sandbox.permission_denied",
+                category=ErrorCategory.POLICY_DENIED,
+                message="path is outside the workspace",
+                safe_to_resume=True,
+                metadata={"side_effect_state": "not_applied"},
+            )
+        )
+
+    model = ScriptedModelProvider(
+        (
+            ScriptedModelStep(events=(completed("", calls=(tool_call("write_value"),)),)),
+            ScriptedModelStep(events=(completed("handled"),)),
+        )
+    )
+    runtime, handle, loop, _ = await setup_loop(
+        model, handlers={"read_value": tool_handler, "write_value": denied_before_write}
+    )
+    loop.tool_policy = DefaultToolPolicy(approval_strategy=ApprovalStrategy.AUTO_APPROVE)
+
+    result = await loop.execute(handle.run_id, CONTEXT)
+    events = await runtime.session_store.read_events(handle.run_id)
+    types = [event.type for event in events]
+    failed = next(event for event in events if event.type == "tool.call.failed")
+
+    assert result.state == RunState.COMPLETED
+    assert "tool.call.unknown" not in types
+    assert "interaction.requested" not in types
+    assert failed.data.error.code == "sandbox.permission_denied"
+    assert failed.data.error.metadata["side_effect_state"] == "not_applied"

--- a/tests/sagents/v2/test_official_tool_provider_matrix.py
+++ b/tests/sagents/v2/test_official_tool_provider_matrix.py
@@ -2,23 +2,29 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+import errno
 import hashlib
 
 import pytest
 
-from sagents.v2.contracts.errors import SageV2Error
+from sagents.v2.contracts.errors import ErrorCategory, RuntimeErrorInfo, SageV2Error
 from sagents.v2.contracts.principals import ActorRef, PrincipalType, RequestContext
 from sagents.v2.runtime.extensions import ExtensionScope, ExtensionScopeContext
 from sagents.v2.runtime.execution.sandbox import (
     FileOperation,
     FileSystemPolicy,
+    InMemorySandboxProvider,
+    LifecyclePolicy,
     LocalWorkspaceSandboxProvider,
     NetworkPolicy,
     ProcessPolicy,
     ResolvedSandboxSpec,
+    SandboxDurability,
     SandboxGrantIssuer,
 )
+from sagents.v2.runtime.execution.sandbox.contracts import FileSystemMode
 from sagents.v2.tool import (
     ReconcileState,
     ToolCall,
@@ -63,7 +69,9 @@ CONTEXT = RequestContext(
 )
 
 
-async def plugin_for(root: Path) -> OfficialToolPlugin:
+async def plugin_for(
+    root: Path, *, filesystem: FileSystemPolicy | None = None
+) -> OfficialToolPlugin:
     issuer = SandboxGrantIssuer()
     provider = LocalWorkspaceSandboxProvider(issuer.verification_key)
     digest = hashlib.sha256(str(root).encode()).hexdigest()
@@ -71,7 +79,8 @@ async def plugin_for(root: Path) -> OfficialToolPlugin:
         ResolvedSandboxSpec(
             spec_hash=f"sha256:{digest}",
             architecture="native",
-            filesystem=FileSystemPolicy(
+            filesystem=filesystem
+            or FileSystemPolicy(
                 allowed_operations=frozenset(FileOperation),
             ),
             process=ProcessPolicy(
@@ -82,6 +91,49 @@ async def plugin_for(root: Path) -> OfficialToolPlugin:
             network=NetworkPolicy(),
             policy_hash=f"sha256:{digest}",
             metadata={"host_workspace": str(root)},
+        ),
+        CONTEXT,
+        run_id="run_1",
+    )
+    return OfficialToolPlugin(
+        ExtensionScopeContext(
+            scope=ExtensionScope.AGENT,
+            scope_id="test-official-tools",
+            config={"runtime": OfficialToolRuntime(handle, issuer)},
+        )
+    )
+
+
+NOW = datetime(2026, 9, 3, tzinfo=timezone.utc)
+
+
+async def ephemeral_plugin_for(
+    filesystem: FileSystemPolicy,
+    *,
+    issuer_clock=None,
+    provider_clock=None,
+) -> OfficialToolPlugin:
+    """Same official plugin on the in-memory provider, which raises typed errors."""
+
+    issuer = SandboxGrantIssuer(
+        b"official-tool-test-key-32-bytes!!", clock=issuer_clock or (lambda: NOW)
+    )
+    provider = InMemorySandboxProvider(
+        issuer.verification_key, clock=provider_clock or (lambda: NOW)
+    )
+    handle = await provider.provision(
+        ResolvedSandboxSpec(
+            spec_hash="sha256:spec",
+            architecture="portable",
+            filesystem_mode=FileSystemMode.WORKSPACE,
+            filesystem=filesystem,
+            process=ProcessPolicy(),
+            network=NetworkPolicy(),
+            lifecycle=LifecyclePolicy(
+                durability=SandboxDurability.SNAPSHOTABLE,
+                pause_behavior="snapshot",
+            ),
+            policy_hash="sha256:policy",
         ),
         CONTEXT,
         run_id="run_1",
@@ -522,3 +574,186 @@ def test_v2_tool_decorator_infers_arguments_and_hides_runtime_injection():
         "required": ["text"],
         "additionalProperties": False,
     }
+
+
+OUTSIDE_ROOTS = FileSystemPolicy(
+    allowed_operations=frozenset(FileOperation),
+    allowed_roots=("/workspace/src",),
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tool_name, arguments",
+    [
+        ("file_write", {"file_path": "notes/outside.txt", "content": "x\n"}),
+        (
+            "file_update",
+            {
+                "file_path": "notes/outside.txt",
+                "operations": [
+                    {
+                        "update_mode": "search_replace",
+                        "search_pattern": "a",
+                        "replacement": "b",
+                    }
+                ],
+            },
+        ),
+        (
+            "apply_patch",
+            {
+                "patch": "*** Begin Patch\n*** Add File: notes/outside.txt\n+x\n"
+                "*** End Patch"
+            },
+        ),
+    ],
+)
+async def test_local_sandbox_denial_is_a_typed_not_applied_failure(
+    tmp_path: Path, tool_name: str, arguments: dict
+):
+    plugin = await plugin_for(tmp_path, filesystem=OUTSIDE_ROOTS)
+
+    with pytest.raises(SageV2Error) as caught:
+        await plugin.executor.execute(call(tool_name, arguments), CONTEXT)
+
+    info = caught.value.info
+    assert info.code == "sandbox.permission_denied"
+    assert info.category == ErrorCategory.POLICY_DENIED
+    assert info.safe_to_resume is True
+    assert info.metadata["side_effect_state"] == "not_applied"
+    assert info.message == "path is outside the allowed filesystem roots"
+    assert not (tmp_path / "notes").exists()
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_denied_midway_rolls_back_before_reporting_not_applied(
+    tmp_path: Path,
+):
+    plugin = await plugin_for(tmp_path, filesystem=OUTSIDE_ROOTS)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "old.txt").write_text("one\n")
+
+    with pytest.raises(SageV2Error) as caught:
+        await plugin.executor.execute(
+            call(
+                "apply_patch",
+                {
+                    "patch": """*** Begin Patch
+*** Update File: src/old.txt
+@@
+-one
++two
+*** Add File: docs/new.txt
++created
+*** End Patch"""
+                },
+            ),
+            CONTEXT,
+        )
+
+    assert caught.value.info.code == "sandbox.permission_denied"
+    assert caught.value.info.metadata["side_effect_state"] == "not_applied"
+    assert (tmp_path / "src" / "old.txt").read_text() == "one\n"
+    assert not (tmp_path / "docs").exists()
+
+
+@pytest.mark.asyncio
+async def test_in_memory_sandbox_policy_denial_keeps_its_code_and_category():
+    plugin = await ephemeral_plugin_for(
+        FileSystemPolicy(
+            allowed_operations=frozenset({FileOperation.READ, FileOperation.LIST})
+        )
+    )
+
+    with pytest.raises(SageV2Error) as caught:
+        await plugin.executor.execute(
+            call("file_write", {"file_path": "notes.txt", "content": "x\n"}), CONTEXT
+        )
+
+    info = caught.value.info
+    provider_error = caught.value.__cause__
+    assert info.code == "sandbox.permission_denied"
+    assert info.category == ErrorCategory.POLICY_DENIED
+    assert info.safe_to_resume is True
+    assert info.metadata["side_effect_state"] == "not_applied"
+    assert isinstance(provider_error, SageV2Error)
+    assert provider_error.info.code == "sandbox.permission_denied"
+    assert "side_effect_state" not in provider_error.info.metadata
+
+
+@pytest.mark.asyncio
+async def test_in_memory_sandbox_resource_limit_is_not_applied():
+    plugin = await ephemeral_plugin_for(
+        FileSystemPolicy(
+            allowed_operations=frozenset(FileOperation), max_file_bytes=4
+        )
+    )
+
+    with pytest.raises(SageV2Error) as caught:
+        await plugin.executor.execute(
+            call("file_write", {"file_path": "notes.txt", "content": "too long\n"}),
+            CONTEXT,
+        )
+
+    assert caught.value.info.code == "sandbox.resource_exhausted"
+    assert caught.value.info.category == ErrorCategory.POLICY_DENIED
+    assert caught.value.info.metadata["side_effect_state"] == "not_applied"
+
+
+@pytest.mark.asyncio
+async def test_in_memory_sandbox_grant_expiry_is_not_applied():
+    plugin = await ephemeral_plugin_for(
+        FileSystemPolicy(allowed_operations=frozenset(FileOperation)),
+        provider_clock=lambda: NOW + timedelta(hours=1),
+    )
+
+    with pytest.raises(SageV2Error) as caught:
+        await plugin.executor.execute(
+            call("file_write", {"file_path": "notes.txt", "content": "x\n"}), CONTEXT
+        )
+
+    assert caught.value.info.code == "sandbox.grant_expired"
+    assert caught.value.info.category == ErrorCategory.AUTHORIZATION
+    assert caught.value.info.safe_to_resume is True
+    assert caught.value.info.metadata["side_effect_state"] == "not_applied"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure",
+    [
+        PermissionError(errno.EACCES, "Permission denied"),
+        OSError(errno.ENOSPC, "No space left on device"),
+        SageV2Error(
+            RuntimeErrorInfo(
+                code="sandbox.network_timeout",
+                category=ErrorCategory.PROVIDER_TRANSIENT,
+                message="the sandbox stopped responding",
+            )
+        ),
+    ],
+    ids=["os-permission-error", "os-error", "non-denial-sandbox-error"],
+)
+async def test_failures_inside_the_write_keep_the_unknown_outcome_path(
+    tmp_path: Path, monkeypatch, failure: BaseException
+):
+    """Only the sandbox's own denials are mapped; an error raised from inside
+    the I/O may have left a partial write and must stay on the reconciliation path."""
+
+    plugin = await plugin_for(tmp_path)
+
+    async def failing_write(path, content, *, intent, grant, overwrite=True):
+        del path, content, intent, grant, overwrite
+        raise failure
+
+    monkeypatch.setattr(plugin.runtime.sandbox.filesystem, "write_bytes", failing_write)
+
+    with pytest.raises(type(failure)) as caught:
+        await plugin.executor.execute(
+            call("file_write", {"file_path": "notes.txt", "content": "x\n"}), CONTEXT
+        )
+
+    assert caught.value is failure
+    if isinstance(failure, SageV2Error):
+        assert "side_effect_state" not in failure.info.metadata


### PR DESCRIPTION
## Summary

Two related gaps in how the v2 loop treats a tool failure, found while wiring `sage v2` in #263 (the ledger bug is the one noted at the end of that PR's description). Both reproduce on current `main` and are independent of #263.

| Commit | Topic |
| --- | --- |
| 1 | Loop: regression tests for the checkpoint-ledger mismatch after a manual reconciliation `cancel` / `mark_failed` (the engine change has since landed on `main` in a2357312) |
| 2 | Official tools: sandbox denials are reported as clean `not_applied` failures instead of unknown outcomes |
| 3 | CLI tests for the end-to-end behaviour |

Nothing under `app/desktop*`, `app/server*` or `app/chrome-extension` is touched, and the sandbox providers' exception types are unchanged.

## 1. `loop.checkpoint_ledger_mismatch` after a manual reconciliation

Reproduction on `main` with the loop test harness: approve a write tool whose handler raises a `SageV2Error` without `side_effect_state` → `tool.call.unknown` → answer the reconciliation interaction with `cancel` (or `mark_failed`) → the Run continues → the next tool call needs approval → `approve_once` → `loop.resume()` raises `loop.checkpoint_ledger_mismatch` (`CORRUPT_STATE`, `safe_to_resume=False`) and the Run is FAILED.

Cause: `_commit_tool_result` localizes a failed result (`localize_error` rewrites `message`, adds `message_key` / `diagnostic_message`, and the content becomes the localized text) before persisting the `ToolResultItemData`, but it returned only the Run. Callers appended the *pre-commit* result to `state.messages`; the next checkpoint hashed that message, and `resume_coordinated` rebuilt the ledger from the canonical Items, which no longer matched. The same divergence existed on the reconcile-confirmed-failure path, on the automatic memory-recall denial, and — with the opposite content — on any `tool_result_received` failure, where the model was shown the authoritative content but the persisted Item carried the localized message.

Fix: `_commit_tool_result` returns `(run, result)` with the result exactly as persisted, and every caller builds the in-memory ledger message from it. That engine change is now on `main` (a2357312), so after the rebase commit 1 carries only the regression tests: the two flows above end-to-end on the loop harness (both failed on the previous `main` with `loop.checkpoint_ledger_mismatch`), plus the assertion that the persisted Item keeps the authoritative `tool_result_received` content the model was shown.

## 2. Sandbox denials from official tools

`_tool_failure_is_uncertain` treats any post-dispatch exception of a write-class tool as an unknown outcome unless it carries `side_effect_state: not_applied`. The sandbox providers reject at their authorization gate before any I/O, but the only denial that carried the marker was `sandbox.protected_path`. The local provider raises a bare `PermissionError` (path outside the workspace or `allowed_roots`, symlink, operation not allowed, grant signature / expiry / replay / mismatch), the in-memory provider raises typed `sandbox.permission_denied`, `sandbox.grant_*`, `sandbox.policy_stale`, `sandbox.resource_exhausted`, … without it. So a `file_write` to `../outside.txt` suspended the Run with "did this write succeed?" for a write that never started — and that reconciliation prompt is exactly the entry point of the bug above.

`OfficialToolRuntime` now maps those denials once, at the boundary where every official file operation crosses into the sandbox (`virtual_path`, `read_bytes`, `stat` / `exists`, `write_bytes`, `delete_file`, `list_paths`):

- a provider `PermissionError` (no `errno`) → `sandbox.permission_denied`, `POLICY_DENIED`, `safe_to_resume=True`, `metadata.side_effect_state = "not_applied"`, original message kept, original exception chained as `__cause__`;
- a `SageV2Error` whose code is in `SANDBOX_DENIAL_CODES` (`sandbox.permission_denied`, `sandbox.protected_path`, `sandbox.grant_mismatch`, `sandbox.grant_invalid`, `sandbox.grant_expired`, `sandbox.grant_replayed`, `sandbox.policy_stale`, `sandbox.resource_exhausted`, `sandbox.unavailable`, `sandbox.lost`, `sandbox.ref_mismatch`) keeps its code and category and gains `not_applied` + `safe_to_resume`; an error that already carries the marker is re-raised as is.

Only failures the sandbox contract guarantees happened before any mutation are mapped. An `OSError` from inside the write, an OS-level `PermissionError` (it carries `errno`), a lost response or any other sandbox code keep their identity and still take the unknown-outcome path. `apply_patch` already rolls back on any exception, so a denial on its second file restores the first before the `not_applied` error propagates. Shell commands are not affected: a denied `process.run` already surfaces as a structured `success: false` job result.

Provider exception types are unchanged (desktop keeps catching `PermissionError` at its HTTP layer). The manual (`sagents/v2/使用手册.md` §7.1) documents the rule.

## 3. CLI

`tests/app/cli/test_v2_run.py`: an approved `file_write` to `../outside.txt` ends in `tool.call.failed` (`sandbox.permission_denied`), the Run completes, the only interaction is the approval and nothing is written. `StaticInteractionDecider` (`--approval-mode approve-all|deny-all`) answers a manual reconciliation prompt with `cancel` — fixed answers only tighten — which is pinned by a test.

## Testing

- `pytest tests/sagents/v2 tests/app/cli tests/sagents/utils/sandbox` and `pytest tests/app`: green on top of current `main` (`9bf96b19`).
- New tests:
  - `test_agent_loop_matrix.py`: manual reconciliation `cancel` / `mark_failed` followed by another approval and resume (fails on `main` with `loop.checkpoint_ledger_mismatch`); `tool_result_received` failure followed by another approval and resume, the persisted Item keeps the authoritative content; a write-class failure marked `not_applied` is `tool.call.failed` without an interaction.
  - `test_official_tool_provider_matrix.py`: `file_write` / `file_update` / `apply_patch` outside `allowed_roots` on the local provider → typed `not_applied` failure, nothing written; `apply_patch` denied on its second file rolls back the first; in-memory provider policy denial, size limit and expired grant keep their code / category and gain the marker; an OS-level `PermissionError`, an `OSError` and a non-denial sandbox error raised from inside the write are re-raised unchanged.
  - `test_v2_run.py`: the two CLI cases above.

## Files

- `sagents/v2/agent/engine.py`, `sagents/v2/tool/official/runtime.py`, `sagents/v2/使用手册.md`
- `tests/sagents/v2/test_agent_loop_matrix.py`, `tests/sagents/v2/test_official_tool_provider_matrix.py`, `tests/app/cli/test_v2_run.py`
