### PR TITLE
fix(v1): enforce local bwrap memory limit from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,8 @@ SAGE_SANDBOX_MODE=local
 # 额外挂载路径，逗号分隔，格式: /host/path:/sandbox/path
 SAGE_SANDBOX_MOUNT_PATHS=
 SAGE_LOCAL_CPU_TIME_LIMIT=300
+# v1 Linux local/bwrap: per-process virtual memory limit (MiB), positive integer.
+# Inherited by child processes; not a combined budget across processes/sessions.
 SAGE_LOCAL_MEMORY_LIMIT_MB=4096
 # Server local 模式必须使用 bwrap；无 bwrap 时改用 remote
 SAGE_LOCAL_LINUX_ISOLATION=bwrap

--- a/.env.example.minimal
+++ b/.env.example.minimal
@@ -51,6 +51,8 @@ SAGE_DEFAULT_LLM_TEMPERATURE=0.2
 # 沙箱配置：本地模式
 SAGE_SANDBOX_MODE=local
 SAGE_LOCAL_CPU_TIME_LIMIT=300
+# v1 Linux local/bwrap: per-process virtual memory limit (MiB), positive integer.
+# Inherited by child processes; not a combined budget across processes/sessions.
 SAGE_LOCAL_MEMORY_LIMIT_MB=4096
 
 # macOS 隔离模式：seatbelt（推荐）或 subprocess

--- a/deploy/images/Dockerfile.server
+++ b/deploy/images/Dockerfile.server
@@ -22,6 +22,7 @@ RUN apt-get update && \
     pandoc \
     libreoffice \
     bubblewrap \
+    util-linux \
     fonts-noto-cjk \
     fonts-dejavu-core \
     fonts-wqy-microhei \

--- a/docs/en/ENV_VARS.md
+++ b/docs/en/ENV_VARS.md
@@ -108,7 +108,7 @@ Advanced overrides are not listed in `.env.example` unless a deployment needs to
 | `SAGE_SHARED_PYTHON_ENV` | `false` | Share a single Python env across sessions |
 | `SAGE_SHARED_PYTHON_ENV_DIR` | — | Shared venv directory |
 | `SAGE_LOCAL_CPU_TIME_LIMIT` | — | Local sandbox CPU time limit (s) |
-| `SAGE_LOCAL_MEMORY_LIMIT_MB` | — | Local sandbox memory limit (MB) |
+| `SAGE_LOCAL_MEMORY_LIMIT_MB` | `4096` | v1 Linux local/bwrap per-process virtual memory limit (MiB, positive integer) |
 | `SAGE_LOCAL_LINUX_ISOLATION` | `false` | Linux namespace isolation |
 | `SAGE_LOCAL_MACOS_ISOLATION` | `false` | macOS sandbox-exec isolation |
 | `SAGE_USE_CLAW_MODE` | `true` | Inject IDENTITY/AGENT/SOUL/USER/MEMORY md into the system prompt |
@@ -123,6 +123,19 @@ Server agent processes receive a minimal allowlisted environment rather than
 the Sage server environment. Server `local` mode requires Linux `bwrap`; use
 `remote` mode when that boundary is unavailable. Desktop keeps its existing
 single-user environment inheritance for compatibility.
+
+For v1 Linux local/bwrap, `SAGE_LOCAL_MEMORY_LIMIT_MB=512` sets both soft and
+hard `RLIMIT_AS` limits before executing foreground shells, background shells,
+or Python payloads. Children inherit the limit. `prlimit` from `util-linux` is
+required; command execution fails if it is unavailable. Rebuild the server image
+and recreate the container to deploy the fix; restart Sage after changing the
+environment so new sandbox instances receive the new value.
+
+This limits each process's **virtual address space**, not the combined RSS of a
+sandbox or all sessions. Runtimes reserving large address ranges (for example
+Node/V8) may require a larger setting even with low RSS. Keep a separate container
+memory limit and concurrency budget; aggregate process-tree accounting requires
+cgroups. This change does not add limits to v2, passthrough, or macOS/Windows.
 
 ### 4.1 OpenSandbox (remote)
 

--- a/docs/zh/ENV_VARS.md
+++ b/docs/zh/ENV_VARS.md
@@ -114,7 +114,7 @@ Kubernetes 模板单独保留 `NAMESPACE`、`SAGE_HOST`、`SAGE_PUBLIC_URL`、`I
 | `SAGE_SHARED_PYTHON_ENV`          | `false`       | 是否共享 Python 环境                             |
 | `SAGE_SHARED_PYTHON_ENV_DIR`      | —             | 共享 Python venv 目录                          |
 | `SAGE_LOCAL_CPU_TIME_LIMIT`       | —             | 本地沙箱 CPU 时限（秒）                             |
-| `SAGE_LOCAL_MEMORY_LIMIT_MB`      | —             | 本地沙箱内存上限（MB）                               |
+| `SAGE_LOCAL_MEMORY_LIMIT_MB`      | `4096`        | v1 Linux local/bwrap 每进程虚拟内存上限（MiB，正整数） |
 | `SAGE_LOCAL_LINUX_ISOLATION`      | `false`       | Linux 命名空间隔离开关                             |
 | `SAGE_LOCAL_MACOS_ISOLATION`      | `false`       | macOS sandbox-exec 隔离开关                    |
 | `SAGE_USE_CLAW_MODE`              | `true`        | 是否启用 IDENTITY/AGENT/SOUL/USER/MEMORY md 注入 |
@@ -129,6 +129,17 @@ Server 的 Agent 子进程只接收最小白名单环境，不继承 Sage Server
 环境变量。Server 使用 `local` 模式时必须运行在 Linux `bwrap` 隔离中；
 无法提供该边界时应使用 `remote` 模式。Desktop 为兼容现有单用户本机工作流，
 继续保持原有环境继承行为。
+
+v1 Linux local/bwrap 下，设置 `SAGE_LOCAL_MEMORY_LIMIT_MB=512` 会在同步 shell、
+后台 shell 和 Python 任务执行前设置 `RLIMIT_AS` 软、硬上限，子进程继承该限制。
+需要 `util-linux` 提供的 `prlimit`；缺失时命令执行失败，不会退回无限制执行。
+部署修复需要重新构建服务端镜像并重建容器；修改环境变量后需重启 Sage，
+让新建沙箱读取新配置。
+
+该限制针对每个进程的**虚拟地址空间**，不是单沙箱或所有会话的 RSS 合计配额。
+Node/V8 等会预留较大虚拟地址空间的运行时，即使 RSS 较低也可能需要更大的配置。
+仍需设置独立的容器内存上限和并发预算；进程树合计配额需要 cgroup 支持。
+本次修改不为 v2、passthrough 或 macOS/Windows 增加限制。
 
 ### 4.1 OpenSandbox（远程）
 

--- a/sagents/utils/sandbox/providers/local/isolation/bwrap.py
+++ b/sagents/utils/sandbox/providers/local/isolation/bwrap.py
@@ -100,6 +100,19 @@ class BwrapIsolation:
             bwrap_cmd.extend([bind_flag, mount.host_path, mount.mount_path])
         return bwrap_cmd, agent_env
 
+    def _limit_command(self, command: List[str]) -> List[str]:
+        """Apply v1's configured per-process address-space limit before exec.
+
+        Run trusted prlimit inside bwrap's read-only /usr mount. Both the soft
+        and hard limits are inherited across fork/exec; shell commands must not
+        bypass this by skipping the Python pickle launcher. This is not an
+        aggregate cgroup budget for all processes in a sandbox.
+        """
+        memory = self.limits.get("memory", 4096 * 1024 * 1024)
+        if isinstance(memory, bool) or not isinstance(memory, int) or memory <= 0:
+            raise ValueError("SAGE_LOCAL_MEMORY_LIMIT_MB must be a positive integer")
+        return ["/usr/bin/prlimit", f"--as={memory}:{memory}", "--", *command]
+
     def build_shell_command(
         self,
         command: str,
@@ -110,7 +123,7 @@ class BwrapIsolation:
         """Build a bwrap command for an agent-controlled background shell."""
 
         bwrap_cmd, _ = self._build_base_command(cwd=cwd, env_vars=env_vars)
-        bwrap_cmd.extend(["/bin/sh", "-c", command])
+        bwrap_cmd.extend(self._limit_command(["/bin/sh", "-c", command]))
         return bwrap_cmd
 
     async def execute(self, payload: Dict[str, Any], cwd: Optional[str] = None) -> Any:
@@ -140,7 +153,9 @@ class BwrapIsolation:
                 cwd=cwd,
                 env_vars=payload.get("env_vars"),
             )
-            bwrap_cmd.extend([python_bin, launcher_path, input_pkl, output_pkl])
+            bwrap_cmd.extend(self._limit_command(
+                [python_bin, launcher_path, input_pkl, output_pkl]
+            ))
 
             # 流式执行：launcher 内部跑命令时，stdout 实时转发到本进程 stdout
             # （受 SAGE_ECHO_SHELL_OUTPUT 控制），stderr 完整捕获用于报错

--- a/sagents/utils/sandbox/providers/local/isolation/bwrap.py
+++ b/sagents/utils/sandbox/providers/local/isolation/bwrap.py
@@ -103,8 +103,10 @@ class BwrapIsolation:
     def _limit_command(self, command: List[str]) -> List[str]:
         """Apply v1's configured per-process address-space limit before exec.
 
-        Run trusted prlimit inside bwrap's read-only /usr mount. Both the soft
-        and hard limits are inherited across fork/exec; shell commands must not
+        Run trusted prlimit BEFORE bwrap with the launcher's sanitized environment.
+        Agent variables (including LD_PRELOAD/LD_AUDIT) are only bwrap --setenv
+        arguments until the limits are installed. Both the soft and hard limits
+        are inherited across fork/exec; shell commands must not
         bypass this by skipping the Python pickle launcher. This is not an
         aggregate cgroup budget for all processes in a sandbox.
         """
@@ -123,8 +125,8 @@ class BwrapIsolation:
         """Build a bwrap command for an agent-controlled background shell."""
 
         bwrap_cmd, _ = self._build_base_command(cwd=cwd, env_vars=env_vars)
-        bwrap_cmd.extend(self._limit_command(["/bin/sh", "-c", command]))
-        return bwrap_cmd
+        bwrap_cmd.extend(["/bin/sh", "-c", command])
+        return self._limit_command(bwrap_cmd)
 
     async def execute(self, payload: Dict[str, Any], cwd: Optional[str] = None) -> Any:
         """
@@ -153,9 +155,8 @@ class BwrapIsolation:
                 cwd=cwd,
                 env_vars=payload.get("env_vars"),
             )
-            bwrap_cmd.extend(self._limit_command(
-                [python_bin, launcher_path, input_pkl, output_pkl]
-            ))
+            bwrap_cmd.extend([python_bin, launcher_path, input_pkl, output_pkl])
+            bwrap_cmd = self._limit_command(bwrap_cmd)
 
             # 流式执行：launcher 内部跑命令时，stdout 实时转发到本进程 stdout
             # （受 SAGE_ECHO_SHELL_OUTPUT 控制），stderr 完整捕获用于报错

--- a/tests/sagents/utils/sandbox/test_environment.py
+++ b/tests/sagents/utils/sandbox/test_environment.py
@@ -136,7 +136,8 @@ def test_bwrap_shell_uses_clean_environment_and_pid_namespace(monkeypatch, tmp_p
     )
 
     assert os.path.isabs(command[0])
-    assert command[0].endswith("/bwrap")
+    assert command[0] == "/usr/bin/prlimit"
+    assert command[3].endswith("/bwrap")
     assert "--clearenv" in command
     assert "--unshare-pid" in command
     assert "must-not-leak" not in command
@@ -194,6 +195,8 @@ async def test_bwrap_supervisor_does_not_receive_agent_environment(
     assert captured["env"]["PATH"] != str(workspace)
     assert "LD_PRELOAD" not in captured["env"]
     assert "LD_PRELOAD" in captured["command"]
+    assert captured["command"][0] == "/usr/bin/prlimit"
+    assert captured["command"].index("LD_PRELOAD") > 3
     assert info_messages == [
         "[BwrapIsolation] 执行完成: command='env', return_code=0"
     ]
@@ -493,12 +496,20 @@ async def test_server_local_background_command_is_wrapped_by_bwrap(
     await provider.start_background(
         "env",
         workdir=str(workspace),
-        env_vars={"TASK_INPUT": "agent-visible"},
+        env_vars={
+            "TASK_INPUT": "agent-visible",
+            "LD_PRELOAD": str(workspace / "agent.so"),
+            "LD_AUDIT": str(workspace / "audit.so"),
+        },
     )
 
     assert captured["shell"] is False
     assert captured["env_vars"] is None
     assert os.path.isabs(captured["command"][0])
+    assert captured["command"][0] == "/usr/bin/prlimit"
+    assert captured["command"][3].endswith("/bwrap")
+    assert captured["command"].index("LD_PRELOAD") > 3
+    assert captured["command"].index("LD_AUDIT") > 3
     assert "--clearenv" in captured["command"]
     assert "--unshare-pid" in captured["command"]
     assert captured["command"][-3:] == ["/bin/sh", "-c", "env"]

--- a/tests/sagents/utils/sandbox/test_v1_bwrap_memory_limit.py
+++ b/tests/sagents/utils/sandbox/test_v1_bwrap_memory_limit.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import shlex
+import shutil
 import subprocess
 import sys
 import time
@@ -42,10 +43,11 @@ async def test_env_limit_reaches_background_shell(tmp_path, monkeypatch):
         "python3 task.py",
         env_vars={"SAGE_LOCAL_MEMORY_LIMIT_MB": "999999", "PATH": str(tmp_path)},
     )
-    assert cmd[-6:] == [
+    assert cmd[:3] == [
         "/usr/bin/prlimit", "--as=134217728:134217728", "--",
-        "/bin/sh", "-c", "python3 task.py",
     ]
+    assert cmd[3] == module._TRUSTED_BWRAP_EXECUTABLE
+    assert cmd[-3:] == ["/bin/sh", "-c", "python3 task.py"]
 
 
 @pytest.mark.parametrize("memory", [0, -1, True, "4096", None])
@@ -67,10 +69,11 @@ async def test_sync_shell_uses_limit(tmp_path, monkeypatch):
     monkeypatch.setattr(module, "run_with_streaming_stdout", run)
     result = await isolation(tmp_path).execute({"mode": "shell", "command": "echo ok"})
     assert result["success"]
-    assert captured[-6:] == [
+    assert captured[:3] == [
         "/usr/bin/prlimit", "--as=67108864:67108864", "--",
-        "/bin/sh", "-c", "echo ok",
     ]
+    assert captured[3] == module._TRUSTED_BWRAP_EXECUTABLE
+    assert captured[-3:] == ["/bin/sh", "-c", "echo ok"]
 
 
 @pytest.mark.asyncio
@@ -84,15 +87,22 @@ async def test_python_payload_uses_same_limit(tmp_path, monkeypatch):
 
     def run(cmd, **kwargs):
         captured.extend(cmd)
+        assert "LD_PRELOAD" not in kwargs["env"]
+        assert "LD_AUDIT" not in kwargs["env"]
         return 0, "", ""
 
     monkeypatch.setattr(module, "run_with_streaming_stdout", run)
-    assert await isolation(tmp_path).execute({"mode": "python"}) == 42
+    assert await isolation(tmp_path).execute({
+        "mode": "python",
+        "env_vars": {"LD_PRELOAD": "/workspace/agent.so", "LD_AUDIT": "/workspace/audit.so"},
+    }) == 42
     index = captured.index("/usr/bin/prlimit")
+    assert index == 0
     assert captured[index:index + 3] == [
         "/usr/bin/prlimit", "--as=67108864:67108864", "--",
     ]
     assert captured[-3:] == ["launcher", "input", "output"]
+    assert captured.index("LD_PRELOAD") > captured.index(module._TRUSTED_BWRAP_EXECUTABLE)
 
 
 LINUX = pytest.mark.skipif(
@@ -164,3 +174,41 @@ else:
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
     assert result.returncode == 0, result.stderr
     assert "hard-limit-enforced" in result.stdout
+
+
+@LINUX
+@pytest.mark.asyncio
+async def test_preload_constructor_runs_only_after_limit(tmp_path, monkeypatch):
+    """Exercise real ld.so constructors without requiring namespace privileges.
+
+    env stands in for bwrap's --setenv stage. The previous ordering executes
+    the constructor in prlimit before setrlimit, and exits with code 86.
+    The probe only reads limits; it never allocates unbounded memory.
+    """
+    compiler = shutil.which("cc")
+    if not compiler:
+        pytest.skip("requires a C compiler for the loader regression")
+    source = tmp_path / "probe.c"
+    library = tmp_path / "probe.so"
+    source.write_text('''
+#include <sys/resource.h>
+#include <unistd.h>
+__attribute__((constructor)) static void check_limit(void) {
+    struct rlimit limit;
+    if (getrlimit(RLIMIT_AS, &limit) != 0 ||
+        limit.rlim_cur != 67108864 || limit.rlim_max != 67108864) {
+        _exit(86);
+    }
+    const char message[] = "constructor-is-limited\\n";
+    write(1, message, sizeof(message) - 1);
+}
+''')
+    subprocess.run([compiler, "-shared", "-fPIC", str(source), "-o", str(library)],
+                   check=True, capture_output=True, timeout=30)
+    sandbox = isolation(tmp_path)
+    monkeypatch.setattr(sandbox, "_build_base_command", lambda **kwargs: (
+        ["/usr/bin/env", f"LD_PRELOAD={library}"], {}
+    ))
+    result = await sandbox.execute({"mode": "shell", "command": "true", "timeout_seconds": 5})
+    assert result["success"], result
+    assert "constructor-is-limited" in result["output"]

--- a/tests/sagents/utils/sandbox/test_v1_bwrap_memory_limit.py
+++ b/tests/sagents/utils/sandbox/test_v1_bwrap_memory_limit.py
@@ -1,0 +1,166 @@
+"""v1 bwrap memory limits, including a bounded Linux allocation regression."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import sys
+import time
+
+import pytest
+
+from sagents.utils.sandbox._bg_runner import HostBackgroundRunner
+from sagents.utils.sandbox.config import SandboxConfig
+from sagents.utils.sandbox.providers.local.isolation import bwrap as module
+from sagents.utils.sandbox.providers.local.isolation.bwrap import BwrapIsolation
+from sagents.utils.sandbox.providers.local.local import LocalSandboxProvider
+
+
+def isolation(tmp_path, memory_mb=64):
+    return BwrapIsolation(
+        venv_dir=str(tmp_path / "venv"),
+        sandbox_agent_workspace=str(tmp_path),
+        limits={"memory": memory_mb * 1024 * 1024},
+    )
+
+
+@pytest.mark.asyncio
+async def test_env_limit_reaches_background_shell(tmp_path, monkeypatch):
+    monkeypatch.setenv("SAGE_LOCAL_MEMORY_LIMIT_MB", "128")
+    config = await SandboxConfig.from_env(sandbox_id="memory-test")
+    sandbox = LocalSandboxProvider(
+        sandbox_id="memory-test",
+        sandbox_agent_workspace=str(tmp_path),
+        memory_limit_mb=config.memory_limit_mb,
+    )
+    sandbox._init_isolation()
+    # Explicitly select Linux isolation when running this test on macOS.
+    if not isinstance(sandbox._isolation, BwrapIsolation):
+        sandbox._isolation = isolation(tmp_path, config.memory_limit_mb)
+    cmd = sandbox._isolation.build_shell_command(
+        "python3 task.py",
+        env_vars={"SAGE_LOCAL_MEMORY_LIMIT_MB": "999999", "PATH": str(tmp_path)},
+    )
+    assert cmd[-6:] == [
+        "/usr/bin/prlimit", "--as=134217728:134217728", "--",
+        "/bin/sh", "-c", "python3 task.py",
+    ]
+
+
+@pytest.mark.parametrize("memory", [0, -1, True, "4096", None])
+def test_invalid_limit_rejected_before_launch(tmp_path, memory):
+    sandbox = isolation(tmp_path)
+    sandbox.limits["memory"] = memory
+    with pytest.raises(ValueError, match="positive integer"):
+        sandbox.build_shell_command("echo must-not-run")
+
+
+@pytest.mark.asyncio
+async def test_sync_shell_uses_limit(tmp_path, monkeypatch):
+    captured = []
+
+    def run(cmd, **kwargs):
+        captured.extend(cmd)
+        return 0, "ok", ""
+
+    monkeypatch.setattr(module, "run_with_streaming_stdout", run)
+    result = await isolation(tmp_path).execute({"mode": "shell", "command": "echo ok"})
+    assert result["success"]
+    assert captured[-6:] == [
+        "/usr/bin/prlimit", "--as=67108864:67108864", "--",
+        "/bin/sh", "-c", "echo ok",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_python_payload_uses_same_limit(tmp_path, monkeypatch):
+    captured = []
+    monkeypatch.setattr(module, "_prepare_payload_files_sync",
+                        lambda *args: ("input", "output", "launcher"))
+    monkeypatch.setattr(module, "_load_pickle_output_sync",
+                        lambda *args: {"status": "success", "result": 42})
+    monkeypatch.setattr(module, "_remove_file_if_exists_sync", lambda *args: None)
+
+    def run(cmd, **kwargs):
+        captured.extend(cmd)
+        return 0, "", ""
+
+    monkeypatch.setattr(module, "run_with_streaming_stdout", run)
+    assert await isolation(tmp_path).execute({"mode": "python"}) == 42
+    index = captured.index("/usr/bin/prlimit")
+    assert captured[index:index + 3] == [
+        "/usr/bin/prlimit", "--as=67108864:67108864", "--",
+    ]
+    assert captured[-3:] == ["launcher", "input", "output"]
+
+
+LINUX = pytest.mark.skipif(
+    sys.platform != "linux" or not os.path.exists("/usr/bin/prlimit"),
+    reason="requires Linux util-linux prlimit",
+)
+
+# Bounded even if the regression reappears: at most 128 MiB, 10-second timeout.
+# Check the kernel limit first so a broken wrapper never allocates unrestricted.
+ALLOCATION_PROGRAM = """
+import resource
+assert resource.getrlimit(resource.RLIMIT_AS) == (67108864, 67108864)
+blocks = []
+try:
+    for _ in range(128):
+        blocks.append(bytearray(1024 * 1024))
+except MemoryError:
+    print('memory-limit-enforced', flush=True)
+    raise SystemExit(42)
+raise SystemExit('allocation unexpectedly succeeded')
+"""
+
+
+@LINUX
+def test_linux_allocation_fails_without_affecting_parent(tmp_path):
+    import resource
+
+    before = resource.getrlimit(resource.RLIMIT_AS)
+    cmd = isolation(tmp_path)._limit_command([sys.executable, "-c", ALLOCATION_PROGRAM])
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    assert result.returncode == 42, result.stderr
+    assert "memory-limit-enforced" in result.stdout
+    assert resource.getrlimit(resource.RLIMIT_AS) == before
+
+
+@LINUX
+def test_linux_background_shell_inherits_limit(tmp_path):
+    runner = HostBackgroundRunner(log_dir=str(tmp_path / "logs"))
+    shell = shlex.join([sys.executable, "-c", ALLOCATION_PROGRAM])
+    cmd = isolation(tmp_path)._limit_command(["/bin/sh", "-c", shell])
+    task = runner.start(cmd, shell=False)
+    task_id = task["task_id"]
+    try:
+        deadline = time.monotonic() + 10
+        while runner.is_alive(task_id) and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert not runner.is_alive(task_id)
+        assert runner.get_exit_code(task_id) == 42
+        assert "memory-limit-enforced" in runner.read_tail(task_id)
+    finally:
+        runner.cleanup(task_id)
+
+
+@LINUX
+def test_linux_child_cannot_raise_hard_limit(tmp_path):
+    program = """
+import resource
+assert resource.getrlimit(resource.RLIMIT_AS) == (67108864, 67108864)
+try:
+    resource.setrlimit(resource.RLIMIT_AS, (134217728, 134217728))
+except (ValueError, PermissionError):
+    print('hard-limit-enforced')
+else:
+    raise SystemExit('hard limit unexpectedly raised')
+"""
+    cmd = isolation(tmp_path)._limit_command([
+        "/bin/sh", "-c", shlex.join([sys.executable, "-c", program]),
+    ])
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    assert result.returncode == 0, result.stderr
+    assert "hard-limit-enforced" in result.stdout


### PR DESCRIPTION
修复 Sage v1 Linux local/bwrap 中 `SAGE_LOCAL_MEMORY_LIMIT_MB` 已配置但命令执行未落实内存限制的问题。后台 shell 直接执行 Python 时绕过 pickle launcher，持续追加列表的脚本可以无限增长；现在同步 shell、`LocalSandboxProvider.start_background` 使用的后台 shell，以及 Python payload，都会先在清理后的启动环境中通过可信 `/usr/bin/prlimit` 设置 `RLIMIT_AS` 软、硬上限，再启动 bwrap；agent 环境只在 bwrap 内应用。

继续使用现有环境变量 `SAGE_LOCAL_MEMORY_LIMIT_MB`（默认 4096 MiB，必须为正整数）。子进程继承硬上限，agent 提供的 PATH 或同名环境变量不会替换限制器或覆盖服务端配置。`LD_PRELOAD`/`LD_AUDIT` 只作为 bwrap 的参数传入，不能在 prlimit 设置限制前执行构造函数。服务端镜像显式安装 util-linux；prlimit 缺失时执行失败。中英文文档说明需重建镜像/容器并重启服务使配置生效。

范围仅为 v1 Linux local/bwrap，不修改 v2。这是**每进程虚拟地址空间限制**，用于阻止此次单进程无界分配；并非多个进程合计的 cgroup 内存配额，也不新增任务执行期限。Node/V8 等预留较大地址空间的运行时可能需要调高配置；仍需独立的容器总内存及并发预算。

验证：
- 本地运行 v1 bwrap 内存回归、local 路径权限、执行超时、后台运行器、server runtime assets 测试：36 passed，3 个 Linux-only 测试在 macOS 跳过。
- 在 Linux 上以 64 MiB 上限和 10 秒外层超时执行有界分配回归：确认软/硬限制、shell 子进程继承、分配失败和父进程不受影响；未修改业务服务或服务器文件。这项验证覆盖 prlimit 内核行为，不是完整 bwrap 端到端验证。
- 新增 Linux-only 测试覆盖前台/后台分配失败及无法提高硬上限，将由现有 Linux CI 执行。
- `git diff --check` 通过。

Review 回归验证：
- 环境边界、内存限制、超时、后台运行器及 runtime assets 测试：49 passed，4 个 Linux-only 测试在 macOS 跳过。
- Linux 上临时编译仅调用 getrlimit 的 LD_PRELOAD 构造函数探针：旧顺序以 86 退出（构造函数尚未受限），新顺序以 0 退出且确认 64 MiB 软/硬限制。探针未执行无界分配。
- 新增真实动态链接器回归测试，用 env 模拟 bwrap 设置环境的阶段，无需 CI 提供 namespace 权限；更新同步、后台、Python 入口的顺序及环境隔离断言。
